### PR TITLE
aarch64: Remove vmlinux

### DIFF
--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -48,9 +48,12 @@ if [ ${REBOOTCOUNT} -eq 0 ]; then
       # These steps are required until the following patch is backported into
       # the kernel trees: https://patchwork.kernel.org/patch/10532993/
 
-      # Skip these steps if the vmlinuz is already present
-      if [ ! -f "/boot/vmlinuz-${KVER}" ]; then
-
+      # Check if the vmlinuz is present (a sign that the upstream patch has
+      # merged)
+      if [ -f "/boot/vmlinuz-${KVER}" ]; then
+        # Remove the vmlinux file so that only the vmlinuz is used
+        rm -f /boot/vmlinux-${KVER}
+      else
         # Strip the vmlinux binary as required for aarch64
         objcopy  -O binary -R .note -R .note.gnu.build-id -R .comment -S /boot/vmlinux-${KVER} /tmp/vmlinux-${KVER}
 
@@ -59,7 +62,6 @@ if [ ${REBOOTCOUNT} -eq 0 ]; then
 
         # Clean up temporary stripped vmlinux and the generic vmlinux in /boot
         rm -f /tmp/vmlinux-${KVER} /boot/vmlinux-${KVER}
-
       fi
   esac
 


### PR DESCRIPTION
Remove the vmlinux file on aarch64 so that the vmlinuz file is used.

Signed-off-by: Major Hayden <major@redhat.com>