### PR TITLE
Add  ltp-lite test case

### DIFF
--- a/distribution/ltp/include/Makefile
+++ b/distribution/ltp/include/Makefile
@@ -1,0 +1,56 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Makefile of /kernel/distribution/ltp/include
+#   Description: Linux Test Project - include
+#   Author: Caspar Zhang <czhang@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2010 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PACKAGE_NAME=ltp
+export TEST=/kernel/distribution/ltp/include
+
+include /usr/share/rhts/lib/rhts-make.include
+include ltp-make.include
+
+# data files, .c files, scripts anything needed to either compile the test and/or run it.
+FILES=$(METADATA) runtest.sh knownissue.sh Makefile PURPOSE stagecase \
+	  kvercmp.sh ltp-make.include patches/
+
+.PHONY: all install download clean
+
+# Generate the testinfo.desc here:
+$(METADATA): Makefile
+	@touch $(METADATA)
+	@echo "Owner:        Caspar Zhang <czhang@redhat.com>" > $(METADATA)
+	@echo "Name:         $(TEST)" >> $(METADATA)
+	@echo "Path:         $(TEST_DIR)"	>> $(METADATA)
+	@echo "License:      GPLv2" >> $(METADATA)
+	@echo "TestVersion:  $(TESTVERSION)"	>> $(METADATA)
+	@echo "Description:  Linux Test Project - include">> $(METADATA)
+	@echo "TestTime:     5h" >> $(METADATA)
+	@echo "RunFor:       kernel glibc" >> $(METADATA)
+	@echo "Requires:     @development " >> $(METADATA)
+	@echo "Requires:     procmail rsyslog sysklogd ntpdate util-linux util-linux-ng redhat-lsb bc wget" >> $(METADATA)
+	#@echo "Releases:     RHELServer5 RHEL6" >>$(METADATA)
+	@echo "Destructive:  no" >>$(METADATA)
+	@echo "Confidential: no" >>$(METADATA)
+	@echo "Priority:     Normal" >>$(METADATA)
+	@echo "Provides:     rh-tests-kernel-distribution-ltp-include" >>$(METADATA)

--- a/distribution/ltp/include/PURPOSE
+++ b/distribution/ltp/include/PURPOSE
@@ -1,0 +1,51 @@
+PURPOSE of /kernel/distribution/ltp/include
+Description: Linux Test Project - include part
+Author: Caspar Zhang <czhang@redhat.com>
+
+LTP Introduction
+================
+LTP is a famous test suite under Linux, I port
+LTP to Beaker every 4 months (+/-1 month if
+needed). You can use this testcase for your
+RHEL testing.
+
+What's this
+===========
+This is a include testcase, you should include
+it in your own ltp projects.
+
+HOW TO USE IT
+=============
+
+1. What you should put in your own Makefile:
+
+ - include /mnt/tests/kernel/distribution/ltp/include/ltp-make.include
+
+ - add "patch-inc" to patch section, i.e.:
+   patch: patch-inc
+       #YOUR OWN PATCHES
+       $(PATCH) < blabla.patch
+   or if you are 100% sure you don't need generic patches, you can just
+   add "patch-critical" to patch section.
+
+ - add "build-basic" or "build-all" to build section, depends on you:
+   . are running a general test or cann't be sure which tests to build,
+     you should add "build-all";
+   . are 100% sure which sub tests you will build,
+     you should add "build-basic", then add your own build commands, e.g.:
+     build: build-basic
+         make -C $(TARGET)/testcases/kernel/mem/hugetlb all
+         make -C $(TARGET)/testcases/kernel/mem/hugetlb install
+
+ - add "rh-tests-kernel-distribution-ltp-include" as RhtsRequires in METADATA
+
+2. What you should put in your own runtest.sh:
+
+  It's a little complex, basically, you should:
+
+ - add this line to your runtest.sh:
+ . /mnt/tests/kernel/distribution/ltp/include/runtest.sh
+
+ - Others.... Hmmm..... have a look at:
+   /kernel/distribution/ltp/generic/runtest.sh
+   /kernel/vm/hugepage/ltp-hugetlbfs/runtest.sh

--- a/distribution/ltp/include/kvercmp.sh
+++ b/distribution/ltp/include/kvercmp.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+kver_ret=0
+function kvercmp()
+{
+    ver1=`echo $1 | sed 's/-/./'`
+    ver2=`echo $2 | sed 's/-/./'`
+
+    ret=0
+    i=1
+    while [ 1 ]; do
+        digit1=`echo $ver1 | cut -d . -f $i`
+        digit2=`echo $ver2 | cut -d . -f $i`
+
+        if [ -z "$digit1" ]; then
+            if [ -z "$digit2" ]; then
+                ret=0
+                break
+            else
+                ret=-1
+                break
+            fi
+        fi
+
+        if [ -z "$digit2" ]; then
+            ret=1
+            break
+        fi
+
+        if [ "$digit1" != "$digit2" ]; then
+            if [ "$digit1" -lt "$digit2" ]; then
+               ret=-1
+               break
+            fi
+            ret=1
+            break
+        fi
+
+        i=$((i+1))
+    done
+    kver_ret=$ret
+
+    echo "kvercmp($1,$2): $kver_ret"
+}
+
+function mytest()
+{
+    kvercmp '2.6.32-100.el6' '2.6.32-100.el6'
+    kvercmp '2.6.32-100.el6' '2.6.32-101.el6'
+    kvercmp '2.6.32-101.el6' '2.6.32-100.el6'
+    kvercmp '2.6.32-101.el6' '3.1.4-0.2.el7.x86_64'
+    kvercmp '3.1.4-0.2.el7.x86_64' `uname -r`
+    kvercmp `uname -r` '3.1.4-0.1.el7.x86_64'
+}

--- a/distribution/ltp/include/ltp-make.include
+++ b/distribution/ltp/include/ltp-make.include
@@ -1,0 +1,308 @@
+# Beaker parameter TEST_VERSION can override the default
+TESTVERSION   = $(shell echo $$TEST_VERSION)
+ifeq (,$(TESTVERSION))
+TESTVERSION   = 20180515
+endif
+export TESTVERSION
+# the task path may be different under the restraint harness if the task
+# is fetched directly from git, so use a relative path to the include task
+ABS_DIR      := $(dir $(lastword $(MAKEFILE_LIST)))patches
+TARGET_DIR    = /mnt/testarea/ltp
+TARGET        = ltp-full-$(TESTVERSION)
+
+SYSENV       := $(shell uname -i)
+ARCH         := $(SYSENV)
+KVER         := $(shell uname -r | cut -d'-' -f 1 | cut -d'.' -f 3)
+KREV         := $(shell uname -r | cut -d'-' -f 2 | cut -d'.' -f 1)
+OS_MAJOR_RELEASE := $(shell grep -Go 'release [0-9]\+' /etc/redhat-release | sed 's/release //')
+
+# Whether NXBIT is Set in /proc/cpuinfo
+NXBIT        := $(shell grep '^flags' /proc/cpuinfo 2>/dev/null | grep -q " nx " \
+				&& echo TRUE || echo FALSE)
+NR_CPUS      := $(shell getconf _NPROCESSORS_ONLN || echo 1)
+# Allow lab sites to use their local $LOOKASIDE domain
+DOWNLOAD_URL := $(shell echo $${LOOKASIDE:-http:\/\/linux-test-project\/ltp\/releases\/download\/})
+IS_DEVEL := $(shell echo ${DOWNLOAD_URL} | grep -o devel)
+#gloabl sync seems not working properly for now, use reverse proxy
+#RELPATH      := $(shell hostname | grep -v nay | grep -qv brq \
+#				&& echo / || echo /pub/rhel)
+RELPATH      := /
+
+MAKE          = make -j$(NR_CPUS)
+# if TEST_VERSION is set, use the --forward flag so patches which are
+# already applied do not cause the entire job to fail, and ignore
+# the exit status (which will be 1 for an error even with --forward)
+ifeq (,$(shell echo $$TEST_VERSION))
+PATCH         = patch -p1 -d $(TARGET)
+else
+PATCH         = -patch --forward -p1 -d $(TARGET)
+endif
+
+$(TARGET).bz2:
+	@echo "============ Download package ============"
+	wget -q $(DOWNLOAD_URL)/$(TARGET).bz2; \
+        if [ $$? -ne 0 ]; then \
+                echo "global sync seems not working correctly, using upstream location" ;\
+                wget https://github.com/linux-test-project/ltp/releases/download/$(TESTVERSION)/$(TARGET).tar.bz2 -O $(TARGET).bz2 ;\
+        fi
+
+$(TARGET): $(TARGET).bz2 clean
+	@echo "============ Unzip package ============"
+	tar xjf $(TARGET).bz2
+
+# Critical patches
+# 1. If a patch fixes installation issue
+# 2. a patch fixes critical issues (causing deadlock, crash, etc), no
+#	matter the test will be executed or not, it should be applied here.
+patch-critical:
+	@echo "============ Critical Patch ============"
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/rhel-scrashme-remove-fork12-test.patch
+
+patch-generic:
+	@echo "============ General Patch ============"
+	@echo " === applying general upstream fixes. ==="
+	@echo " === applying general internal fixes. ==="
+ifeq ($(TESTVERSION),20150903)
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/ltp-pan-ltp-testname-stamps-in-dmesg-and-console.patch
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/disable-testcases.patch
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/rhel-fs-quota_remount-solve-SELinux-issue.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/lib-mem.c-handle-mlock-returning-EAGAIN.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/mtest01-sigchld.patch
+endif
+ifeq ($(TESTVERSION),20160126)
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/ltp-pan-ltp-testname-stamps-in-dmesg-and-console.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/open_posix-add-SAFE_PFUNC-macro.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/open_posix-condvar-schedule-use-SAFE_PFUNC.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/open_posix-condvar-schedule-remove-useless-waiting.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/open_posix-condvar-schedule-remove-duplicit-setsched.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/open_posix-condvar-schedule-remove-signal-handlers.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/syscalls-readahead02-use-bdi-max-readahead-limit.patch
+	@# Tips: this patch should be applied in single on ltp-next(version > 20160126)
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/readahead02-use-per-device-readahead-limit-in-RHEL7.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/mm-ksm-extend-max_page_sharing-before-ksm-testing.patch
+endif
+ifeq ($(TESTVERSION),20160510)
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/ltp-pan-ltp-testname-stamps-in-dmesg-and-console.patch
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/readahead02-use-per-device-readahead-limit-in-RHEL7.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/creat05-don-t-assume-number-of-opened-fds.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/mem-oom-fork-may-fail-before-test.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/handle-EOPNOTSUPP-if-hugepages_supported.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/mem-lib-skip-oom-KSM-for-lite-1-single-TESTMEM-MB-al.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/fanotify06-create-a-mount-for-test.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/lib-add-SAFE_-FILE_LINES_SCANF.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/syscalls-madvise06-Convert-to-new-test-API.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/zram01-extend-the-zram3-disksize-to-40MB.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/madvise06-make-bug-detection-more-reliable.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/swapping01-replace-mem_free-by-mem_available.patch
+endif
+ifeq ($(TESTVERSION),20160920)
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/ltp-pan-ltp-testname-stamps-in-dmesg-and-console.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/lib-Add-optional-minimal-size-for-test-device.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/utimensat-fix-immutable-file-retcodes-for-4.8.0-and-.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/move_pages04-fix-zero-page-status-code-for-kernels-4.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/lib-add-tst_res_hexd-for-newlib.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/syscalls-new-test-writev07.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/writev-remove-writev03-and-writev04.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/writev01-rewrite-and-drop-partially-valid-iovec-test.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/kernel-zram-Fix-testcase-for-kernels-v4.7.patch
+endif
+ifeq ($(TESTVERSION),20170116)
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/ltp-pan-ltp-testname-stamps-in-dmesg-and-console.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-quotactl02-flags-for-Q_XQUOTA-ON-OFF-is-32bit-int.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-getrandom02-relax-check-for-returned-data.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-checkpoints-Add-TST_SAFE_CHECKPOINT_WAIT2.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-mmap16-extend-checkpoint-wait-time-during-fs-fill.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-kmsg01-fix-race-in-SEEK_SET-0-test.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-sem_post-8-1-improve-child-blocked-on-semaphore-dete.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-syscalls-syslog02-fix-typo.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-syscalls-syslog-added-debugging-and-message-loss-che.patch
+endif
+ifeq ($(TESTVERSION),20170516)
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/ltp-pan-ltp-testname-stamps-in-dmesg-and-console.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-pipeio-avoid-SAFE-macros-in-cleanup.patch
+	@$(PATCH) < $(ABS_DIR)/20170116/0001-syscalls-syslog-added-debugging-and-message-loss-che.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-syscalls-memfd_create-test-memfd-flags-separately.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-move_pages12-replace-memset-with-mlock.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-recvmsg03-avoid-close-and-recvmsg-racing.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-configure.ac-Generate-linux_syscall_headers.h.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-dio-reduce-the-number-of-cycles.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-kmsg01-convert-to-newlib.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-syscalls-add_key02-update-to-test-fix-for-nonempty-N.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-syscalls-add_key02-add-the-logon-key-type.patch
+endif
+ifeq ($(TESTVERSION),20170929)
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-kmsg01-set-restore-console-log-level.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0002-kmsg01-specify-read-timeout-in-usec.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0003-kmsg01-use-lower-timeout-for-test_read_block.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-clone08-don-t-treat-EWOULDBLOCK-as-failure.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-lib-fix-kernel-bit-detection-on-s390-platform.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-mm-raise-mmap-HIGH_ADDR-value-for-s390-arch.patch
+endif
+ifeq ($(TESTVERSION),20180118)
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-safe_macros-make-is_fuse-return-zero-if-fs_type-is-N.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-mallocstress-extend-test-time.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0002-times03-don-t-assume-process-initial-us-time-is-0.patch
+endif
+ifeq ($(TESTVERSION),20180515)
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-cve-2017-5669-shmat-for-0-or-PAGESIZE-with-RND-flag-.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-pthread_cancel_3-1-rewrite.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-open_posix-add-LTP_ATTRIBUTE-macros-to-supress-warni.patch
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/0001-cve-meltdown-read-saved_command_line.patch
+endif
+	@# The following ones are for specific hardware/release
+ifneq (,$(filter 4 5 s390 s390x, $(OS_MAJOR_RELEASE) $(ARCH)))
+	@echo " - remove cfs sched hacbench in RHEL[45] and s390x"
+	$(PATCH) < $(ABS_DIR)/INTERNAL/rhel345-sched-remove-cfs-sched-hackbench.patch
+endif
+ifneq (,$(filter ppc ppc64 s390 s390x, $(ARCH)))
+	@echo " - remove kernel/firmware tests in s390/ppc64 arch"
+	$(PATCH) < $(ABS_DIR)/INTERNAL/skip-firmware-tests.patch
+endif
+ifeq ($(shell test $(TESTVERSION) -ge 20170516; echo $$?), 0)
+	@echo " - cron_tests.sh has been rewritten since ltp-20170516"
+else ifeq ($(OS_MAJOR_RELEASE), 6)
+	@echo " - fix cron01 in RHEL6"
+	$(PATCH) < $(ABS_DIR)/INTERNAL/rhel6-commands-cron-ensure-syslog-enabled.patch
+endif
+ifeq ($(NXBIT), TRUE)
+	@echo " - fix crashme testcase on systems with NX flag."
+	$(PATCH) < $(ABS_DIR)/INTERNAL/rhel-scrashme-remove-f00f-test-on-system-with-NX-bit.patch
+endif
+ifeq ($(ARCH), aarch64)
+	@echo " - no aarch64 patches needed at this time"
+endif
+
+patch-newcase:
+	@echo "============ Applying for new testcases. ============"
+
+patch-hugetlb:
+	@echo "============ Applying ltp-hugetlb patches. ============"
+ifeq ($(TESTVERSION),20150903)
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/mem-hugetlb-Find-an-empty-region-to-use-in-hugemmap0.patch
+endif
+ifeq ($(TESTVERSION),20160126)
+	@$(PATCH) < $(ABS_DIR)/$(TESTVERSION)/hugemmap02.c-don-t-skip-cleanup-in-the-loop.patch
+endif
+
+patch-cgroups:
+	@echo "============ Applying ltp-cgroups patches. ============"
+	@$(PATCH) < $(ABS_DIR)/INTERNAL/cgroup-debug-check-cgroups.patch
+
+patch-inc: patch-critical patch-generic
+
+AUTOCONFIGVER=$(shell rpm -qa autoconf |cut -f 2 -d "-")
+AUTOMAKEVER=$(shell rpm -qa automake |cut -f 2 -d "-"|cut -f 1,2 -d ".")
+AUTOCONFIGVER_1=$(shell echo $(AUTOCONFIGVER) |cut -f 1 -d ".")
+AUTOCONFIGVER_2=$(shell echo $(AUTOCONFIGVER) |cut -f 2 -d ".")
+
+# Setup desired filesystem mounted at /mnt/testarea
+# TEST_DEV or TEST_MNT can be set, this useful when testing filesystems in beaker
+#
+# If TEST_DEV is set, mkfs on TEST_DEV and mount it at /mnt/testarea
+# If TEST_MNT is set, grab device mounted at TEST_MNT first and mkfs & mount at
+# /mnt/testarea
+#
+# Also MKFS_OPTS and MOUNT_OPTS can be set to specify mkfs and mount options, e.g.
+# FSTYP=xfs MKFS_OPTS="-m crc=1" MOUNT_OPTS="-o relatime" make run
+setup-testarea:
+	@if [ "$(TEST_DEV)" != "" ] || [ "$(TEST_MNT)" != "" ]; then \
+		echo "============ Setup /mnt/testarea ============"; \
+		if [ "$(FSTYP)" == "" ]; then \
+			echo " - Having TEST_DEV or TEST_MNT set but not FSTYP"; \
+			exit 1; \
+		fi; \
+		if [ "$(TEST_MNT)" != "" ]; then \
+			dev=`grep "$(TEST_MNT)" /proc/mounts | awk '{print $$1}'`; \
+			if [ -z $$dev ]; then \
+				echo " - TEST_MNT set to $(TEST_MNT) but no partition mounted there"; \
+				exit 1; \
+			fi; \
+			cp /etc/fstab{,.bak}; \
+			grep -v $(TEST_MNT) /etc/fstab.bak >/etc/fstab; \
+			umount $(TEST_MNT); \
+		fi; \
+		if [ "$$dev" == "" ] && [ "$(TEST_DEV)" != "" ]; then \
+			dev=$(TEST_DEV); \
+		fi; \
+		if [ "$$dev" == "" ]; then \
+			echo " - No suitable test device found"; \
+			exit 1; \
+		fi; \
+		if [ "$(FSTYP)" == "xfs" ] || [ "$(FSTYP)" == "btrfs" ]; then \
+			mkfs -t $(FSTYP) $(MKFS_OPTS) -f $$dev; \
+		elif [ "$(FSTYP)" == "overlayfs" ]; then \
+			mkfs -t xfs -n ftype=1 -f $$dev; \
+		else \
+			mkfs -t $(FSTYP) $(MKFS_OPTS) $$dev; \
+		fi; \
+		if [ $$? -ne 0 ]; then \
+			echo " - mkfs failed"; \
+			exit 1; \
+		fi; \
+		if [ "$(FSTYP)" == "overlayfs" ]; then \
+			mkdir -p /mnt/ltp-overlay; \
+			mount $(MOUNT_OPTS) $$dev /mnt/ltp-overlay; \
+			mkdir -p /mnt/ltp-overlay/lower; \
+			mkdir -p /mnt/ltp-overlay/upper; \
+			mkdir -p /mnt/ltp-overlay/workdir; \
+			mount -t overlay overlay -olowerdir=/mnt/ltp-overlay/lower,upperdir=/mnt/ltp-overlay/upper,workdir=/mnt/ltp-overlay/workdir /mnt/testarea; \
+		else \
+			mount $(MOUNT_OPTS) $$dev /mnt/testarea; \
+		fi; \
+		if [ $$? -ne 0 ]; then \
+			echo " - mount $$dev at /mnt/testarea failed"; \
+			exit 1; \
+		fi; \
+	fi
+
+configure: setup-testarea $(TARGET)
+	@echo "============ Start configure ============"
+	if [ $(AUTOCONFIGVER_1) -lt 1 -o $(AUTOCONFIGVER_1) -eq 2 -a $(AUTOCONFIGVER_2) -lt 69 ]; then \
+            wget -q $(DOWNLOAD_URL)/m4-1.4.16.tar.gz ; \
+            tar xzf m4-1.4.16.tar.gz; \
+            pushd  m4-1.4.16; \
+            ./configure --prefix=/usr 2>&1 >/dev/null; \
+            make 2>&1 >/dev/null && make install 2>&1 >/dev/null; \
+            popd ; \
+            wget -q $(DOWNLOAD_URL)/autoconf-2.69.tar.gz ; \
+            tar xzf autoconf-2.69.tar.gz; \
+            pushd autoconf-2.69; \
+            ./configure --prefix=/usr 2>&1 >/dev/null ; \
+            make 2>&1 >/dev/null && make install 2>&1 >/dev/null ;  \
+            popd ; \
+        fi 
+	pushd $(TARGET); make autotools; ./configure --prefix=$(TARGET_DIR) &> configlog.txt || cat configlog.txt; popd
+
+build-basic: $(METADATA) configure
+	@echo "============ Start make and install ============"
+	$(MAKE) -C $(TARGET)/pan all
+	$(MAKE) -C $(TARGET)/pan install
+	$(MAKE) -C $(TARGET)/runtest install
+	$(MAKE) -C $(TARGET)/tools all
+	$(MAKE) -C $(TARGET)/tools install
+	$(MAKE) -C $(TARGET) Version
+	(cd $(TARGET); cp -f ver_linux Version runltp IDcheck.sh $(TARGET_DIR)/)
+
+build-all: $(METADATA) configure
+	@echo "============ Start $(MAKE) and install ============"
+	$(MAKE) -C $(TARGET) all &> buildlog.txt || (cat buildlog.txt && false)
+	$(MAKE) -C $(TARGET) install &> buildlog.txt || (cat buildlog.txt && false)
+
+clean:
+	rm -f *~ $(METADATA)
+	rm -rf $(TARGET)
+	rm -rf m4-1.4.16
+	rm -rf autoconf-2.69
+	rm -rf *.rpm
+
+# For manual testing
+testpatch: $(TARGET) patch
+
+testconfigure: $(TARGET) patch configure
+
+testfullbuild: $(TARGET) patch build-all
+
+showmeta: $(METADATA)
+	@cat $(METADATA)
+
+# vim: syntax=make shiftwidth=8 tabstop=8 noexpandtab

--- a/distribution/ltp/include/metadata
+++ b/distribution/ltp/include/metadata
@@ -1,0 +1,13 @@
+[General]
+name=/kernel/distribution/ltp/include
+owner=Kernel General Test Team <kernel-general-test-team@redhat.com>
+description=Linux Test Project - include
+license=GPLv3
+confidential=no
+destructive=no
+
+[restraint]
+entry_point=make run
+max_time=5h
+dependencies=procmail;rsyslog;ntpdate;util-linux;redhat-lsb;bc;wget
+dependencies[RedHatEnterpriseLinuxServer5]=procmail;rsyslog;ntpdate;util-linux;util-linux-ng;redhat-lsb;bc;wget;sysklogd

--- a/distribution/ltp/include/patches/20150903/lib-mem.c-handle-mlock-returning-EAGAIN.patch
+++ b/distribution/ltp/include/patches/20150903/lib-mem.c-handle-mlock-returning-EAGAIN.patch
@@ -1,0 +1,59 @@
+From af9c8e0bf4f0f97bd0c5b0df83637b34583e204c Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Wed, 16 Sep 2015 17:55:32 +0800
+Subject: [PATCH 10/40] lib/mem.c: handle mlock returning EAGAIN
+
+Sometimes oom0{3,5} failed with following results:
+
+oom05       0  TINFO  :  start OOM testing for mlocked pages.
+oom05       0  TINFO  :  expected victim is 3371.
+oom05       0  TINFO  :  thread (3fff788ff1c0), allocating 3221225472 bytes.
+...
+oom05       5  TFAIL  :  mem.c:153: victim unexpectedly ended with retcode: 11, expected: 12
+
+In the OOM test, that tries to consume all memory, but it doesn't
+retry to mlock, it simply exits with errno returned by mlock. At the
+moment testcase is expecting either ENOMEM or getting killed by kernel.
+
+Retry mlock() if it returns EAGAIN for limited number of attempts
+(at the moment 10).
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Reviewed-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/mem/lib/mem.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/testcases/kernel/mem/lib/mem.c b/testcases/kernel/mem/lib/mem.c
+index 8fe4bf0..118b6c0 100644
+--- a/testcases/kernel/mem/lib/mem.c
++++ b/testcases/kernel/mem/lib/mem.c
+@@ -30,6 +30,7 @@ static int alloc_mem(long int length, int testcase)
+ {
+ 	char *s;
+ 	long i, pagesz = getpagesize();
++	int loop = 10;
+ 
+ 	tst_resm(TINFO, "thread (%lx), allocating %ld bytes.",
+ 		(unsigned long) pthread_self(), length);
+@@ -39,8 +40,15 @@ static int alloc_mem(long int length, int testcase)
+ 	if (s == MAP_FAILED)
+ 		return errno;
+ 
+-	if (testcase == MLOCK && mlock(s, length) == -1)
+-		return errno;
++	if (testcase == MLOCK) {
++		while (mlock(s, length) == -1 && loop > 0) {
++			if (EAGAIN != errno)
++				return errno;
++			usleep(300000);
++			loop--;
++		}
++	}
++
+ #ifdef HAVE_MADV_MERGEABLE
+ 	if (testcase == KSM && madvise(s, length, MADV_MERGEABLE) == -1)
+ 		return errno;
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20150903/mem-hugetlb-Find-an-empty-region-to-use-in-hugemmap0.patch
+++ b/distribution/ltp/include/patches/20150903/mem-hugetlb-Find-an-empty-region-to-use-in-hugemmap0.patch
@@ -1,0 +1,166 @@
+From 74c95c22deaf143c1e00b6dc146193f89442d5ae Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Thu, 15 Oct 2015 11:23:23 +0800
+Subject: [PATCH] mem/hugetlb: Find an empty region to use in hugemmap02.c
+
+the testcase 'hugemmap02' always failed on s390x as:
+----------
+hugemmap02    0  TINFO  :  set nr_hugepages to 128
+hugemmap02    1  TPASS  :  huge mmap succeeded (64-bit)
+./hugemmap02: relocation error: ./hugemmap02: symbol , version GLIBC_2.2 not defined in file libc.so.6 with link time reference
+----------
+
+it is caused by mapping in zero where libc.so.6 was loaded and resulting in
+the dynamic loader finding no information about versions for the library.
+
+running the program, we could obviously see the region area:
+---------------
+program address:
+80000000-80001000 r--s 00000000 00:05 2644                               /dev/zero
+80001000-80012000 r-xp 00001000 fd:00 35121302                           /mnt/tests/kernel/distribution/ltp/generic/ltp-full-20150903/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02
+80012000-80013000 r--p 00011000 fd:00 35121302                           /mnt/tests/kernel/distribution/ltp/generic/ltp-full-20150903/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02
+80013000-80014000 rw-p 00012000 fd:00 35121302                           /mnt/tests/kernel/distribution/ltp/generic/ltp-full-20150903/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02
+80014000-80017000 rw-p 00000000 00:00 0
+90000000-90200000 rw-s 00000000 00:29 75950                              /tmp/hugme85Xf/mmapfile41071
+9c14f000-9c170000 rw-p 00000000 00:00 0                                  [heap]
+3ffad342000-3ffbd342000 r--s 00000000 00:05 2644                         /dev/zero
+3ffbd342000-3ffcd342000 r--s 00000000 00:05 2644                         /dev/zero
+3ffcd342000-3ffdd342000 r--s 00000000 00:05 2644                         /dev/zero
+3ffdd342000-3ffed342000 r--s 00000000 00:05 2644                         /dev/zero
+3ffed342000-3fffd342000 r--s 00000000 00:05 2644                         /dev/zero
+3fffd342000-3fffd344000 rw-p 00000000 00:00 0
+3fffd344000-3fffd4db000 r-xp 00000000 fd:00 5438                         /usr/lib64/libc-2.17.so
+3fffd4db000-3fffd4df000 r--p 00196000 fd:00 5438                         /usr/lib64/libc-2.17.so
+3fffd4df000-3fffd4e1000 rw-p 0019a000 fd:00 5438                         /usr/lib64/libc-2.17.so
+3fffd4e1000-3fffd4e6000 rw-p 00000000 00:00 0
+3fffd4e6000-3fffd4fe000 r-xp 00000000 fd:00 5464                         /usr/lib64/libpthread-2.17.so
+3fffd4fe000-3fffd4ff000 r--p 00017000 fd:00 5464                         /usr/lib64/libpthread-2.17.so
+3fffd4ff000-3fffd500000 rw-p 00018000 fd:00 5464                         /usr/lib64/libpthread-2.17.so
+3fffd500000-3fffd504000 rw-p 00000000 00:00 0
+3fffd50c000-3fffd510000 rw-p 00000000 00:00 0
+3fffd510000-3fffd512000 r-xp 00000000 00:00 0                            [vdso]
+3fffd512000-3fffd534000 r-xp 00000000 fd:00 5431                         /usr/lib64/ld-2.17.so
+3fffd534000-3fffd535000 r--p 00022000 fd:00 5431                         /usr/lib64/ld-2.17.so
+3fffd535000-3fffd536000 rw-p 00023000 fd:00 5431                         /usr/lib64/ld-2.17.so
+3fffd536000-3fffd537000 rw-p 00000000 00:00 0
+3ffffaaf000-3ffffad0000 rw-p 00000000 00:00 0                            [stack]
+-------------
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Reviewed-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/mem/hugetlb/hugemmap/hugemmap02.c | 24 +++++++++++++---
+ testcases/kernel/mem/include/mem.h                 |  2 ++
+ testcases/kernel/mem/lib/mem.c                     | 32 ++++++++++++++++++++++
+ 3 files changed, 54 insertions(+), 4 deletions(-)
+
+diff --git a/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02.c b/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02.c
+index cfdcb3c..9fee330 100644
+--- a/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02.c
++++ b/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02.c
+@@ -56,8 +56,8 @@
+ #include "safe_macros.h"
+ #include "mem.h"
+ 
+-#define LOW_ADDR       (void *)(0x80000000)
+-#define LOW_ADDR2      (void *)(0x90000000)
++#define LOW_ADDR       0x80000000
++#define LOW_ADDR2      0x90000000
+ 
+ static char TEMPFILE[MAXPATHLEN];
+ 
+@@ -65,6 +65,8 @@ char *TCID = "hugemmap02";
+ int TST_TOTAL = 1;
+ static unsigned long *addr;
+ static unsigned long *addr2;
++static unsigned long low_addr = LOW_ADDR;
++static unsigned long low_addr2 = LOW_ADDR2;
+ static unsigned long *addrlist[5];
+ static int i;
+ static int fildes;
+@@ -127,15 +129,29 @@ int main(int ac, char **av)
+ 			addrlist[i] = addr;
+ 		}
+ 
++		while (range_is_mapped(cleanup, low_addr, low_addr + map_sz) == 1) {
++			low_addr = low_addr + 0x10000000;
++
++			if (low_addr < LOW_ADDR)
++				tst_brkm(TBROK | TERRNO, cleanup,
++						"no empty region to use");
++		}
+ 		/* mmap using normal pages and a low memory address */
+-		addr = mmap(LOW_ADDR, page_sz, PROT_READ,
++		addr = mmap((void *)low_addr, page_sz, PROT_READ,
+ 			    MAP_SHARED | MAP_FIXED, nfildes, 0);
+ 		if (addr == MAP_FAILED)
+ 			tst_brkm(TBROK | TERRNO, cleanup,
+ 				 "mmap failed on nfildes");
+ 
++		while (range_is_mapped(cleanup, low_addr2, low_addr2 + map_sz) == 1) {
++			low_addr2 = low_addr2 + 0x10000000;
++
++			if (low_addr2 < LOW_ADDR2)
++				tst_brkm(TBROK | TERRNO, cleanup,
++						"no empty region to use");
++		}
+ 		/* Attempt to mmap a huge page into a low memory address */
+-		addr2 = mmap(LOW_ADDR2, map_sz, PROT_READ | PROT_WRITE,
++		addr2 = mmap((void *)low_addr2, map_sz, PROT_READ | PROT_WRITE,
+ 			     MAP_SHARED, fildes, 0);
+ #if __WORDSIZE == 64		/* 64-bit process */
+ 		if (addr2 == MAP_FAILED) {
+diff --git a/testcases/kernel/mem/include/mem.h b/testcases/kernel/mem/include/mem.h
+index fd1879c..4a18799 100644
+--- a/testcases/kernel/mem/include/mem.h
++++ b/testcases/kernel/mem/include/mem.h
+@@ -100,4 +100,6 @@ void setup(void);
+ 
+ void update_shm_size(size_t *shm_size);
+ 
++/* MMAP */
++int range_is_mapped(void (*cleanup_fn) (void), unsigned long low, unsigned long high);
+ #endif
+diff --git a/testcases/kernel/mem/lib/mem.c b/testcases/kernel/mem/lib/mem.c
+index 118b6c0..215c052 100644
+--- a/testcases/kernel/mem/lib/mem.c
++++ b/testcases/kernel/mem/lib/mem.c
+@@ -1113,3 +1113,35 @@ void update_shm_size(size_t * shm_size)
+ 		*shm_size = shmmax;
+ 	}
+ }
++
++int range_is_mapped(void (*cleanup_fn) (void), unsigned long low, unsigned long high)
++{
++	FILE *fp;
++
++	fp = fopen("/proc/self/maps", "r");
++	if (fp == NULL)
++		tst_brkm(TBROK | TERRNO, cleanup_fn, "Failed to open /proc/self/maps.");
++
++	while (!feof(fp)) {
++		unsigned long start, end;
++		int ret;
++
++		ret = fscanf(fp, "%lx-%lx %*[^\n]\n", &start, &end);
++		if (ret != 2) {
++			fclose(fp);
++			tst_brkm(TBROK | TERRNO, cleanup_fn, "Couldn't parse /proc/self/maps line.");
++		}
++
++		if ((start >= low) && (start < high)) {
++			fclose(fp);
++			return 1;
++		}
++		if ((end >= low) && (end < high)) {
++			fclose(fp);
++			return 1;
++		}
++	}
++
++	fclose(fp);
++	return 0;
++}
+-- 
+1.9.3
+

--- a/distribution/ltp/include/patches/20150903/mtest01-sigchld.patch
+++ b/distribution/ltp/include/patches/20150903/mtest01-sigchld.patch
@@ -1,0 +1,90 @@
+commit ba607821c508573ee36749f7c1bc9802bf6ee337
+Author: jvohanka <jvohanka@redhat.com>
+Date:   Wed Nov 18 14:39:21 2015 +0100
+
+    mtest01: fail if a child unexpectedly terminates
+    
+    mtest01 checks that a specified amount of memory could be allocated.
+    The memory allocation is performed by several child processes. Each
+    child allocates certain amount of memory and then sends SIGRTMIN to
+    the parent. The parent waits until it receives SIGRTMIN from all child
+    processes or until the amount of free memory is decreased by at least
+    the amount it tasked the children to allocate.
+    
+    The problem is that in certain situations the child process gets killed
+    by oom-killer. The parent never receives SIGRTMIN from that process and
+    there is not sufficient decrease in the amount of free memory, so
+    the parent keeps waiting indefinitely.
+    
+    This patch fixes the above issue. It modifies the test in such a way that
+    it also waits for SIGCHLD signal (which is sent when the oom-killer
+    terminates the child process). If SIGCHLD is received the test FAILS.
+    
+    Signed-off-by: Jiri Vohanka <jvohanka@redhat.com>
+    Signed-off-by: Jan Stancek <jstancek@redhat.com>
+
+diff --git a/testcases/kernel/mem/mtest01/mtest01.c b/testcases/kernel/mem/mtest01/mtest01.c
+index 8c9e81c93d90..5fe4adc25c88 100644
+--- a/testcases/kernel/mem/mtest01/mtest01.c
++++ b/testcases/kernel/mem/mtest01/mtest01.c
+@@ -50,10 +50,13 @@
+ 
+ char *TCID = "mtest01";
+ int TST_TOTAL = 1;
+-int pid_count = 0;
++static sig_atomic_t pid_count;
++static sig_atomic_t sigchld_count;
+ 
+-void handler(int signo)
++static void handler(int signo)
+ {
++	if (signo == SIGCHLD)
++		sigchld_count++;
+ 	pid_count++;
+ }
+ 
+@@ -77,6 +80,7 @@ int main(int argc, char *argv[])
+ 	act.sa_flags = 0;
+ 	sigemptyset(&act.sa_mask);
+ 	sigaction(SIGRTMIN, &act, 0);
++	sigaction(SIGCHLD, &act, 0);
+ 
+ 	while ((c = getopt(argc, argv, "c:b:p:wvh")) != -1) {
+ 		switch (c) {
+@@ -268,7 +272,7 @@ int main(int argc, char *argv[])
+ 
+ 			while ((((unsigned long long)pre_mem - post_mem) <
+ 				(unsigned long long)original_maxbytes) &&
+-			       pid_count < pid_cntr) {
++			       pid_count < pid_cntr && !sigchld_count) {
+ 				sleep(1);
+ 				sysinfo(&sstats);
+ 				post_mem =
+@@ -280,16 +284,21 @@ int main(int argc, char *argv[])
+ 				    sstats.freeswap;
+ 			}
+ 		}
+-		while (pid_list[i] != 0) {
+-			kill(pid_list[i], SIGKILL);
+-			i++;
+-		}
+-		if (dowrite)
++
++		if (sigchld_count) {
++			tst_resm(TFAIL, "child process exited unexpectedly");
++		} else if (dowrite) {
+ 			tst_resm(TPASS, "%llu kbytes allocated and used.",
+ 				 original_maxbytes / 1024);
+-		else
++		} else {
+ 			tst_resm(TPASS, "%llu kbytes allocated only.",
+ 				 original_maxbytes / 1024);
++		}
++
++		while (pid_list[i] != 0) {
++			kill(pid_list[i], SIGKILL);
++			i++;
++		}
+ 	}
+ 	free(pid_list);
+ 	tst_exit();

--- a/distribution/ltp/include/patches/20160126/hugemmap02.c-don-t-skip-cleanup-in-the-loop.patch
+++ b/distribution/ltp/include/patches/20160126/hugemmap02.c-don-t-skip-cleanup-in-the-loop.patch
@@ -1,0 +1,58 @@
+From f5e190310ee6a7b5e678a69cdb5edf223e35f046 Mon Sep 17 00:00:00 2001
+From: Shuang Qiu <shuang.qiu@oracle.com>
+Date: Wed, 17 Feb 2016 16:22:36 +0800
+Subject: [PATCH] hugemmap02.c: don't skip cleanup in the loop
+
+* Remove continue in the loop because it skips the cleanup
+
+* munmap() addr2 for 32-bit
+
+* close nfildes fd in the end of loop
+
+Signed-off-by: Shuang Qiu <shuang.qiu@oracle.com>
+Reviewed-by: Alexey Kodanev <alexey.kodanev@oracle.com>
+Reviewed-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/mem/hugetlb/hugemmap/hugemmap02.c | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02.c b/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02.c
+index 1a44993..d31609d 100644
+--- a/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02.c
++++ b/testcases/kernel/mem/hugetlb/hugemmap/hugemmap02.c
+@@ -158,8 +158,6 @@ int main(int ac, char **av)
+ 		if (addr2 == MAP_FAILED) {
+ 			tst_resm(TFAIL | TERRNO, "huge mmap failed unexpectedly"
+ 				 " with %s (64-bit)", TEMPFILE);
+-			close(fildes);
+-			continue;
+ 		} else {
+ 			tst_resm(TPASS, "huge mmap succeeded (64-bit)");
+ 		}
+@@ -170,8 +168,6 @@ int main(int ac, char **av)
+ 		else if (addr2 > 0) {
+ 			tst_resm(TCONF,
+ 				 "huge mmap failed to test the scenario");
+-			close(fildes);
+-			continue;
+ 		} else if (addr == 0)
+ 			tst_resm(TPASS, "huge mmap succeeded (32-bit)");
+ #endif
+@@ -183,13 +179,12 @@ int main(int ac, char **av)
+ 					 "munmap of addrlist[%d] failed", i);
+ 		}
+ 
+-#if __WORDSIZE == 64
+ 		if (munmap(addr2, map_sz) == -1)
+ 			tst_brkm(TFAIL | TERRNO, NULL, "huge munmap failed");
+-#endif
+ 		if (munmap(addr, page_sz) == -1)
+ 			tst_brkm(TFAIL | TERRNO, NULL, "munmap failed");
+ 
++		close(nfildes);
+ 		close(fildes);
+ 	}
+ 
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160126/mm-ksm-extend-max_page_sharing-before-ksm-testing.patch
+++ b/distribution/ltp/include/patches/20160126/mm-ksm-extend-max_page_sharing-before-ksm-testing.patch
@@ -1,0 +1,217 @@
+From 44363705de7b1145274c88ef4af9f48ce1c25348 Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Wed, 23 Mar 2016 12:25:56 +0800
+Subject: [PATCH 3/4] mm/ksm: extend 'max_page_sharing' before ksm testing
+
+This kernel commit (de39e60a6, ksm: introduce ksm_max_page_sharing per page...)
+introduced a new KSM sysfs knob '/sys/kernel/mm/ksm/max_page_sharing' in linux-next.
+
+The runtime value of 'max_page_sharing' will affect pages_shared/pages_sharing,
+because this enforces a deduplication limit to avoid the virtual memory rmap lists
+to grow too large.
+
+ltp/ksm0* tests can easily get failures on that kernel like:
+-----
+ksm01       0  TINFO  :  wait for all children to stop.
+ksm01       0  TINFO  :  KSM merging...
+ksm01       0  TINFO  :  resume all children.
+ksm01       0  TINFO  :  child 2 stops.
+...
+ksm01       0  TINFO  :  run is 1.
+ksm01       0  TINFO  :  pages_shared is 384.
+ksm01       1  TFAIL  :  mem.c:238: pages_shared is not 2.
+ksm01       0  TINFO  :  pages_sharing is 97920.
+ksm01       2  TFAIL  :  mem.c:238: pages_sharing is not 98302.
+ksm01       0  TINFO  :  pages_volatile is 0.
+ksm01       0  TINFO  :  pages_unshared is 0.
+ksm01       0  TINFO  :  sleep_millisecs is 0.
+ksm01       0  TINFO  :  pages_to_scan is 98304.
+
+This patch is intened to extend the 'max_page_sharing' value dynamically to
+make tests pass.
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Signed-off-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/mem/include/mem.h |  2 ++
+ testcases/kernel/mem/ksm/ksm01.c   |  4 ++++
+ testcases/kernel/mem/ksm/ksm02.c   |  3 +++
+ testcases/kernel/mem/ksm/ksm03.c   |  4 ++++
+ testcases/kernel/mem/ksm/ksm04.c   |  4 ++++
+ testcases/kernel/mem/ksm/ksm06.c   |  4 ++++
+ testcases/kernel/mem/lib/mem.c     | 24 +++++++++++++++++++++++-
+ 7 files changed, 44 insertions(+), 1 deletion(-)
+
+diff --git a/testcases/kernel/mem/include/mem.h b/testcases/kernel/mem/include/mem.h
+index 43988fe..f9522a5 100644
+--- a/testcases/kernel/mem/include/mem.h
++++ b/testcases/kernel/mem/include/mem.h
+@@ -44,6 +44,8 @@ void testoom(int mempolicy, int lite, int retcode, int allow_sigkill);
+ 
+ #define PATH_KSM		"/sys/kernel/mm/ksm/"
+ 
++void save_max_page_sharing(void);
++void restore_max_page_sharing(void);
+ void test_ksm_merge_across_nodes(unsigned long nr_pages);
+ 
+ /* THP */
+diff --git a/testcases/kernel/mem/ksm/ksm01.c b/testcases/kernel/mem/ksm/ksm01.c
+index b62df06..824881c 100644
+--- a/testcases/kernel/mem/ksm/ksm01.c
++++ b/testcases/kernel/mem/ksm/ksm01.c
+@@ -106,6 +106,8 @@ void setup(void)
+ 	if (access(PATH_KSM, F_OK) == -1)
+ 		tst_brkm(TCONF, NULL, "KSM configuration is not enabled");
+ 
++	save_max_page_sharing();
++
+ 	/*
+ 	 * kernel commit 90bd6fd introduced a new KSM sysfs knob
+ 	 * /sys/kernel/mm/ksm/merge_across_nodes, setting it to '0'
+@@ -128,4 +130,6 @@ void cleanup(void)
+ 	if (access(PATH_KSM "merge_across_nodes", F_OK) == 0)
+ 		FILE_PRINTF(PATH_KSM "merge_across_nodes",
+ 				 "%d", merge_across_nodes);
++
++	restore_max_page_sharing();
+ }
+diff --git a/testcases/kernel/mem/ksm/ksm02.c b/testcases/kernel/mem/ksm/ksm02.c
+index 537ec01..6274f8a 100644
+--- a/testcases/kernel/mem/ksm/ksm02.c
++++ b/testcases/kernel/mem/ksm/ksm02.c
+@@ -125,6 +125,8 @@ void cleanup(void)
+ 		FILE_PRINTF(PATH_KSM "merge_across_nodes",
+ 				 "%d", merge_across_nodes);
+ 
++	restore_max_page_sharing();
++
+ 	umount_mem(CPATH, CPATH_NEW);
+ }
+ 
+@@ -136,6 +138,7 @@ void setup(void)
+ 		tst_brkm(TCONF, NULL, "2.6.32 or greater kernel required");
+ 	if (access(PATH_KSM, F_OK) == -1)
+ 		tst_brkm(TCONF, NULL, "KSM configuration is not enabled");
++	save_max_page_sharing();
+ 
+ 	if (access(PATH_KSM "merge_across_nodes", F_OK) == 0) {
+ 		SAFE_FILE_SCANF(NULL, PATH_KSM "merge_across_nodes",
+diff --git a/testcases/kernel/mem/ksm/ksm03.c b/testcases/kernel/mem/ksm/ksm03.c
+index b73e023..979222a 100644
+--- a/testcases/kernel/mem/ksm/ksm03.c
++++ b/testcases/kernel/mem/ksm/ksm03.c
+@@ -113,6 +113,8 @@ void setup(void)
+ 		SAFE_FILE_PRINTF(NULL, PATH_KSM "merge_across_nodes", "1");
+ 	}
+ 
++	save_max_page_sharing();
++
+ 	mount_mem("memcg", "cgroup", "memory", MEMCG_PATH, MEMCG_PATH_NEW);
+ 	tst_sig(FORK, DEF_HANDLER, NULL);
+ 	TEST_PAUSE;
+@@ -124,5 +126,7 @@ void cleanup(void)
+ 		FILE_PRINTF(PATH_KSM "merge_across_nodes",
+ 				 "%d", merge_across_nodes);
+ 
++	restore_max_page_sharing();
++
+ 	umount_mem(MEMCG_PATH, MEMCG_PATH_NEW);
+ }
+diff --git a/testcases/kernel/mem/ksm/ksm04.c b/testcases/kernel/mem/ksm/ksm04.c
+index 0c1d4e0..4beeed6 100644
+--- a/testcases/kernel/mem/ksm/ksm04.c
++++ b/testcases/kernel/mem/ksm/ksm04.c
+@@ -127,6 +127,8 @@ void cleanup(void)
+ 		FILE_PRINTF(PATH_KSM "merge_across_nodes",
+ 				 "%d", merge_across_nodes);
+ 
++	restore_max_page_sharing();
++
+ 	umount_mem(CPATH, CPATH_NEW);
+ 	umount_mem(MEMCG_PATH, MEMCG_PATH_NEW);
+ }
+@@ -146,6 +148,8 @@ void setup(void)
+ 		SAFE_FILE_PRINTF(NULL, PATH_KSM "merge_across_nodes", "1");
+ 	}
+ 
++	save_max_page_sharing();
++
+ 	tst_sig(FORK, DEF_HANDLER, cleanup);
+ 	TEST_PAUSE;
+ 	mount_mem("cpuset", "cpuset", NULL, CPATH, CPATH_NEW);
+diff --git a/testcases/kernel/mem/ksm/ksm06.c b/testcases/kernel/mem/ksm/ksm06.c
+index 02d304f..2092746 100644
+--- a/testcases/kernel/mem/ksm/ksm06.c
++++ b/testcases/kernel/mem/ksm/ksm06.c
+@@ -105,6 +105,8 @@ void setup(void)
+ 	SAFE_FILE_SCANF(NULL, PATH_KSM "sleep_millisecs",
+ 			"%d", &sleep_millisecs);
+ 
++	save_max_page_sharing();
++
+ 	tst_sig(FORK, DEF_HANDLER, cleanup);
+ 	TEST_PAUSE;
+ }
+@@ -116,6 +118,8 @@ void cleanup(void)
+ 	FILE_PRINTF(PATH_KSM "sleep_millisecs",
+ 			 "%d", sleep_millisecs);
+ 	FILE_PRINTF(PATH_KSM "run", "%d", run);
++
++	restore_max_page_sharing();
+ }
+ 
+ static void usage(void)
+diff --git a/testcases/kernel/mem/lib/mem.c b/testcases/kernel/mem/lib/mem.c
+index b0af82a..e41ddb1 100644
+--- a/testcases/kernel/mem/lib/mem.c
++++ b/testcases/kernel/mem/lib/mem.c
+@@ -229,6 +229,22 @@ void testoom(int mempolicy, int lite, int retcode, int allow_sigkill)
+ 
+ /* KSM */
+ 
++static int max_page_sharing;
++
++void save_max_page_sharing(void)
++{
++	if (access(PATH_KSM "max_page_sharing", F_OK) == 0)
++	        SAFE_FILE_SCANF(NULL, PATH_KSM "max_page_sharing",
++	                        "%d", &max_page_sharing);
++}
++
++void restore_max_page_sharing(void)
++{
++	if (access(PATH_KSM "max_page_sharing", F_OK) == 0)
++	        FILE_PRINTF(PATH_KSM "max_page_sharing",
++	                         "%d", max_page_sharing);
++}
++
+ static void check(char *path, long int value)
+ {
+ 	char fullpath[BUFSIZ];
+@@ -501,9 +517,12 @@ void create_same_memory(int size, int num, int unit)
+ 	stop_ksm_children(child, num);
+ 
+ 	tst_resm(TINFO, "KSM merging...");
++	if (access(PATH_KSM "max_page_sharing", F_OK) == 0)
++		SAFE_FILE_PRINTF(cleanup, PATH_KSM "max_page_sharing",
++				"%ld", size * pages * num);
+ 	SAFE_FILE_PRINTF(cleanup, PATH_KSM "run", "1");
+ 	SAFE_FILE_PRINTF(cleanup, PATH_KSM "pages_to_scan", "%ld",
+-			 size * pages *num);
++			 size * pages * num);
+ 	SAFE_FILE_PRINTF(cleanup, PATH_KSM "sleep_millisecs", "0");
+ 
+ 	resume_ksm_children(child, num);
+@@ -594,6 +613,9 @@ void test_ksm_merge_across_nodes(unsigned long nr_pages)
+ 	SAFE_FILE_PRINTF(cleanup, PATH_KSM "sleep_millisecs", "0");
+ 	SAFE_FILE_PRINTF(cleanup, PATH_KSM "pages_to_scan", "%ld",
+ 			 nr_pages * num_nodes);
++	if (access(PATH_KSM "max_page_sharing", F_OK) == 0)
++		SAFE_FILE_PRINTF(cleanup, PATH_KSM "max_page_sharing",
++			"%ld", nr_pages * num_nodes);
+ 	/*
+ 	 * merge_across_nodes setting can be changed only when there
+ 	 * are no ksm shared pages in system, so set run 2 to unmerge
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160126/open_posix-add-SAFE_PFUNC-macro.patch
+++ b/distribution/ltp/include/patches/20160126/open_posix-add-SAFE_PFUNC-macro.patch
@@ -1,0 +1,57 @@
+From 41bb9ed1b29567b541675412d40730b7ca817bdc Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 18 Feb 2016 14:01:45 +0100
+Subject: [PATCH] open_posix: add SAFE_PFUNC macro
+
+Simple macro to exit test and print error if a pthread_* function
+returned non-zero.
+
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ .../open_posix_testsuite/include/safe_helpers.h    | 33 ++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+ create mode 100644 testcases/open_posix_testsuite/include/safe_helpers.h
+
+diff --git a/testcases/open_posix_testsuite/include/safe_helpers.h b/testcases/open_posix_testsuite/include/safe_helpers.h
+new file mode 100644
+index 0000000..7f945a0
+--- /dev/null
++++ b/testcases/open_posix_testsuite/include/safe_helpers.h
+@@ -0,0 +1,33 @@
++/*
++ * Copyright (c) 2016 Linux Test Project
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of version 2 of the GNU General Public License as
++ * published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it would be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
++ *
++ * You should have received a copy of the GNU General Public License
++ * alone with this program.
++ */
++
++#ifndef __SAFE_HELPERS_H__
++#define __SAFE_HELPERS_H__
++
++#include <stdio.h>
++#include <string.h>
++
++#define SAFE_PFUNC(op) \
++do {\
++	int ret = (op); \
++	if (ret != 0) { \
++		printf("Test %s unresolved: got %i (%s) on line %i\n  %s\n", \
++			__FILE__, ret, strerror(ret), __LINE__, #op); \
++		fflush(stdout); \
++		exit(PTS_UNRESOLVED); \
++	} \
++} while (0)
++
++#endif
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160126/open_posix-condvar-schedule-remove-duplicit-setsched.patch
+++ b/distribution/ltp/include/patches/20160126/open_posix-condvar-schedule-remove-duplicit-setsched.patch
@@ -1,0 +1,194 @@
+From 0f029d9eea2b580cd4389aecb50f016b7d5fdc04 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Fri, 19 Feb 2016 09:58:16 +0100
+Subject: [PATCH] open_posix: condvar/schedule: remove duplicit setsched calls
+
+pthread_attr_setschedparam's man page says:
+In  order for the parameter setting made by pthread_attr_setschedparam()
+to have effect when calling pthread_create(3), the caller must use
+pthread_attr_setinheritsched(3) to set the inherit-scheduler attribute
+of the attributes object attr to PTHREAD_EXPLICIT_SCHED.
+
+So add PTHREAD_EXPLICIT_SCHED to attr used during pthread_create and
+remove duplicit pthread_setsched calls in each thread.
+
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ .../functional/threads/condvar/pthread_cond_wait_1.c             | 6 ++----
+ .../functional/threads/condvar/pthread_cond_wait_2.c             | 6 ++----
+ testcases/open_posix_testsuite/functional/threads/schedule/1-1.c | 8 ++++----
+ testcases/open_posix_testsuite/functional/threads/schedule/1-2.c | 9 ++++-----
+ 4 files changed, 12 insertions(+), 17 deletions(-)
+
+diff --git a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
+index dfbf44b..a674efc 100644
+--- a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
++++ b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
+@@ -61,9 +61,7 @@ void *hi_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
+-	param.sched_priority = HIGH_PRIORITY;
+ 
+-	SAFE_PFUNC(pthread_setschedparam(pthread_self(), POLICY, &param));
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != HIGH_PRIORITY)) {
+ 		printf("Error: the policy or priority not correct\n");
+@@ -99,9 +97,7 @@ void *low_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
+-	param.sched_priority = LOW_PRIORITY;
+ 
+-	SAFE_PFUNC(pthread_setschedparam(pthread_self(), POLICY, &param));
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != LOW_PRIORITY)) {
+ 		printf("Error: the policy or priority not correct\n");
+@@ -126,6 +122,7 @@ int main()
+ 
+ 	/* Create the higher priority thread */
+ 	SAFE_PFUNC(pthread_attr_init(&high_attr));
++	SAFE_PFUNC(pthread_attr_setinheritsched(&high_attr, PTHREAD_EXPLICIT_SCHED));
+ 	SAFE_PFUNC(pthread_attr_setschedpolicy(&high_attr, POLICY));
+ 	param.sched_priority = HIGH_PRIORITY;
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
+@@ -133,6 +130,7 @@ int main()
+ 
+ 	/* Create the low priority thread */
+ 	SAFE_PFUNC(pthread_attr_init(&low_attr));
++	SAFE_PFUNC(pthread_attr_setinheritsched(&low_attr, PTHREAD_EXPLICIT_SCHED));
+ 	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, POLICY));
+ 	param.sched_priority = LOW_PRIORITY;
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
+diff --git a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
+index c5670f8..398b8db 100644
+--- a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
++++ b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
+@@ -61,9 +61,7 @@ void *hi_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
+-	param.sched_priority = HIGH_PRIORITY;
+ 
+-	SAFE_PFUNC(pthread_setschedparam(pthread_self(), POLICY, &param));
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != HIGH_PRIORITY)) {
+ 		printf("Error: the policy or priority not correct\n");
+@@ -99,9 +97,7 @@ void *low_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
+-	param.sched_priority = LOW_PRIORITY;
+ 
+-	SAFE_PFUNC(pthread_setschedparam(pthread_self(), POLICY, &param));
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != LOW_PRIORITY)) {
+ 		printf("Error: the policy or priority not correct\n");
+@@ -126,6 +122,7 @@ int main()
+ 
+ 	/* Create the higher priority thread */
+ 	SAFE_PFUNC(pthread_attr_init(&high_attr));
++	SAFE_PFUNC(pthread_attr_setinheritsched(&high_attr, PTHREAD_EXPLICIT_SCHED));
+ 	SAFE_PFUNC(pthread_attr_setschedpolicy(&high_attr, POLICY));
+ 	param.sched_priority = HIGH_PRIORITY;
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
+@@ -133,6 +130,7 @@ int main()
+ 
+ 	/* Create the low priority thread */
+ 	SAFE_PFUNC(pthread_attr_init(&low_attr));
++	SAFE_PFUNC(pthread_attr_setinheritsched(&low_attr, PTHREAD_EXPLICIT_SCHED));
+ 	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, POLICY));
+ 	param.sched_priority = LOW_PRIORITY;
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
+diff --git a/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c b/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
+index a6b634c..c65e127 100644
+--- a/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
++++ b/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
+@@ -70,8 +70,7 @@ void *hi_prio_thread(void *tmp)
+ 	void *previous_signal;
+ 
+ 	(void) tmp;
+-	param.sched_priority = HIGH_PRIORITY;
+-	SAFE_PFUNC(pthread_setschedparam(pthread_self(), SCHED_RR, &param));
++
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR || param.sched_priority != HIGH_PRIORITY) {
+ 		printf("Error: the policy or priority not correct\n");
+@@ -104,8 +103,7 @@ void *low_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
+-	param.sched_priority = LOW_PRIORITY;
+-	SAFE_PFUNC(pthread_setschedparam(pthread_self(), SCHED_RR, &param));
++
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR || param.sched_priority != LOW_PRIORITY) {
+ 		printf("Error: the policy or priority not correct\n");
+@@ -133,6 +131,7 @@ int main()
+ 
+ 	/* Create the higher priority */
+ 	SAFE_PFUNC(pthread_attr_init(&high_attr));
++	SAFE_PFUNC(pthread_attr_setinheritsched(&high_attr, PTHREAD_EXPLICIT_SCHED));
+ 	SAFE_PFUNC(pthread_attr_setschedpolicy(&high_attr, SCHED_RR));
+ 	param.sched_priority = HIGH_PRIORITY;
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
+@@ -140,6 +139,7 @@ int main()
+ 
+ 	/* Create the low priority thread */
+ 	SAFE_PFUNC(pthread_attr_init(&low_attr));
++	SAFE_PFUNC(pthread_attr_setinheritsched(&low_attr, PTHREAD_EXPLICIT_SCHED));
+ 	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, SCHED_RR));
+ 	param.sched_priority = LOW_PRIORITY;
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
+diff --git a/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c b/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
+index f7b0bd8..c85460e 100644
+--- a/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
++++ b/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
+@@ -61,8 +61,7 @@ void *hi_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
+-	param.sched_priority = HIGH_PRIORITY;
+-	SAFE_PFUNC(pthread_setschedparam(pthread_self(), SCHED_RR, &param));
++
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR) {
+ 		printf(ERROR_PREFIX "The policy is not correct\n");
+@@ -92,8 +91,7 @@ void *low_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
+-	param.sched_priority = LOW_PRIORITY;
+-	SAFE_PFUNC(pthread_setschedparam(pthread_self(), SCHED_RR, &param));
++
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR) {
+ 		printf(ERROR_PREFIX "Policy not correct\n");
+@@ -137,6 +135,7 @@ int main()
+ 
+ 	/* create the higher priority */
+ 	SAFE_PFUNC(pthread_attr_init(&high_attr));
++	SAFE_PFUNC(pthread_attr_setinheritsched(&high_attr, PTHREAD_EXPLICIT_SCHED));
+ 	SAFE_PFUNC(pthread_attr_setschedpolicy(&high_attr, SCHED_RR));
+ 	param.sched_priority = HIGH_PRIORITY;
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
+@@ -144,6 +143,7 @@ int main()
+ 
+ 	/* Create the low priority thread */
+ 	SAFE_PFUNC(pthread_attr_init(&low_attr));
++	SAFE_PFUNC(pthread_attr_setinheritsched(&low_attr, PTHREAD_EXPLICIT_SCHED));
+ 	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, SCHED_RR));
+ 	param.sched_priority = LOW_PRIORITY;
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
+@@ -156,7 +156,6 @@ int main()
+ 	}
+ 
+ 	SAFE_PFUNC(pthread_mutex_lock(&cond_mutex));
+-
+ 	alarm(2);
+ 	SAFE_PFUNC(pthread_cond_wait(&cond, &cond_mutex));
+ 	SAFE_PFUNC(pthread_mutex_unlock(&cond_mutex));
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160126/open_posix-condvar-schedule-remove-signal-handlers.patch
+++ b/distribution/ltp/include/patches/20160126/open_posix-condvar-schedule-remove-signal-handlers.patch
@@ -1,0 +1,458 @@
+From dadab74ec5c36fe26ea6ebd788196051e8130da6 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Tue, 23 Feb 2016 13:14:36 +0100
+Subject: [PATCH] open_posix: condvar/schedule: remove signal handlers
+
+POSIX states:
+"It is not safe to use the pthread_cond_signal() function in a signal
+handler that is invoked asynchronously. Even if it were safe, there
+would still be a race between the test of the Boolean pthread_cond_wait()
+that could not be efficiently eliminated."
+
+Further, this test could hang on single CPU, if signal gets delivered
+to main thread, because there is low prio thread busy looping with
+higher priority than main.
+
+This patch removes signal handlers and instead uses main to
+signal/unlock condition/barrier/mutex that high prio thread is
+blocked on.
+
+High and low prio threads are set to run on same CPU to check that
+high prio thread really preempted low prio thread regarless of number
+of CPUs on system. Main thread's priority is at least the same as
+low prio thread, therefore it should eventually run even if there
+is only single CPU on system.
+
+Suggested-by: Cyril Hrubis <chrubis@suse.cz>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ .../threads/condvar/pthread_cond_wait_1.c          | 41 ++++++++-------------
+ .../threads/condvar/pthread_cond_wait_2.c          | 41 ++++++++-------------
+ .../functional/threads/schedule/1-1.c              | 43 ++++++++--------------
+ .../functional/threads/schedule/1-2.c              | 32 +++++-----------
+ 4 files changed, 57 insertions(+), 100 deletions(-)
+
+diff --git a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
+index a674efc..b2ad546 100644
+--- a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
++++ b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
+@@ -13,14 +13,15 @@
+  * 1. Create a condition variable
+  * 2. Create a high priority thread and make it wait on the cond
+  * 3. Create a low priority thread and let it busy-loop
+- * 4. Signal the cond in a signal handler and check that high
+- *    priority thread got woken up
++ * 4. Both low and high prio threads run on same CPU
++ * 5. Signal the cond from main and check that high priority thread
++ *    got woken up and preempted low priority thread
+  */
+ 
++#include "affinity.h"
+ #include <pthread.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <signal.h>
+ #include <unistd.h>
+ #include <time.h>
+ #include "posixtest.h"
+@@ -42,12 +43,6 @@ pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+ static volatile int woken_up;
+ static volatile int low_done;
+ 
+-void signal_handler(int sig)
+-{
+-	(void) sig;
+-	SAFE_PFUNC(pthread_cond_signal(&cond));
+-}
+-
+ float timediff(struct timespec t2, struct timespec t1)
+ {
+ 	float diff = t2.tv_sec - t1.tv_sec;
+@@ -61,6 +56,7 @@ void *hi_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
++	set_affinity_single();
+ 
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != HIGH_PRIORITY)) {
+@@ -68,15 +64,8 @@ void *hi_prio_thread(void *tmp)
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	if (signal(SIGALRM, signal_handler) != 0) {
+-		perror(ERROR_PREFIX "signal:");
+-		exit(PTS_UNRESOLVED);
+-	}
+-
+ 	SAFE_PFUNC(pthread_mutex_lock(&mutex));
+ 
+-	alarm(2);
+-
+ 	/* Block, to be woken up by the signal handler */
+ 	SAFE_PFUNC(pthread_cond_wait(&cond, &mutex));
+ 
+@@ -97,6 +86,7 @@ void *low_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
++	set_affinity_single();
+ 
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != LOW_PRIORITY)) {
+@@ -117,7 +107,7 @@ void *low_prio_thread(void *tmp)
+ int main()
+ {
+ 	pthread_t high_id, low_id;
+-	pthread_attr_t high_attr, low_attr;
++	pthread_attr_t high_attr;
+ 	struct sched_param param;
+ 
+ 	/* Create the higher priority thread */
+@@ -128,22 +118,23 @@ int main()
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
+ 	SAFE_PFUNC(pthread_create(&high_id, &high_attr, hi_prio_thread, NULL));
+ 
+-	/* Create the low priority thread */
+-	SAFE_PFUNC(pthread_attr_init(&low_attr));
+-	SAFE_PFUNC(pthread_attr_setinheritsched(&low_attr, PTHREAD_EXPLICIT_SCHED));
+-	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, POLICY));
++	/* run main with same priority as low prio thread */
+ 	param.sched_priority = LOW_PRIORITY;
+-	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
+-	SAFE_PFUNC(pthread_create(&low_id, &low_attr, low_prio_thread, NULL));
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), POLICY, &param));
++
++	/* Create the low priority thread (inherits sched policy from main) */
++	SAFE_PFUNC(pthread_create(&low_id, NULL, low_prio_thread, NULL));
++
++	sleep(1);
++	SAFE_PFUNC(pthread_cond_signal(&cond));
+ 
+ 	/* Wait for the threads to exit */
+-	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 	SAFE_PFUNC(pthread_join(low_id, NULL));
+-
+ 	if (!woken_up) {
+ 		printf("Test FAILED: high priority was not woken up\n");
+ 		exit(PTS_FAIL);
+ 	}
++	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 
+ 	printf("Test PASSED\n");
+ 	exit(PTS_PASS);
+diff --git a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
+index 398b8db..a7826cd 100644
+--- a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
++++ b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
+@@ -13,14 +13,15 @@
+  * 1. Create a condition variable
+  * 2. Create a high priority thread and make it wait on the cond
+  * 3. Create a low priority thread and let it busy-loop
+- * 4. Broadcast the cond in a signal handler and check that high
+- *    priority thread got woken up
++ * 4. Both low and high prio threads run on same CPU
++ * 5. Signal the cond from main and check that high priority thread
++ *    got woken up and preempted low priority thread
+  */
+ 
++#include "affinity.h"
+ #include <pthread.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <signal.h>
+ #include <unistd.h>
+ #include <time.h>
+ #include "posixtest.h"
+@@ -42,12 +43,6 @@ pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+ static volatile int woken_up;
+ static volatile int low_done;
+ 
+-void signal_handler(int sig)
+-{
+-	(void) sig;
+-	SAFE_PFUNC(pthread_cond_broadcast(&cond));
+-}
+-
+ float timediff(struct timespec t2, struct timespec t1)
+ {
+ 	float diff = t2.tv_sec - t1.tv_sec;
+@@ -61,6 +56,7 @@ void *hi_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
++	set_affinity_single();
+ 
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != HIGH_PRIORITY)) {
+@@ -68,15 +64,8 @@ void *hi_prio_thread(void *tmp)
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	if (signal(SIGALRM, signal_handler) != 0) {
+-		perror(ERROR_PREFIX "signal:");
+-		exit(PTS_UNRESOLVED);
+-	}
+-
+ 	SAFE_PFUNC(pthread_mutex_lock(&mutex));
+ 
+-	alarm(2);
+-
+ 	/* Block, to be woken up by the signal handler */
+ 	SAFE_PFUNC(pthread_cond_wait(&cond, &mutex));
+ 
+@@ -97,6 +86,7 @@ void *low_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
++	set_affinity_single();
+ 
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != LOW_PRIORITY)) {
+@@ -117,7 +107,7 @@ void *low_prio_thread(void *tmp)
+ int main()
+ {
+ 	pthread_t high_id, low_id;
+-	pthread_attr_t high_attr, low_attr;
++	pthread_attr_t high_attr;
+ 	struct sched_param param;
+ 
+ 	/* Create the higher priority thread */
+@@ -128,22 +118,23 @@ int main()
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
+ 	SAFE_PFUNC(pthread_create(&high_id, &high_attr, hi_prio_thread, NULL));
+ 
+-	/* Create the low priority thread */
+-	SAFE_PFUNC(pthread_attr_init(&low_attr));
+-	SAFE_PFUNC(pthread_attr_setinheritsched(&low_attr, PTHREAD_EXPLICIT_SCHED));
+-	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, POLICY));
++	/* run main with same priority as low prio thread */
+ 	param.sched_priority = LOW_PRIORITY;
+-	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
+-	SAFE_PFUNC(pthread_create(&low_id, &low_attr, low_prio_thread, NULL));
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), POLICY, &param));
++
++	/* Create the low priority thread (inherits sched policy from main) */
++	SAFE_PFUNC(pthread_create(&low_id, NULL, low_prio_thread, NULL));
++
++	sleep(1);
++	SAFE_PFUNC(pthread_cond_broadcast(&cond));
+ 
+ 	/* Wait for the threads to exit */
+-	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 	SAFE_PFUNC(pthread_join(low_id, NULL));
+-
+ 	if (!woken_up) {
+ 		printf("Test FAILED: high priority was not woken up\n");
+ 		exit(PTS_FAIL);
+ 	}
++	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 
+ 	printf("Test PASSED\n");
+ 	exit(PTS_PASS);
+diff --git a/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c b/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
+index c65e127..d926801 100644
+--- a/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
++++ b/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
+@@ -13,16 +13,17 @@
+  * 1. Create a barrier object
+  * 2. Create a high priority thread and make it wait on the barrier
+  * 3. Create a low priority thread and let it busy-loop
+- * 4. Setup a signal handler for ALRM
+- * 5. Call the final barrier_wait in the signal handler
++ * 4. Both low and high prio threads run on same CPU
++ * 5. Call the final barrier_wait from main
+  * 6. Check that the higher priority thread got woken up
++ *    and preempted low priority thread
+  */
+ 
+ #define _XOPEN_SOURCE 600
++#include "affinity.h"
+ #include <pthread.h>
+ #include <stdlib.h>
+ #include <stdio.h>
+-#include <signal.h>
+ #include <unistd.h>
+ #include <sys/time.h>
+ #include "posixtest.h"
+@@ -57,19 +58,13 @@ int my_pthread_barrier_wait(pthread_barrier_t *p)
+ 	return rc;
+ }
+ 
+-void signal_handler(int sig)
+-{
+-	(void) sig;
+-	SAFE_PFUNC(my_pthread_barrier_wait(&barrier));
+-}
+-
+ void *hi_prio_thread(void *tmp)
+ {
+ 	struct sched_param param;
+ 	int policy;
+-	void *previous_signal;
+ 
+ 	(void) tmp;
++	set_affinity_single();
+ 
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR || param.sched_priority != HIGH_PRIORITY) {
+@@ -77,14 +72,6 @@ void *hi_prio_thread(void *tmp)
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	previous_signal = signal(SIGALRM, signal_handler);
+-	if (previous_signal == SIG_ERR) {
+-		perror(ERROR_PREFIX "signal");
+-		exit(PTS_UNRESOLVED);
+-	}
+-
+-	alarm(2);
+-
+ 	SAFE_PFUNC(my_pthread_barrier_wait(&barrier));
+ 
+ 	/* This variable is unprotected because the scheduling removes
+@@ -103,6 +90,7 @@ void *low_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
++	set_affinity_single();
+ 
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR || param.sched_priority != LOW_PRIORITY) {
+@@ -124,7 +112,7 @@ void *low_prio_thread(void *tmp)
+ int main()
+ {
+ 	pthread_t high_id, low_id;
+-	pthread_attr_t low_attr, high_attr;
++	pthread_attr_t high_attr;
+ 	struct sched_param param;
+ 
+ 	SAFE_PFUNC(pthread_barrier_init(&barrier, NULL, 2));
+@@ -137,22 +125,23 @@ int main()
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
+ 	SAFE_PFUNC(pthread_create(&high_id, &high_attr, hi_prio_thread, NULL));
+ 
+-	/* Create the low priority thread */
+-	SAFE_PFUNC(pthread_attr_init(&low_attr));
+-	SAFE_PFUNC(pthread_attr_setinheritsched(&low_attr, PTHREAD_EXPLICIT_SCHED));
+-	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, SCHED_RR));
++	/* run main with same priority as low prio thread */
+ 	param.sched_priority = LOW_PRIORITY;
+-	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
+-	SAFE_PFUNC(pthread_create(&low_id, &low_attr, low_prio_thread, NULL));
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), SCHED_RR, &param));
++
++	/* Create the low priority thread (inherits sched policy from main) */
++	SAFE_PFUNC(pthread_create(&low_id, NULL, low_prio_thread, NULL));
++
++	sleep(1);
++	SAFE_PFUNC(my_pthread_barrier_wait(&barrier));
+ 
+ 	/* Wait for the threads to exit */
+-	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 	SAFE_PFUNC(pthread_join(low_id, NULL));
+-
+ 	if (!woken_up) {
+ 		printf("High priority was not woken up. Test FAILED\n");
+ 		exit(PTS_FAIL);
+ 	}
++	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 
+ 	printf("Test PASSED\n");
+ 	exit(PTS_PASS);
+diff --git a/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c b/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
+index c85460e..92e3ef1 100644
+--- a/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
++++ b/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
+@@ -13,14 +13,15 @@
+  * 1. Create a mutex and lock
+  * 2. Create a high priority thread and make it wait on the mutex
+  * 3. Create a low priority thread and let it busy-loop
+- * 4. Unlock the mutex and make sure that the higher priority thread
+- *    got woken up
++ * 4. Both low and high prio threads run on same CPU
++ * 5. Unlock the mutex and make sure that the higher priority thread
++ *    got woken up and preempted low priority thread
+  */
+ 
++#include "affinity.h"
+ #include <pthread.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <signal.h>
+ #include <unistd.h>
+ #include <sys/time.h>
+ #include "posixtest.h"
+@@ -36,8 +37,6 @@
+ #define RUNTIME 5
+ 
+ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+-pthread_mutex_t cond_mutex = PTHREAD_MUTEX_INITIALIZER;
+-pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+ 
+ static volatile int woken_up;
+ static volatile int low_done;
+@@ -49,18 +48,13 @@ float timediff(struct timespec t2, struct timespec t1)
+ 	return diff;
+ }
+ 
+-void signal_handler(int sig)
+-{
+-	(void) sig;
+-	SAFE_PFUNC(pthread_cond_signal(&cond));
+-}
+-
+ void *hi_prio_thread(void *tmp)
+ {
+ 	struct sched_param param;
+ 	int policy;
+ 
+ 	(void) tmp;
++	set_affinity_single();
+ 
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR) {
+@@ -91,6 +85,7 @@ void *low_prio_thread(void *tmp)
+ 	int policy;
+ 
+ 	(void) tmp;
++	set_affinity_single();
+ 
+ 	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR) {
+@@ -149,28 +144,19 @@ int main()
+ 	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
+ 	SAFE_PFUNC(pthread_create(&low_id, &low_attr, low_prio_thread, NULL));
+ 
+-	/* setup a signal handler which will wakeup main later */
+-	if (signal(SIGALRM, signal_handler) == SIG_ERR) {
+-		perror(ERROR_PREFIX "signal");
+-		exit(PTS_UNRESOLVED);
+-	}
+-
+-	SAFE_PFUNC(pthread_mutex_lock(&cond_mutex));
+-	alarm(2);
+-	SAFE_PFUNC(pthread_cond_wait(&cond, &cond_mutex));
+-	SAFE_PFUNC(pthread_mutex_unlock(&cond_mutex));
++	sleep(1);
+ 
+ 	/* Wake the other high priority thread up */
+ 	SAFE_PFUNC(pthread_mutex_unlock(&mutex));
+ 
+ 	/* Wait for the threads to exit */
+-	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 	SAFE_PFUNC(pthread_join(low_id, NULL));
+-
+ 	if (!woken_up) {
+ 		printf("High priority was not woken up. Test FAILED.\n");
+ 		exit(PTS_FAIL);
+ 	}
++	SAFE_PFUNC(pthread_join(high_id, NULL));
++
+ 	printf("Test PASSED\n");
+ 	exit(PTS_PASS);
+ }
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160126/open_posix-condvar-schedule-remove-useless-waiting.patch
+++ b/distribution/ltp/include/patches/20160126/open_posix-condvar-schedule-remove-useless-waiting.patch
@@ -1,0 +1,194 @@
+From d9d0e9cc0cd3f5eb5f70d47177a4b9ed4a0de827 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 18 Feb 2016 14:53:27 +0100
+Subject: [PATCH] open_posix: condvar/schedule: remove useless waiting
+
+If high prio thread wakes up, test is done, there's no point waiting
+another 3 seconds for low prio thread to end its busy loop.
+
+If test PASS-es, we save 3 seconds per test.
+
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ .../functional/threads/condvar/pthread_cond_wait_1.c         | 12 ++++++------
+ .../functional/threads/condvar/pthread_cond_wait_2.c         | 12 ++++++------
+ .../open_posix_testsuite/functional/threads/schedule/1-1.c   | 10 +++++-----
+ .../open_posix_testsuite/functional/threads/schedule/1-2.c   | 10 +++++-----
+ 4 files changed, 22 insertions(+), 22 deletions(-)
+
+diff --git a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
+index 5b36fc2..dfbf44b 100644
+--- a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
++++ b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
+@@ -39,8 +39,8 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+ pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+ 
+ /* Flags that the threads use to indicate events */
+-int woken_up = -1;
+-int low_done = -1;
++static volatile int woken_up;
++static volatile int low_done;
+ 
+ void signal_handler(int sig)
+ {
+@@ -85,7 +85,7 @@ void *hi_prio_thread(void *tmp)
+ 	/* This variable is unprotected because the scheduling removes
+ 	 * the contention
+ 	 */
+-	if (low_done != 1)
++	if (!low_done)
+ 		woken_up = 1;
+ 
+ 	SAFE_PFUNC(pthread_mutex_unlock(&mutex));
+@@ -109,7 +109,7 @@ void *low_prio_thread(void *tmp)
+ 	}
+ 
+ 	clock_gettime(CLOCK_REALTIME, &start_time);
+-	while (1) {
++	while (!woken_up) {
+ 		clock_gettime(CLOCK_REALTIME, &current_time);
+ 		if (timediff(current_time, start_time) > RUNTIME)
+ 			break;
+@@ -142,8 +142,8 @@ int main()
+ 	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 	SAFE_PFUNC(pthread_join(low_id, NULL));
+ 
+-	if (woken_up == -1) {
+-		printf("Test FAILED: high priority was not woken up\\n");
++	if (!woken_up) {
++		printf("Test FAILED: high priority was not woken up\n");
+ 		exit(PTS_FAIL);
+ 	}
+ 
+diff --git a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
+index 7308bd6..c5670f8 100644
+--- a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
++++ b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
+@@ -39,8 +39,8 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+ pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+ 
+ /* Flags that the threads use to indicate events */
+-int woken_up = -1;
+-int low_done = -1;
++static volatile int woken_up;
++static volatile int low_done;
+ 
+ void signal_handler(int sig)
+ {
+@@ -85,7 +85,7 @@ void *hi_prio_thread(void *tmp)
+ 	/* This variable is unprotected because the scheduling removes
+ 	 * the contention
+ 	 */
+-	if (low_done != 1)
++	if (!low_done)
+ 		woken_up = 1;
+ 
+ 	SAFE_PFUNC(pthread_mutex_unlock(&mutex));
+@@ -109,7 +109,7 @@ void *low_prio_thread(void *tmp)
+ 	}
+ 
+ 	clock_gettime(CLOCK_REALTIME, &start_time);
+-	while (1) {
++	while (!woken_up) {
+ 		clock_gettime(CLOCK_REALTIME, &current_time);
+ 		if (timediff(current_time, start_time) > RUNTIME)
+ 			break;
+@@ -142,8 +142,8 @@ int main()
+ 	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 	SAFE_PFUNC(pthread_join(low_id, NULL));
+ 
+-	if (woken_up == -1) {
+-		printf("Test FAILED: high priority was not woken up\\n");
++	if (!woken_up) {
++		printf("Test FAILED: high priority was not woken up\n");
+ 		exit(PTS_FAIL);
+ 	}
+ 
+diff --git a/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c b/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
+index f1bf372..a6b634c 100644
+--- a/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
++++ b/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
+@@ -37,8 +37,8 @@
+ #define RUNTIME 5
+ 
+ pthread_barrier_t barrier;
+-volatile int woken_up = -1;
+-volatile int low_done = -1;
++static volatile int woken_up;
++static volatile int low_done;
+ 
+ float timediff(struct timespec t2, struct timespec t1)
+ {
+@@ -91,7 +91,7 @@ void *hi_prio_thread(void *tmp)
+ 	/* This variable is unprotected because the scheduling removes
+ 	 * the contention
+ 	 */
+-	if (low_done != 1)
++	if (!low_done)
+ 		woken_up = 1;
+ 
+ 	pthread_exit(NULL);
+@@ -113,7 +113,7 @@ void *low_prio_thread(void *tmp)
+ 	}
+ 
+ 	clock_gettime(CLOCK_REALTIME, &start_timespec);
+-	while (1) {
++	while (!woken_up) {
+ 		clock_gettime(CLOCK_REALTIME, &current_timespec);
+ 		if (timediff(current_timespec, start_timespec) > RUNTIME)
+ 			break;
+@@ -149,7 +149,7 @@ int main()
+ 	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 	SAFE_PFUNC(pthread_join(low_id, NULL));
+ 
+-	if (woken_up == -1) {
++	if (!woken_up) {
+ 		printf("High priority was not woken up. Test FAILED\n");
+ 		exit(PTS_FAIL);
+ 	}
+diff --git a/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c b/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
+index 3d3427b..f7b0bd8 100644
+--- a/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
++++ b/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
+@@ -39,8 +39,8 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+ pthread_mutex_t cond_mutex = PTHREAD_MUTEX_INITIALIZER;
+ pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+ 
+-volatile int woken_up = -1;
+-volatile int low_done = -1;
++static volatile int woken_up;
++static volatile int low_done;
+ 
+ float timediff(struct timespec t2, struct timespec t1)
+ {
+@@ -78,7 +78,7 @@ void *hi_prio_thread(void *tmp)
+ 	/* This variable is unprotected because the scheduling removes
+ 	 * the contention
+ 	 */
+-	if (low_done != 1)
++	if (!low_done)
+ 		woken_up = 1;
+ 
+ 	SAFE_PFUNC(pthread_mutex_unlock(&mutex));
+@@ -105,7 +105,7 @@ void *low_prio_thread(void *tmp)
+ 	}
+ 
+ 	clock_gettime(CLOCK_REALTIME, &start_time);
+-	while (1) {
++	while (!woken_up) {
+ 		clock_gettime(CLOCK_REALTIME, &current_time);
+ 		if (timediff(current_time, start_time) > RUNTIME)
+ 			break;
+@@ -168,7 +168,7 @@ int main()
+ 	SAFE_PFUNC(pthread_join(high_id, NULL));
+ 	SAFE_PFUNC(pthread_join(low_id, NULL));
+ 
+-	if (woken_up == -1) {
++	if (!woken_up) {
+ 		printf("High priority was not woken up. Test FAILED.\n");
+ 		exit(PTS_FAIL);
+ 	}
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160126/open_posix-condvar-schedule-use-SAFE_PFUNC.patch
+++ b/distribution/ltp/include/patches/20160126/open_posix-condvar-schedule-use-SAFE_PFUNC.patch
@@ -1,0 +1,1021 @@
+From 061df0771e1e4c42dc6d0f1efabe38b9392de48e Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 18 Feb 2016 14:02:33 +0100
+Subject: [PATCH] open_posix: condvar/schedule: use SAFE_PFUNC
+
+Replace common error checking with SAFE_PFUNC macro. Also remove
+some obvious comments.
+
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ .../threads/condvar/pthread_cond_wait_1.c          | 136 ++++-------------
+ .../threads/condvar/pthread_cond_wait_2.c          | 135 +++-------------
+ .../functional/threads/schedule/1-1.c              | 137 +++++------------
+ .../functional/threads/schedule/1-2.c              | 169 ++++-----------------
+ 4 files changed, 115 insertions(+), 462 deletions(-)
+
+diff --git a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
+index 123d1e5..5b36fc2 100644
+--- a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
++++ b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_1.c
+@@ -4,18 +4,17 @@
+  * This file is licensed under the GPL license.  For the full content
+  * of this license, see the COPYING file at the top level of this
+  * source tree.
+-
++ *
+  * Test that pthread_cond_signal()
+  *   shall wakeup a high priority thread even when a low priority thread
+  *   is running
+-
++ *
+  * Steps:
+  * 1. Create a condition variable
+  * 2. Create a high priority thread and make it wait on the cond
+  * 3. Create a low priority thread and let it busy-loop
+  * 4. Signal the cond in a signal handler and check that high
+  *    priority thread got woken up
+- *
+  */
+ 
+ #include <pthread.h>
+@@ -25,6 +24,7 @@
+ #include <unistd.h>
+ #include <time.h>
+ #include "posixtest.h"
++#include "safe_helpers.h"
+ 
+ #define TEST "5-1"
+ #define AREA "scheduler"
+@@ -35,27 +35,19 @@
+ #define RUNTIME       5
+ #define POLICY        SCHED_RR
+ 
+-/* mutex required by the cond variable */
+ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+-/* condition variable that threads block on*/
+ pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+ 
+ /* Flags that the threads use to indicate events */
+ int woken_up = -1;
+ int low_done = -1;
+ 
+-/* Signal handler that handle the ALRM and wakes up
+- * the high priority thread
+- */
+ void signal_handler(int sig)
+ {
+-	if (pthread_cond_signal(&cond) != 0) {
+-		printf(ERROR_PREFIX "pthread_cond_signal\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	(void) sig;
++	SAFE_PFUNC(pthread_cond_signal(&cond));
+ }
+ 
+-/* Utility function to find difference between two time values */
+ float timediff(struct timespec t2, struct timespec t1)
+ {
+ 	float diff = t2.tv_sec - t1.tv_sec;
+@@ -63,51 +55,32 @@ float timediff(struct timespec t2, struct timespec t1)
+ 	return diff;
+ }
+ 
+-void *hi_priority_thread(void *tmp)
++void *hi_prio_thread(void *tmp)
+ {
+ 	struct sched_param param;
+ 	int policy;
+-	int rc = 0;
+ 
++	(void) tmp;
+ 	param.sched_priority = HIGH_PRIORITY;
+ 
+-	rc = pthread_setschedparam(pthread_self(), POLICY, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_getschedparam(pthread_self(), &policy, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_getschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), POLICY, &param));
++	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != HIGH_PRIORITY)) {
+ 		printf("Error: the policy or priority not correct\n");
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	/* Install a signal handler for ALRM */
+ 	if (signal(SIGALRM, signal_handler) != 0) {
+ 		perror(ERROR_PREFIX "signal:");
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	/* acquire the mutex */
+-	rc = pthread_mutex_lock(&mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_mutex_lock\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_mutex_lock(&mutex));
+ 
+-	/* Setup an alarm to go off in 2 seconds */
+ 	alarm(2);
+ 
+ 	/* Block, to be woken up by the signal handler */
+-	rc = pthread_cond_wait(&cond, &mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_cond_wait\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_cond_wait(&cond, &mutex));
+ 
+ 	/* This variable is unprotected because the scheduling removes
+ 	 * the contention
+@@ -115,39 +88,26 @@ void *hi_priority_thread(void *tmp)
+ 	if (low_done != 1)
+ 		woken_up = 1;
+ 
+-	rc = pthread_mutex_unlock(&mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_mutex_unlock\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_mutex_unlock(&mutex));
+ 	return NULL;
+ }
+ 
+-void *low_priority_thread(void *tmp)
++void *low_prio_thread(void *tmp)
+ {
+ 	struct timespec start_time, current_time;
+ 	struct sched_param param;
+ 	int policy;
+-	int rc = 0;
+ 
++	(void) tmp;
+ 	param.sched_priority = LOW_PRIORITY;
+ 
+-	rc = pthread_setschedparam(pthread_self(), POLICY, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_getschedparam(pthread_self(), &policy, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_getschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), POLICY, &param));
++	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != LOW_PRIORITY)) {
+ 		printf("Error: the policy or priority not correct\n");
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	/* grab the start time and busy loop for 5 seconds */
+ 	clock_gettime(CLOCK_REALTIME, &start_time);
+ 	while (1) {
+ 		clock_gettime(CLOCK_REALTIME, &current_time);
+@@ -163,69 +123,25 @@ int main()
+ 	pthread_t high_id, low_id;
+ 	pthread_attr_t high_attr, low_attr;
+ 	struct sched_param param;
+-	int rc = 0;
+ 
+ 	/* Create the higher priority thread */
+-	rc = pthread_attr_init(&high_attr);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_init\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-
+-	rc = pthread_attr_setschedpolicy(&high_attr, POLICY);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedpolicy\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_init(&high_attr));
++	SAFE_PFUNC(pthread_attr_setschedpolicy(&high_attr, POLICY));
+ 	param.sched_priority = HIGH_PRIORITY;
+-	rc = pthread_attr_setschedparam(&high_attr, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_create(&high_id, &high_attr, hi_priority_thread, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_create\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
++	SAFE_PFUNC(pthread_create(&high_id, &high_attr, hi_prio_thread, NULL));
+ 
+ 	/* Create the low priority thread */
+-	rc = pthread_attr_init(&low_attr);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_init\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_attr_setschedpolicy(&low_attr, POLICY);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedpolicy\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_init(&low_attr));
++	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, POLICY));
+ 	param.sched_priority = LOW_PRIORITY;
+-	rc = pthread_attr_setschedparam(&low_attr, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_create(&low_id, &low_attr, low_priority_thread, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_create\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
++	SAFE_PFUNC(pthread_create(&low_id, &low_attr, low_prio_thread, NULL));
+ 
+ 	/* Wait for the threads to exit */
+-	rc = pthread_join(high_id, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_join\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-
+-	rc = pthread_join(low_id, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_join\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_join(high_id, NULL));
++	SAFE_PFUNC(pthread_join(low_id, NULL));
+ 
+-	/* Check the result */
+ 	if (woken_up == -1) {
+ 		printf("Test FAILED: high priority was not woken up\\n");
+ 		exit(PTS_FAIL);
+diff --git a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
+index bf2b1f2..7308bd6 100644
+--- a/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
++++ b/testcases/open_posix_testsuite/functional/threads/condvar/pthread_cond_wait_2.c
+@@ -4,7 +4,7 @@
+  * This file is licensed under the GPL license.  For the full content
+  * of this license, see the COPYING file at the top level of this
+  * source tree.
+-
++ *
+  * Test that pthread_cond_broadcast()
+  *   shall wakeup a high priority thread even when a low priority thread
+  *   is running
+@@ -15,8 +15,6 @@
+  * 3. Create a low priority thread and let it busy-loop
+  * 4. Broadcast the cond in a signal handler and check that high
+  *    priority thread got woken up
+-
+- *
+  */
+ 
+ #include <pthread.h>
+@@ -26,6 +24,7 @@
+ #include <unistd.h>
+ #include <time.h>
+ #include "posixtest.h"
++#include "safe_helpers.h"
+ 
+ #define TEST "5-1"
+ #define AREA "scheduler"
+@@ -36,27 +35,19 @@
+ #define RUNTIME       5
+ #define POLICY        SCHED_RR
+ 
+-/* mutex required by the cond variable */
+ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+-/* condition variable that threads block on*/
+ pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+ 
+ /* Flags that the threads use to indicate events */
+ int woken_up = -1;
+ int low_done = -1;
+ 
+-/* Signal handler that handle the ALRM and wakes up
+- * the high priority thread
+- */
+ void signal_handler(int sig)
+ {
+-	if (pthread_cond_broadcast(&cond) != 0) {
+-		printf(ERROR_PREFIX "pthread_cond_broadcast\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	(void) sig;
++	SAFE_PFUNC(pthread_cond_broadcast(&cond));
+ }
+ 
+-/* Utility function to find difference between two time values */
+ float timediff(struct timespec t2, struct timespec t1)
+ {
+ 	float diff = t2.tv_sec - t1.tv_sec;
+@@ -64,51 +55,32 @@ float timediff(struct timespec t2, struct timespec t1)
+ 	return diff;
+ }
+ 
+-void *hi_priority_thread(void *tmp)
++void *hi_prio_thread(void *tmp)
+ {
+ 	struct sched_param param;
+ 	int policy;
+-	int rc = 0;
+ 
++	(void) tmp;
+ 	param.sched_priority = HIGH_PRIORITY;
+ 
+-	rc = pthread_setschedparam(pthread_self(), POLICY, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_getschedparam(pthread_self(), &policy, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_getschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), POLICY, &param));
++	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != HIGH_PRIORITY)) {
+ 		printf("Error: the policy or priority not correct\n");
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	/* Install a signal handler for ALRM */
+ 	if (signal(SIGALRM, signal_handler) != 0) {
+ 		perror(ERROR_PREFIX "signal:");
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	/* acquire the mutex */
+-	rc = pthread_mutex_lock(&mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_mutex_lock\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_mutex_lock(&mutex));
+ 
+-	/* Setup an alarm to go off in 2 seconds */
+ 	alarm(2);
+ 
+ 	/* Block, to be woken up by the signal handler */
+-	rc = pthread_cond_wait(&cond, &mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_cond_wait\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_cond_wait(&cond, &mutex));
+ 
+ 	/* This variable is unprotected because the scheduling removes
+ 	 * the contention
+@@ -116,39 +88,26 @@ void *hi_priority_thread(void *tmp)
+ 	if (low_done != 1)
+ 		woken_up = 1;
+ 
+-	rc = pthread_mutex_unlock(&mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_mutex_unlock\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_mutex_unlock(&mutex));
+ 	return NULL;
+ }
+ 
+-void *low_priority_thread(void *tmp)
++void *low_prio_thread(void *tmp)
+ {
+ 	struct timespec start_time, current_time;
+ 	struct sched_param param;
+ 	int policy;
+-	int rc = 0;
+ 
++	(void) tmp;
+ 	param.sched_priority = LOW_PRIORITY;
+ 
+-	rc = pthread_setschedparam(pthread_self(), POLICY, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_getschedparam(pthread_self(), &policy, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_getschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), POLICY, &param));
++	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if ((policy != POLICY) || (param.sched_priority != LOW_PRIORITY)) {
+ 		printf("Error: the policy or priority not correct\n");
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	/* grab the start time and busy loop for 5 seconds */
+ 	clock_gettime(CLOCK_REALTIME, &start_time);
+ 	while (1) {
+ 		clock_gettime(CLOCK_REALTIME, &current_time);
+@@ -164,69 +123,25 @@ int main()
+ 	pthread_t high_id, low_id;
+ 	pthread_attr_t high_attr, low_attr;
+ 	struct sched_param param;
+-	int rc = 0;
+ 
+ 	/* Create the higher priority thread */
+-	rc = pthread_attr_init(&high_attr);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_init\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-
+-	rc = pthread_attr_setschedpolicy(&high_attr, POLICY);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedpolicy\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_init(&high_attr));
++	SAFE_PFUNC(pthread_attr_setschedpolicy(&high_attr, POLICY));
+ 	param.sched_priority = HIGH_PRIORITY;
+-	rc = pthread_attr_setschedparam(&high_attr, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_create(&high_id, &high_attr, hi_priority_thread, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_create\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
++	SAFE_PFUNC(pthread_create(&high_id, &high_attr, hi_prio_thread, NULL));
+ 
+ 	/* Create the low priority thread */
+-	rc = pthread_attr_init(&low_attr);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_init\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_attr_setschedpolicy(&low_attr, POLICY);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedpolicy\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_init(&low_attr));
++	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, POLICY));
+ 	param.sched_priority = LOW_PRIORITY;
+-	rc = pthread_attr_setschedparam(&low_attr, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_create(&low_id, &low_attr, low_priority_thread, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_create\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
++	SAFE_PFUNC(pthread_create(&low_id, &low_attr, low_prio_thread, NULL));
+ 
+ 	/* Wait for the threads to exit */
+-	rc = pthread_join(high_id, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_join\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-
+-	rc = pthread_join(low_id, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_join\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_join(high_id, NULL));
++	SAFE_PFUNC(pthread_join(low_id, NULL));
+ 
+-	/* Check the result */
+ 	if (woken_up == -1) {
+ 		printf("Test FAILED: high priority was not woken up\\n");
+ 		exit(PTS_FAIL);
+diff --git a/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c b/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
+index 73be55b..f1bf372 100644
+--- a/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
++++ b/testcases/open_posix_testsuite/functional/threads/schedule/1-1.c
+@@ -16,17 +16,17 @@
+  * 4. Setup a signal handler for ALRM
+  * 5. Call the final barrier_wait in the signal handler
+  * 6. Check that the higher priority thread got woken up
+- *
+  */
+ 
+ #define _XOPEN_SOURCE 600
+-#include "posixtest.h"
+ #include <pthread.h>
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <signal.h>
+ #include <unistd.h>
+ #include <sys/time.h>
++#include "posixtest.h"
++#include "safe_helpers.h"
+ 
+ #define TEST "5-4"
+ #define AREA "scheduler"
+@@ -40,7 +40,6 @@ pthread_barrier_t barrier;
+ volatile int woken_up = -1;
+ volatile int low_done = -1;
+ 
+-/* Utility function to find difference between two time values */
+ float timediff(struct timespec t2, struct timespec t1)
+ {
+ 	float diff = t2.tv_sec - t1.tv_sec;
+@@ -48,44 +47,37 @@ float timediff(struct timespec t2, struct timespec t1)
+ 	return diff;
+ }
+ 
+-/* This signal handler will wakeup the high priority thread by
+- * calling barrier wait
+- */
+-void signal_handler(int sig)
++int my_pthread_barrier_wait(pthread_barrier_t *p)
+ {
+-	int rc = 0;
++	int rc;
+ 
+-	rc = pthread_barrier_wait(&barrier);
+-	if ((rc != 0) && (rc != PTHREAD_BARRIER_SERIAL_THREAD)) {
+-		printf(ERROR_PREFIX "pthread_barrier_wait in handler\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	rc = pthread_barrier_wait(p);
++	if (rc == PTHREAD_BARRIER_SERIAL_THREAD)
++		rc = 0;
++	return rc;
++}
++
++void signal_handler(int sig)
++{
++	(void) sig;
++	SAFE_PFUNC(my_pthread_barrier_wait(&barrier));
+ }
+ 
+-void *hi_priority_thread(void *tmp)
++void *hi_prio_thread(void *tmp)
+ {
+ 	struct sched_param param;
+ 	int policy;
+-	int rc = 0;
+ 	void *previous_signal;
+ 
++	(void) tmp;
+ 	param.sched_priority = HIGH_PRIORITY;
+-	rc = pthread_setschedparam(pthread_self(), SCHED_RR, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_getschedparam(pthread_self(), &policy, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_getschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), SCHED_RR, &param));
++	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR || param.sched_priority != HIGH_PRIORITY) {
+ 		printf("Error: the policy or priority not correct\n");
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	/* setup a signal handler for ALRM */
+ 	previous_signal = signal(SIGALRM, signal_handler);
+ 	if (previous_signal == SIG_ERR) {
+ 		perror(ERROR_PREFIX "signal");
+@@ -94,11 +86,7 @@ void *hi_priority_thread(void *tmp)
+ 
+ 	alarm(2);
+ 
+-	rc = pthread_barrier_wait(&barrier);
+-	if ((rc != 0) && (rc != PTHREAD_BARRIER_SERIAL_THREAD)) {
+-		printf(ERROR_PREFIX "pthread_barrier_wait\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(my_pthread_barrier_wait(&barrier));
+ 
+ 	/* This variable is unprotected because the scheduling removes
+ 	 * the contention
+@@ -109,30 +97,21 @@ void *hi_priority_thread(void *tmp)
+ 	pthread_exit(NULL);
+ }
+ 
+-void *low_priority_thread(void *tmp)
++void *low_prio_thread(void *tmp)
+ {
+ 	struct timespec start_timespec, current_timespec;
+ 	struct sched_param param;
+-	int rc = 0;
+ 	int policy;
+ 
++	(void) tmp;
+ 	param.sched_priority = LOW_PRIORITY;
+-	rc = pthread_setschedparam(pthread_self(), SCHED_RR, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_getschedparam(pthread_self(), &policy, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_getschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), SCHED_RR, &param));
++	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR || param.sched_priority != LOW_PRIORITY) {
+ 		printf("Error: the policy or priority not correct\n");
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	/* grab the start time and busy loop for RUNTIME seconds */
+ 	clock_gettime(CLOCK_REALTIME, &start_timespec);
+ 	while (1) {
+ 		clock_gettime(CLOCK_REALTIME, &current_timespec);
+@@ -149,75 +128,27 @@ int main()
+ 	pthread_t high_id, low_id;
+ 	pthread_attr_t low_attr, high_attr;
+ 	struct sched_param param;
+-	int rc = 0;
+ 
+-	/* Initialize the barrier */
+-	rc = pthread_barrier_init(&barrier, NULL, 2);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_barrier_init\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_barrier_init(&barrier, NULL, 2));
+ 
+ 	/* Create the higher priority */
+-	rc = pthread_attr_init(&high_attr);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_init\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_attr_setschedpolicy(&high_attr, SCHED_RR);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedpolicy\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_init(&high_attr));
++	SAFE_PFUNC(pthread_attr_setschedpolicy(&high_attr, SCHED_RR));
+ 	param.sched_priority = HIGH_PRIORITY;
+-	rc = pthread_attr_setschedparam(&high_attr, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_create(&high_id, &high_attr, hi_priority_thread, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_create\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
++	SAFE_PFUNC(pthread_create(&high_id, &high_attr, hi_prio_thread, NULL));
+ 
+ 	/* Create the low priority thread */
+-	rc = pthread_attr_init(&low_attr);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_init\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_attr_setschedpolicy(&low_attr, SCHED_RR);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedpolicy\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_init(&low_attr));
++	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, SCHED_RR));
+ 	param.sched_priority = LOW_PRIORITY;
+-	rc = pthread_attr_setschedparam(&low_attr, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_create(&low_id, &low_attr, low_priority_thread, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_create\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
++	SAFE_PFUNC(pthread_create(&low_id, &low_attr, low_prio_thread, NULL));
+ 
+ 	/* Wait for the threads to exit */
+-	rc = pthread_join(high_id, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_join\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-
+-	rc = pthread_join(low_id, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_join\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_join(high_id, NULL));
++	SAFE_PFUNC(pthread_join(low_id, NULL));
+ 
+-	/* Check the result */
+ 	if (woken_up == -1) {
+ 		printf("High priority was not woken up. Test FAILED\n");
+ 		exit(PTS_FAIL);
+diff --git a/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c b/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
+index cfc4608..3d3427b 100644
+--- a/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
++++ b/testcases/open_posix_testsuite/functional/threads/schedule/1-2.c
+@@ -15,7 +15,6 @@
+  * 3. Create a low priority thread and let it busy-loop
+  * 4. Unlock the mutex and make sure that the higher priority thread
+  *    got woken up
+- *
+  */
+ 
+ #include <pthread.h>
+@@ -25,6 +24,7 @@
+ #include <unistd.h>
+ #include <sys/time.h>
+ #include "posixtest.h"
++#include "safe_helpers.h"
+ 
+ #define TEST "5-5"
+ #define AREA "scheduler"
+@@ -35,17 +35,13 @@
+ #define LOW_PRIORITY 5
+ #define RUNTIME 5
+ 
+-/* mutex  high priority thread will wait on*/
+ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+-/* mutex required by the cond variable */
+ pthread_mutex_t cond_mutex = PTHREAD_MUTEX_INITIALIZER;
+-/* condition variable that threads block on*/
+ pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+ 
+ volatile int woken_up = -1;
+ volatile int low_done = -1;
+ 
+-/* Utility function to find difference between two time values */
+ float timediff(struct timespec t2, struct timespec t1)
+ {
+ 	float diff = t2.tv_sec - t1.tv_sec;
+@@ -53,37 +49,21 @@ float timediff(struct timespec t2, struct timespec t1)
+ 	return diff;
+ }
+ 
+-/* This signal handler will wakeup the main thread by sending a signal
+- * to a condition variable that the main thread is waiting on.
+- */
+ void signal_handler(int sig)
+ {
+-	int rc = 0;
+-
+-	rc = pthread_cond_signal(&cond);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_cond_signal\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	(void) sig;
++	SAFE_PFUNC(pthread_cond_signal(&cond));
+ }
+ 
+-void *hi_priority_thread(void *tmp)
++void *hi_prio_thread(void *tmp)
+ {
+ 	struct sched_param param;
+ 	int policy;
+-	int rc = 0;
+ 
++	(void) tmp;
+ 	param.sched_priority = HIGH_PRIORITY;
+-	rc = pthread_setschedparam(pthread_self(), SCHED_RR, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_getschedparam(pthread_self(), &policy, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_getschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), SCHED_RR, &param));
++	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR) {
+ 		printf(ERROR_PREFIX "The policy is not correct\n");
+ 		exit(PTS_UNRESOLVED);
+@@ -93,12 +73,7 @@ void *hi_priority_thread(void *tmp)
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	/* acquire the mutex */
+-	rc = pthread_mutex_lock(&mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_mutex_lock\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_mutex_lock(&mutex));
+ 
+ 	/* This variable is unprotected because the scheduling removes
+ 	 * the contention
+@@ -106,32 +81,20 @@ void *hi_priority_thread(void *tmp)
+ 	if (low_done != 1)
+ 		woken_up = 1;
+ 
+-	rc = pthread_mutex_unlock(&mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_mutex_unlock\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_mutex_unlock(&mutex));
+ 	pthread_exit(NULL);
+ }
+ 
+-void *low_priority_thread(void *tmp)
++void *low_prio_thread(void *tmp)
+ {
+ 	struct timespec current_time, start_time;
+ 	struct sched_param param;
+-	int rc = 0;
+ 	int policy;
+ 
++	(void) tmp;
+ 	param.sched_priority = LOW_PRIORITY;
+-	rc = pthread_setschedparam(pthread_self(), SCHED_RR, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_getschedparam(pthread_self(), &policy, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_getschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), SCHED_RR, &param));
++	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR) {
+ 		printf(ERROR_PREFIX "Policy not correct\n");
+ 		exit(PTS_UNRESOLVED);
+@@ -141,7 +104,6 @@ void *low_priority_thread(void *tmp)
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	/* Grab the start time and busy loop for 5 seconds */
+ 	clock_gettime(CLOCK_REALTIME, &start_time);
+ 	while (1) {
+ 		clock_gettime(CLOCK_REALTIME, &current_time);
+@@ -157,20 +119,11 @@ int main()
+ 	pthread_t high_id, low_id;
+ 	pthread_attr_t low_attr, high_attr;
+ 	struct sched_param param;
+-	int rc = 0;
+ 	int policy;
+ 
+ 	param.sched_priority = MID_PRIORITY;
+-	rc = pthread_setschedparam(pthread_self(), SCHED_RR, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_getschedparam(pthread_self(), &policy, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_getschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_setschedparam(pthread_self(), SCHED_RR, &param));
++	SAFE_PFUNC(pthread_getschedparam(pthread_self(), &policy, &param));
+ 	if (policy != SCHED_RR) {
+ 		printf(ERROR_PREFIX "The policy is not correct\n");
+ 		exit(PTS_UNRESOLVED);
+@@ -180,57 +133,21 @@ int main()
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	rc = pthread_mutex_lock(&mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_mutex_lock\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_mutex_lock(&mutex));
+ 
+ 	/* create the higher priority */
+-	rc = pthread_attr_init(&high_attr);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_init\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_attr_setschedpolicy(&high_attr, SCHED_RR);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedpolicy\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_init(&high_attr));
++	SAFE_PFUNC(pthread_attr_setschedpolicy(&high_attr, SCHED_RR));
+ 	param.sched_priority = HIGH_PRIORITY;
+-	rc = pthread_attr_setschedparam(&high_attr, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_create(&high_id, &high_attr, hi_priority_thread, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_create\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_setschedparam(&high_attr, &param));
++	SAFE_PFUNC(pthread_create(&high_id, &high_attr, hi_prio_thread, NULL));
+ 
+ 	/* Create the low priority thread */
+-	rc = pthread_attr_init(&low_attr);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_init\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_attr_setschedpolicy(&low_attr, SCHED_RR);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedpolicy\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_init(&low_attr));
++	SAFE_PFUNC(pthread_attr_setschedpolicy(&low_attr, SCHED_RR));
+ 	param.sched_priority = LOW_PRIORITY;
+-	rc = pthread_attr_setschedparam(&low_attr, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_attr_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_create(&low_id, &low_attr, low_priority_thread, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_create\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_attr_setschedparam(&low_attr, &param));
++	SAFE_PFUNC(pthread_create(&low_id, &low_attr, low_prio_thread, NULL));
+ 
+ 	/* setup a signal handler which will wakeup main later */
+ 	if (signal(SIGALRM, signal_handler) == SIG_ERR) {
+@@ -238,45 +155,19 @@ int main()
+ 		exit(PTS_UNRESOLVED);
+ 	}
+ 
+-	rc = pthread_mutex_lock(&cond_mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_mutex_lock\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_mutex_lock(&cond_mutex));
+ 
+ 	alarm(2);
+-	rc = pthread_cond_wait(&cond, &cond_mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_cond_wait\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	rc = pthread_mutex_unlock(&cond_mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_mutex_unlock\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_cond_wait(&cond, &cond_mutex));
++	SAFE_PFUNC(pthread_mutex_unlock(&cond_mutex));
+ 
+ 	/* Wake the other high priority thread up */
+-	rc = pthread_mutex_unlock(&mutex);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_mutex_unlock\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_mutex_unlock(&mutex));
+ 
+ 	/* Wait for the threads to exit */
+-	rc = pthread_join(high_id, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_join\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-
+-	rc = pthread_join(low_id, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_join\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	SAFE_PFUNC(pthread_join(high_id, NULL));
++	SAFE_PFUNC(pthread_join(low_id, NULL));
+ 
+-	/* Check the result */
+ 	if (woken_up == -1) {
+ 		printf("High priority was not woken up. Test FAILED.\n");
+ 		exit(PTS_FAIL);
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160126/syscalls-readahead02-use-bdi-max-readahead-limit.patch
+++ b/distribution/ltp/include/patches/20160126/syscalls-readahead02-use-bdi-max-readahead-limit.patch
@@ -1,0 +1,72 @@
+From f6b7a503db7dd5c9c957e64a90604791f8f6c19c Mon Sep 17 00:00:00 2001
+From: Roman Gushchin <klamm@yandex-team.ru>
+Date: Tue, 15 Mar 2016 15:16:00 +0100
+Subject: [PATCH] syscalls/readahead02: use bdi max readahead limit
+
+After commit 600e19afc5f8a6 ("mm: use only per-device readahead limit")
+readahead size is not limited anymore by 2 megabytes. Instead,
+the per-bdi limit is used for kernels 4.4 and older.
+
+Signed-off-by: Roman Gushchin <klamm@yandex-team.ru>
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/syscalls/readahead/readahead02.c | 28 ++++++++++++++++++++---
+ 1 file changed, 25 insertions(+), 3 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/readahead/readahead02.c b/testcases/kernel/syscalls/readahead/readahead02.c
+index 90ad853..7dc308c 100644
+--- a/testcases/kernel/syscalls/readahead/readahead02.c
++++ b/testcases/kernel/syscalls/readahead/readahead02.c
+@@ -184,6 +184,21 @@ static void create_testfile(void)
+ 	free(tmp);
+ }
+ 
++static long get_device_readahead(const char *fname)
++{
++	struct stat st;
++	unsigned long ra_kb = 0;
++	char buf[256];
++
++	if (stat(fname, &st) == -1)
++		tst_brkm(TBROK | TERRNO, cleanup, "stat");
++	snprintf(buf, sizeof(buf), "/sys/dev/block/%d:%d/queue/read_ahead_kb",
++		 major(st.st_dev), minor(st.st_dev));
++	SAFE_FILE_SCANF(cleanup, buf, "%ld", &ra_kb);
++
++	return ra_kb * 1024;
++}
++
+ /* read_testfile - mmap testfile and read every page.
+  * This functions measures how many I/O and time it takes to fully
+  * read contents of test file.
+@@ -206,16 +221,23 @@ static void read_testfile(int do_readahead, const char *fname, size_t fsize,
+ 	unsigned long time_start_usec, time_end_usec;
+ 	off_t offset;
+ 	struct timeval now;
++	long readahead_size;
++
++	/* use bdi limit for 4.4 and older, otherwise default to 2M */
++	if ((tst_kvercmp(4, 4, 0)) >= 0)
++		readahead_size = get_device_readahead(fname);
++	else
++		readahead_size = 2 * 1024 * 1024;
++	tst_resm(TINFO, "max readahead size is: %ld", readahead_size);
+ 
+ 	fd = open(fname, O_RDONLY);
+ 	if (fd < 0)
+ 		tst_brkm(TBROK | TERRNO, cleanup, "Failed to open %s", fname);
+ 
+ 	if (do_readahead) {
+-		/* read ahead in chunks, 2MB is maximum since 3.15-rc1 */
+-		for (i = 0; i < fsize; i += 2*1024*1024) {
++		for (i = 0; i < fsize; i += readahead_size) {
+ 			TEST(ltp_syscall(__NR_readahead, fd,
+-				(off64_t) i, 2*1024*1024));
++				(off64_t) i, readahead_size));
+ 			if (TEST_RETURN != 0)
+ 				break;
+ 		}
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160510/creat05-don-t-assume-number-of-opened-fds.patch
+++ b/distribution/ltp/include/patches/20160510/creat05-don-t-assume-number-of-opened-fds.patch
@@ -1,0 +1,95 @@
+From db790f49b662fa96a29da1ea820c1057a50b0a63 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Tue, 17 May 2016 14:06:15 +0200
+Subject: [PATCH] creat05: don't assume number of opened fds
+
+This testcase estimates number of opened fds by opening
+a new one and assuming there are no gaps. This doesn't always
+hold true. There can be gaps if test harness that runs it
+opens couple/closes fds or opens some with O_CLOEXEC flag.
+As result, testcase unexpectedly fails in setup with EMFILE.
+
+This patch keeps opening fds in setup() until it arrives
+at fd == max_fd - 1.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/syscalls/creat/creat05.c | 36 +++++++++++++++----------------
+ 1 file changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/creat/creat05.c b/testcases/kernel/syscalls/creat/creat05.c
+index 9a51b87..5e1342e 100644
+--- a/testcases/kernel/syscalls/creat/creat05.c
++++ b/testcases/kernel/syscalls/creat/creat05.c
+@@ -22,6 +22,7 @@
+  */
+ 
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <errno.h>
+ #include <sys/types.h>
+ #include <sys/time.h>
+@@ -32,7 +33,7 @@
+ #include <unistd.h>
+ #include "tst_test.h"
+ 
+-static int first_fd, last_fd;
++static int *opened_fds, num_opened_fds;
+ 
+ static void verify_creat(void)
+ {
+@@ -56,34 +57,33 @@ static void setup(void)
+ 	int fd;
+ 	char fname[PATH_MAX];
+ 
+-	/* create a file to get the first file descriptor available */
+-	first_fd = fd = SAFE_CREAT("fname", 0666);
+-	SAFE_CLOSE(fd);
+-	SAFE_UNLINK("fname");
+-	tst_res(TINFO, "first fd is #%d", first_fd);
+-
+ 	/* get the maximum number of files that we can open */
+ 	max_open = getdtablesize();
+ 	tst_res(TINFO, "getdtablesize() = %d", max_open);
++	opened_fds = SAFE_MALLOC(max_open * sizeof(int));
+ 
+ 	/* now open as many files as we can up to max_open */
+-	for (fd = first_fd; fd < max_open; fd++) {
+-		snprintf(fname, sizeof(fname), "creat05_%d", fd);
+-		last_fd = SAFE_CREAT(fname, 0666);
+-	}
++	do {
++		snprintf(fname, sizeof(fname), "creat05_%d", num_opened_fds);
++		fd = SAFE_CREAT(fname, 0666);
++		opened_fds[num_opened_fds++] = fd;
++	} while (fd < max_open - 1);
++
++	tst_res(TINFO, "Opened additional #%d fds", num_opened_fds);
+ }
+ 
+ static void cleanup(void)
+ {
+-	int fd;
++	int i;
+ 
+-	if (last_fd <= 0)
+-		return;
+-
+-	for (fd = first_fd + 1; fd <= last_fd; fd++) {
+-		if (close(fd))
+-			tst_res(TWARN | TERRNO, "close(%i) failed", fd);
++	for (i = 0; i < num_opened_fds; i++) {
++		if (close(opened_fds[i])) {
++			tst_res(TWARN | TERRNO, "close(%i) failed",
++				opened_fds[i]);
++		}
+ 	}
++
++	free(opened_fds);
+ }
+ 
+ static struct tst_test test = {
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160510/fanotify06-create-a-mount-for-test.patch
+++ b/distribution/ltp/include/patches/20160510/fanotify06-create-a-mount-for-test.patch
@@ -1,0 +1,82 @@
+From c96217b271311b56ccd44b9116ed8f095c69c462 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Wed, 29 Jun 2016 10:38:18 +0200
+Subject: [PATCH] fanotify06: create a mount for test
+
+This testcase can rarely fail, when there is a background process
+modifying files on same mountpoint as is LTP's tmpdir:
+
+fanotify06    1  TFAIL  :  fanotify06.c:212: group 0 got more than one event (48 > 24)
+fanotify06    2  TFAIL  :  fanotify06.c:212: group 1 got more than one event (48 > 24)
+fanotify06    3  TFAIL  :  fanotify06.c:212: group 2 got more than one event (48 > 24)
+fanotify06    4  TFAIL  :  fanotify06.c:222: group 3 got event
+fanotify06    5  TFAIL  :  fanotify06.c:222: group 4 got event
+fanotify06    6  TPASS  :  group 5 got no event
+fanotify06    7  TPASS  :  group 6 got no event
+fanotify06    8  TPASS  :  group 7 got no event
+fanotify06    9  TPASS  :  group 8 got no event
+
+This patch creates a mount, which should be only used by this
+test to limit interference from rest of OS. It also adds missing
+tst_require_root().
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Jan Kara <jack@suse.cz>
+---
+ testcases/kernel/syscalls/fanotify/fanotify06.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/testcases/kernel/syscalls/fanotify/fanotify06.c b/testcases/kernel/syscalls/fanotify/fanotify06.c
+index 93c9602..3c8ab8d 100644
+--- a/testcases/kernel/syscalls/fanotify/fanotify06.c
++++ b/testcases/kernel/syscalls/fanotify/fanotify06.c
+@@ -42,6 +42,7 @@
+ #include <sys/fcntl.h>
+ #include <errno.h>
+ #include <string.h>
++#include <sys/mount.h>
+ #include <sys/syscall.h>
+ #include "test.h"
+ #include "linux_syscall_numbers.h"
+@@ -80,6 +81,9 @@ static int fd_notify[FANOTIFY_PRIORITIES][GROUPS_PER_PRIO];
+ 
+ static char event_buf[EVENT_BUF_LEN];
+ 
++#define MOUNT_NAME "mntpoint"
++static int mount_created;
++
+ static void create_fanotify_groups(void)
+ {
+ 	unsigned int p, i;
+@@ -245,8 +249,14 @@ static void setup(void)
+ 
+ 	TEST_PAUSE;
+ 
++	tst_require_root();
+ 	tst_tmpdir();
+ 
++	SAFE_MKDIR(cleanup, MOUNT_NAME, 0755);
++	SAFE_MOUNT(cleanup, MOUNT_NAME, MOUNT_NAME, NULL, MS_BIND, NULL);
++	mount_created = 1;
++	SAFE_CHDIR(cleanup, MOUNT_NAME);
++
+ 	sprintf(fname, "tfile_%d", getpid());
+ 	fd = SAFE_OPEN(cleanup, fname, O_RDWR | O_CREAT, 0700);
+ 	SAFE_WRITE(cleanup, 1, fd, fname, 1);
+@@ -258,6 +268,13 @@ static void setup(void)
+ static void cleanup(void)
+ {
+ 	cleanup_fanotify_groups();
++
++	if (chdir(tst_get_tmpdir()) < 0)
++		tst_brkm(TBROK, NULL, "chdir(tmpdir) failed");
++
++	if (mount_created && tst_umount(MOUNT_NAME) < 0)
++		tst_brkm(TBROK | TERRNO, NULL, "umount failed");
++
+ 	tst_rmdir();
+ }
+ 
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160510/handle-EOPNOTSUPP-if-hugepages_supported.patch
+++ b/distribution/ltp/include/patches/20160510/handle-EOPNOTSUPP-if-hugepages_supported.patch
@@ -1,0 +1,66 @@
+From 8a3e39f303937a4af39349e328f9fe0c7d888b03 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Tue, 7 Jun 2016 16:25:46 +0200
+Subject: [PATCH] proc01: handle EOPNOTSUPP if !hugepages_supported()
+
+This patch adds entries to known issue list. These proc files
+may return EOPNOTSUPP (depending on CONFIG_HUGETLB_PAGE, CONFIG_NUMA)
+if hugepages_supported() is false:
+  /proc/sys/vm/nr_hugepages
+  /proc/sys/vm/nr_overcommit_hugepages
+  /proc/sys/vm/nr_hugepages_mempolicy
+
+from mm/hugetlb.c:
+--------------------------------- 8< ---------------------------------
+static int hugetlb_sysctl_handler_common(bool obey_mempolicy,
+                         struct ctl_table *table, int write,
+                         void __user *buffer, size_t *length, loff_t *ppos)
+{
+        struct hstate *h = &default_hstate;
+        unsigned long tmp = h->max_huge_pages;
+        int ret;
+
+        if (!hugepages_supported())
+                return -EOPNOTSUPP;
+--------------------------------- >8 ---------------------------------
+
+I've noticed this issue on s390 only after this commit:
+  commit 7f9be77555bb2e52de84e9dddf7b4eb20cc6e171
+  Author: Dominik Dingel <dingel@linux.vnet.ibm.com>
+  Date:   Fri Jul 17 16:23:39 2015 -0700
+    s390/hugetlb: add hugepages_supported define
+
+Also note, that kernel versions prior to 4.4 may fail with
+ENOTSUPP, which has been changed to EOPNOTSUPP by:
+  commit 86613628b3d367743f71b945c203774c522404f4
+  Author: Jan Stancek <jstancek@redhat.com>
+  Date:   Wed Mar 9 14:08:35 2016 -0800
+    mm/hugetlb: use EOPNOTSUPP in hugetlb sysctl handlers
+
+Given that nobody complained running into this issue before,
+it's assumed that this is not common and therefore this patch
+adds only EOPNOTSUPP to list.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/fs/proc/proc01.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/testcases/kernel/fs/proc/proc01.c b/testcases/kernel/fs/proc/proc01.c
+index 2825b51..c886e7e 100644
+--- a/testcases/kernel/fs/proc/proc01.c
++++ b/testcases/kernel/fs/proc/proc01.c
+@@ -108,6 +108,9 @@ static const struct mapping known_issues[] = {
+ 	{"read", "/proc/fs/nfsd/.getfd", EINVAL},
+ 	{"read", "/proc/self/net/rpc/use-gss-proxy", EAGAIN},
+ 	{"read", "/proc/sys/net/ipv6/conf/*/stable_secret", EIO},
++	{"read", "/proc/sys/vm/nr_hugepages", EOPNOTSUPP},
++	{"read", "/proc/sys/vm/nr_overcommit_hugepages", EOPNOTSUPP},
++	{"read", "/proc/sys/vm/nr_hugepages_mempolicy", EOPNOTSUPP},
+ 	{"", "", 0}
+ };
+ 
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160510/lib-add-SAFE_-FILE_LINES_SCANF.patch
+++ b/distribution/ltp/include/patches/20160510/lib-add-SAFE_-FILE_LINES_SCANF.patch
@@ -1,0 +1,190 @@
+From 670c3a82c2dbdfb0d7172f90c3e0892857ced8e4 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 14 Jul 2016 12:35:22 +0200
+Subject: [PATCH] lib: add [SAFE_]FILE_LINES_SCANF
+
+This patch adds 2 macros that try to parse each line from
+a file according to user-supplied (scanf) format. First line
+that matches all format directives ends the search. If EOF
+is reached, SAFE_ version triggers TBROK, non-SAFE_ returns
+non-zero retcode to user.
+
+Main motivation is parsing various /proc files, for example:
+  if (FILE_LINES_SCANF("/proc/meminfo", "MemFree: %ld", &free))
+      do_something();
+
+  SAFE_FILE_LINES_SCANF("/proc/meminfo", "MemFree: %ld", &free);
+      // automatically calls TBROK if all directives can't be matched
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ include/old/old_safe_file_ops.h     |  8 +++++++
+ include/safe_file_ops_fn.h          |  5 ++++
+ include/tst_safe_file_ops.h         |  8 +++++++
+ lib/newlib_tests/tst_safe_fileops.c | 40 +++++++++++++++++++++++++++++++
+ lib/safe_file_ops.c                 | 47 +++++++++++++++++++++++++++++++++++++
+ 5 files changed, 108 insertions(+)
+ create mode 100644 lib/newlib_tests/tst_safe_fileops.c
+
+diff --git a/include/old/old_safe_file_ops.h b/include/old/old_safe_file_ops.h
+index d656823..d6e2d29 100644
+--- a/include/old/old_safe_file_ops.h
++++ b/include/old/old_safe_file_ops.h
+@@ -38,6 +38,14 @@
+ 	safe_file_scanf(__FILE__, __LINE__, (cleanup_fn), \
+ 	                (path), (fmt), ## __VA_ARGS__)
+ 
++#define FILE_LINES_SCANF(cleanup_fn, path, fmt, ...) \
++	file_lines_scanf(__FILE__, __LINE__, (cleanup_fn), 0, \
++			(path), (fmt), ## __VA_ARGS__)
++
++#define SAFE_FILE_LINES_SCANF(cleanup_fn, path, fmt, ...) \
++	file_lines_scanf(__FILE__, __LINE__, (cleanup_fn), 1, \
++			(path), (fmt), ## __VA_ARGS__)
++
+ #define FILE_PRINTF(path, fmt, ...) \
+ 	file_printf(__FILE__, __LINE__, \
+ 	            (path), (fmt), ## __VA_ARGS__)
+diff --git a/include/safe_file_ops_fn.h b/include/safe_file_ops_fn.h
+index cdb0f74..35ec4fb 100644
+--- a/include/safe_file_ops_fn.h
++++ b/include/safe_file_ops_fn.h
+@@ -35,6 +35,11 @@ void safe_file_scanf(const char *file, const int lineno,
+ 		     const char *path, const char *fmt, ...)
+ 		     __attribute__ ((format (scanf, 5, 6)));
+ 
++int file_lines_scanf(const char *file, const int lineno,
++		     void (*cleanup_fn)(void), int strict,
++		     const char *path, const char *fmt, ...)
++		     __attribute__ ((format (scanf, 6, 7)));
++
+ /*
+  * All-in-one function that lets you printf directly into a file.
+  */
+diff --git a/include/tst_safe_file_ops.h b/include/tst_safe_file_ops.h
+index 74e6791..2e4067c 100644
+--- a/include/tst_safe_file_ops.h
++++ b/include/tst_safe_file_ops.h
+@@ -30,6 +30,14 @@
+ 	safe_file_scanf(__FILE__, __LINE__, NULL, \
+ 	                (path), (fmt), ## __VA_ARGS__)
+ 
++#define FILE_LINES_SCANF(path, fmt, ...) \
++	file_lines_scanf(__FILE__, __LINE__, NULL, 0,\
++			(path), (fmt), ## __VA_ARGS__)
++
++#define SAFE_FILE_LINES_SCANF(path, fmt, ...) \
++	file_lines_scanf(__FILE__, __LINE__, NULL, 1,\
++			(path), (fmt), ## __VA_ARGS__)
++
+ #define SAFE_FILE_PRINTF(path, fmt, ...) \
+ 	safe_file_printf(__FILE__, __LINE__, NULL, \
+ 	                 (path), (fmt), ## __VA_ARGS__)
+diff --git a/lib/newlib_tests/tst_safe_fileops.c b/lib/newlib_tests/tst_safe_fileops.c
+new file mode 100644
+index 0000000..bdf4e9d
+--- /dev/null
++++ b/lib/newlib_tests/tst_safe_fileops.c
+@@ -0,0 +1,40 @@
++/*
++ * Copyright (c) 2016 Linux Test Project
++ *
++ * This program is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation, either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program. If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <stdio.h>
++#include "tst_test.h"
++
++static void do_test(void)
++{
++	long free;
++	long nproc;
++	long dummy;
++
++	SAFE_FILE_LINES_SCANF("/proc/meminfo", "MemFree: %ld", &free);
++	if (FILE_LINES_SCANF("/proc/stat", "processes %ld", &nproc))
++		tst_brk(TBROK, "Could not parse processes");
++	tst_res(TPASS, "Free: %ld, nproc: %ld", free, nproc);
++
++	if (FILE_LINES_SCANF("/proc/stat", "non-existent %ld", &dummy))
++		tst_res(TPASS, "non-existent not found");
++	SAFE_FILE_LINES_SCANF("/proc/stat", "non-existent %ld", &dummy);
++}
++
++static struct tst_test test = {
++	.tid = "tst_safe_fileops",
++	.test_all = do_test,
++};
+diff --git a/lib/safe_file_ops.c b/lib/safe_file_ops.c
+index dff85cd..01f64ed 100644
+--- a/lib/safe_file_ops.c
++++ b/lib/safe_file_ops.c
+@@ -169,6 +169,53 @@ void safe_file_scanf(const char *file, const int lineno,
+ 	}
+ }
+ 
++
++/*
++ * Try to parse each line from file specified by 'path' according
++ * to scanf format 'fmt'. If all fields could be parsed, stop and
++ * return 0, otherwise continue or return 1 if EOF is reached.
++ */
++int file_lines_scanf(const char *file, const int lineno,
++		     void (*cleanup_fn)(void), int strict,
++		     const char *path, const char *fmt, ...)
++{
++	FILE *fp;
++	int ret = 0;
++	int arg_count = 0;
++	char line[BUFSIZ];
++	va_list ap;
++
++	if (!fmt) {
++		tst_brkm(TBROK, cleanup_fn, "pattern is NULL, %s:%d",
++			file, lineno);
++	}
++
++	fp = fopen(path, "r");
++	if (fp == NULL) {
++		tst_brkm(TBROK | TERRNO, cleanup_fn,
++			"Failed to open FILE '%s' for reading at %s:%d",
++			path, file, lineno);
++	}
++
++	arg_count = count_scanf_conversions(fmt);
++
++	while (fgets(line, BUFSIZ, fp) != NULL) {
++		va_start(ap, fmt);
++		ret = vsscanf(line, fmt, ap);
++		va_end(ap);
++
++		if (ret == arg_count)
++			break;
++	}
++	fclose(fp);
++
++	if (strict && ret != arg_count)
++		tst_brkm(TBROK, cleanup_fn, "Expected %i conversions got %i"
++			" at %s:%d", arg_count, ret, file, lineno);
++
++	return !(ret == arg_count);
++}
++
+ int file_printf(const char *file, const int lineno,
+ 		      const char *path, const char *fmt, ...)
+ {
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160510/madvise06-make-bug-detection-more-reliable.patch
+++ b/distribution/ltp/include/patches/20160510/madvise06-make-bug-detection-more-reliable.patch
@@ -1,0 +1,220 @@
+From 1edd40229ac28a5b63ce1cf0dae63f28793bb820 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Fri, 22 Jul 2016 12:56:41 +0200
+Subject: [PATCH] madvise06: make bug detection more reliable
+
+1. set up memory cgroup
+This allows us to get swapped memory faster, and also
+eliminates problems with running testcase on big systems.
+
+2. check for expected effects in a loop
+madvise_willneed() reads memory asynchronously, so we check
+multiple times with delay in-between. Because we can't
+distinguish between bad kernel and slow I/O, bad kernel
+will make test check for 5 seconds before giving up.
+As last resort we check presence of first page.
+
+Tested-by: Chunyu Hu <chuhu@redhat.com>
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/syscalls/madvise/madvise06.c | 140 ++++++++++++++++++--------
+ 1 file changed, 100 insertions(+), 40 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/madvise/madvise06.c b/testcases/kernel/syscalls/madvise/madvise06.c
+index 6b081fd..ddd1814 100644
+--- a/testcases/kernel/syscalls/madvise/madvise06.c
++++ b/testcases/kernel/syscalls/madvise/madvise06.c
+@@ -34,29 +34,82 @@
+  */
+ 
+ #include <errno.h>
++#include <stdio.h>
++#include <sys/mount.h>
+ #include <sys/sysinfo.h>
+ #include "tst_test.h"
+ 
+-#define GB_SZ  (1024*1024*1024)
++#define CHUNK_SZ (400*1024*1024L)
++#define CHUNK_PAGES (CHUNK_SZ / pg_sz)
++#define PASS_THRESHOLD (CHUNK_SZ / 4)
+ 
+-static long dst_max;
++#define MNT_NAME "memory"
++#define GROUP_NAME "madvise06"
++
++static const char drop_caches_fname[] = "/proc/sys/vm/drop_caches";
+ static int pg_sz;
+ 
++static void check_path(const char *path)
++{
++	if (access(path, R_OK | W_OK))
++		tst_brk(TCONF, "file needed: %s\n", path);
++}
++
+ static void setup(void)
+ {
+-	struct sysinfo sys_buf;
++	struct sysinfo sys_buf_start;
+ 
+-	sysinfo(&sys_buf);
++	pg_sz = getpagesize();
+ 
+-	if (sys_buf.totalram < 2L * GB_SZ)
+-		tst_brk(TCONF, "Test requires more than 2GB of RAM");
+-	if (sys_buf.totalram > 100L * GB_SZ)
+-		tst_brk(TCONF, "System RAM is too large, skip test");
++	check_path(drop_caches_fname);
++	tst_res(TINFO, "dropping caches");
++	sync();
++	SAFE_FILE_PRINTF(drop_caches_fname, "3");
++
++	sysinfo(&sys_buf_start);
++	if (sys_buf_start.freeram < 2 * CHUNK_SZ)
++		tst_brk(TCONF, "System RAM is too small, skip test");
++	if (sys_buf_start.freeswap < 2 * CHUNK_SZ)
++		tst_brk(TCONF, "System swap is too small");
++
++	SAFE_MKDIR(MNT_NAME, 0700);
++	if (mount("memory", MNT_NAME, "cgroup", 0, "memory") == -1) {
++		if (errno == ENODEV || errno == ENOENT)
++			tst_brk(TCONF, "memory cgroup needed");
++	}
++	SAFE_MKDIR(MNT_NAME"/"GROUP_NAME, 0700);
++
++	check_path("/proc/self/oom_score_adj");
++	check_path(MNT_NAME"/"GROUP_NAME"/memory.limit_in_bytes");
++	check_path(MNT_NAME"/"GROUP_NAME"/memory.swappiness");
++	check_path(MNT_NAME"/"GROUP_NAME"/tasks");
++
++	SAFE_FILE_PRINTF("/proc/self/oom_score_adj", "%d", -1000);
++	SAFE_FILE_PRINTF(MNT_NAME"/"GROUP_NAME"/memory.limit_in_bytes", "%ld\n",
++		PASS_THRESHOLD);
++	SAFE_FILE_PRINTF(MNT_NAME"/"GROUP_NAME"/memory.swappiness", "60");
++	SAFE_FILE_PRINTF(MNT_NAME"/"GROUP_NAME"/tasks", "%d\n", getpid());
++}
+ 
+-	dst_max = sys_buf.totalram / GB_SZ;
+-	tst_res(TINFO, "dst_max = %ld", dst_max);
++static void cleanup(void)
++{
++	FILE *f = fopen(MNT_NAME"/tasks", "w");
++
++	if (f) {
++		fprintf(f, "%d\n", getpid());
++		fclose(f);
++	}
++	rmdir(MNT_NAME"/"GROUP_NAME);
++	umount(MNT_NAME);
++}
+ 
+-	pg_sz = getpagesize();
++static void dirty_pages(char *ptr, long size)
++{
++	long i;
++	long pages = size / pg_sz;
++
++	for (i = 0; i < pages; i++)
++		ptr[i * pg_sz] = 'x';
+ }
+ 
+ static int get_page_fault_num(void)
+@@ -66,46 +119,52 @@ static int get_page_fault_num(void)
+ 	SAFE_FILE_SCANF("/proc/self/stat",
+ 			"%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d",
+ 			&pg);
+-
+ 	return pg;
+ }
+ 
+ static void test_advice_willneed(void)
+ {
+-	int i;
+-	char *src;
+-	char *dst[100];
+-	int page_fault_num_1;
+-	int page_fault_num_2;
+-
+-	/* allocate source memory (1GB only) */
+-	src = SAFE_MMAP(NULL, 1 * GB_SZ, PROT_READ | PROT_WRITE,
++	int loops = 50;
++	char *target;
++	long swapcached_start, swapcached;
++	int page_fault_num_1, page_fault_num_2;
++
++	target = SAFE_MMAP(NULL, CHUNK_SZ, PROT_READ | PROT_WRITE,
+ 			MAP_SHARED | MAP_ANONYMOUS,
+ 			-1, 0);
++	dirty_pages(target, CHUNK_SZ);
+ 
+-	/* allocate destination memory (array) */
+-	for (i = 0; i < dst_max; ++i)
+-		dst[i] = SAFE_MMAP(NULL, 1 * GB_SZ,
+-				PROT_READ | PROT_WRITE,
+-				MAP_SHARED | MAP_ANONYMOUS,
+-				-1, 0);
+-
+-	/* memmove source to each destination memories (for SWAP-OUT) */
+-	for (i = 0; i < dst_max; ++i)
+-		memmove(dst[i], src, 1 * GB_SZ);
++	SAFE_FILE_LINES_SCANF("/proc/meminfo", "SwapCached: %ld",
++		&swapcached_start);
++	tst_res(TINFO, "SwapCached (before madvise): %ld", swapcached_start);
+ 
+-	tst_res(TINFO, "PageFault(no madvice): %d", get_page_fault_num());
+-
+-	/* Do madvice() to dst[0] */
+-	TEST(madvise(dst[0], pg_sz, MADV_WILLNEED));
++	TEST(madvise(target, CHUNK_SZ, MADV_WILLNEED));
+ 	if (TEST_RETURN == -1)
+ 		tst_brk(TBROK | TERRNO, "madvise failed");
+ 
++	do {
++		loops--;
++		usleep(100000);
++		SAFE_FILE_LINES_SCANF("/proc/meminfo", "SwapCached: %ld",
++			&swapcached);
++	} while (swapcached < swapcached_start + PASS_THRESHOLD / 1024
++		&& loops > 0);
++
++	tst_res(TINFO, "SwapCached (after madvise): %ld", swapcached);
++	if (swapcached > swapcached_start + PASS_THRESHOLD / 1024) {
++		tst_res(TPASS, "Regression test pass");
++		SAFE_MUNMAP(target, CHUNK_SZ);
++		return;
++	}
++
++	/*
++	 * We may have hit a bug or we just have slow I/O,
++	 * try accessing first page.
++	 */
+ 	page_fault_num_1 = get_page_fault_num();
+ 	tst_res(TINFO, "PageFault(madvice / no mem access): %d",
+ 			page_fault_num_1);
+-
+-	*dst[0] = 'a';
++	target[0] = 'a';
+ 	page_fault_num_2 = get_page_fault_num();
+ 	tst_res(TINFO, "PageFault(madvice / mem access): %d",
+ 			page_fault_num_2);
+@@ -115,13 +174,14 @@ static void test_advice_willneed(void)
+ 	else
+ 		tst_res(TPASS, "Regression test pass");
+ 
+-	SAFE_MUNMAP(src, 1 * GB_SZ);
+-	for (i = 0; i < dst_max; ++i)
+-		SAFE_MUNMAP(dst[i], 1 * GB_SZ);
++	SAFE_MUNMAP(target, CHUNK_SZ);
+ }
+ 
+ static struct tst_test test = {
+-	.tid = "madvice06",
++	.tid = "madvise06",
+ 	.test_all = test_advice_willneed,
+ 	.setup = setup,
++	.cleanup = cleanup,
++	.needs_tmpdir = 1,
++	.needs_root = 1,
+ };
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160510/mem-lib-skip-oom-KSM-for-lite-1-single-TESTMEM-MB-al.patch
+++ b/distribution/ltp/include/patches/20160510/mem-lib-skip-oom-KSM-for-lite-1-single-TESTMEM-MB-al.patch
@@ -1,0 +1,49 @@
+From 393980b01421bc1b782671d245128d1c5feca6e0 Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Tue, 21 Jun 2016 18:54:43 +0800
+Subject: [PATCH] mem/lib: skip oom(KSM) for lite == 1 (single TESTMEM+MB
+ allocation)
+
+We occasionally catch errors like:
+oom03       0  TINFO  :  start OOM testing for KSM pages.
+oom03       0  TINFO  :  expected victim is 3490.
+oom03       6  TFAIL  :  mem.c:163: victim unexpectedly ended with retcode: 0, expected: 12
+oom03       0  TINFO  :  set overcommit_memory to 0
+
+The issue occurred when child_alloc() ran with lite == 1, meaning it made
+only single TESTMEM+MB allocation and returned 0. That's not what oom03
+expects as it sets 'limit_in_bytes = TESTMEM' via cgroup. The cause is
+presumably that KSM scan merged some allocated pages before child could
+hit OOM.
+
+This patch will skip oom(KSM) when lite == 1. At present this applies
+only to oom03 testcase.
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Acked-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/mem/lib/mem.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/testcases/kernel/mem/lib/mem.c b/testcases/kernel/mem/lib/mem.c
+index 3d853a3..7e403b5 100644
+--- a/testcases/kernel/mem/lib/mem.c
++++ b/testcases/kernel/mem/lib/mem.c
+@@ -224,8 +224,12 @@ void testoom(int mempolicy, int lite, int retcode, int allow_sigkill)
+ 	tst_resm(TINFO, "start OOM testing for mlocked pages.");
+ 	oom(MLOCK, lite, retcode, allow_sigkill);
+ 
+-	if (access(PATH_KSM, F_OK) == -1) {
+-		tst_resm(TINFO, "KSM configuration is not enabled, "
++	/*
++	 * Skip oom(KSM) if lite == 1, since limit_in_bytes may vary from
++	 * run to run, which isn't reliable for oom03 cgroup test.
++	 */
++	if (access(PATH_KSM, F_OK) == -1 || lite == 1) {
++		tst_resm(TINFO, "KSM is not configed or lite == 1, "
+ 			 "skip OOM test for KSM pags");
+ 	} else {
+ 		tst_resm(TINFO, "start OOM testing for KSM pages.");
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160510/mem-oom-fork-may-fail-before-test.patch
+++ b/distribution/ltp/include/patches/20160510/mem-oom-fork-may-fail-before-test.patch
@@ -1,0 +1,37 @@
+From 69714573dcdffd4e5001ae246c665078a60ee37b Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 19 May 2016 16:43:03 +0200
+Subject: [PATCH] mem/oom: fork may fail before test
+
+On systems with small RAM and vm.overcommit_memory == 2,
+the system may already be in state where Committed_AS is
+larger than CommitLimit due to various backround daemons
+(NM, tuned, polkitd,...) asking for big allocations.
+
+In such instances oom testcases report TBROK on very first fork.
+This patch allows this to be a valid outcome (TPASS).
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/mem/lib/mem.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/testcases/kernel/mem/lib/mem.c b/testcases/kernel/mem/lib/mem.c
+index c55a55d..3d853a3 100644
+--- a/testcases/kernel/mem/lib/mem.c
++++ b/testcases/kernel/mem/lib/mem.c
+@@ -127,6 +127,10 @@ void oom(int testcase, int lite, int retcode, int allow_sigkill)
+ 
+ 	switch (pid = fork()) {
+ 	case -1:
++		if (errno == retcode) {
++			tst_resm(TPASS | TERRNO, "fork");
++			return;
++		}
+ 		tst_brkm(TBROK | TERRNO, cleanup, "fork");
+ 	case 0:
+ 		threads = MAX(1, tst_ncpus() - 1);
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160510/swapping01-replace-mem_free-by-mem_available.patch
+++ b/distribution/ltp/include/patches/20160510/swapping01-replace-mem_free-by-mem_available.patch
@@ -1,0 +1,134 @@
+From 495654ba1ab297d4e38af8a5d00d098f426d7d7a Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Tue, 2 Aug 2016 11:47:22 +0800
+Subject: [PATCH] swapping01: replace mem_free by mem_available
+
+On some ppc64 systems, there free memory are larger than available memory, but
+total swap size is very small. Then this swapping01 easily get failures like:
+
+swapping01    0  TINFO  :  free physical memory: 14651 MB
+swapping01    0  TINFO  :  try to allocate: 19046 MB
+swapping01    1  TBROK  :  swapping01.c:134: malloc: errno=ENOMEM(12): Cannot allocate memory
+swapping01    2  TBROK  :  swapping01.c:134: Remaining cases broken
+swapping01    1  TBROK  :  swapping01.c:151: child was not stopped.
+swapping01    2  TBROK  :  swapping01.c:151: Remaining cases broken
+
+ # free -m
+               total        used        free      shared  buff/cache   available
+ Mem:          15316         238       14651           0         427       14478
+ Swap:          4607         202        4405
+
+That's because 14478(available_mem) + 4405(swap_free) < 19046(expected: 14651(free_mem) * 1.3),
+so we get malloc ENOMEM errors.
+
+In this patch:
+  * replace the free memory by available
+  * compare free swap with mem_over_max
+  * take new method to monitor swap usage
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Reviewed-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/mem/swapping/swapping01.c | 55 ++++++++++++++++++------------
+ 1 file changed, 33 insertions(+), 22 deletions(-)
+
+diff --git a/testcases/kernel/mem/swapping/swapping01.c b/testcases/kernel/mem/swapping/swapping01.c
+index b530ee2..171edb3 100644
+--- a/testcases/kernel/mem/swapping/swapping01.c
++++ b/testcases/kernel/mem/swapping/swapping01.c
+@@ -68,7 +68,7 @@ static void init_meminfo(void);
+ static void do_alloc(void);
+ static void check_swapping(void);
+ 
+-static long mem_free_init;
++static long mem_available_init;
+ static long swap_free_init;
+ static long mem_over;
+ static long mem_over_max;
+@@ -108,18 +108,19 @@ int main(int argc, char *argv[])
+ static void init_meminfo(void)
+ {
+ 	swap_free_init = read_meminfo("SwapFree:");
+-	mem_free_init = read_meminfo("MemFree:");
+-	mem_over = mem_free_init * COE_SLIGHT_OVER;
+-	mem_over_max = mem_free_init * COE_DELTA;
+-
+-	/* at least 10MB free physical memory needed */
+-	if (mem_free_init < 10240) {
+-		sleep(5);
+-		if (mem_free_init < 10240)
+-			tst_brkm(TCONF, cleanup,
+-				 "Not enough free memory to test.");
++	if (FILE_LINES_SCANF(cleanup, "/proc/meminfo", "MemAvailable: %ld",
++		&mem_available_init)) {
++		mem_available_init = read_meminfo("MemFree:")
++			+ read_meminfo("Cached:");
+ 	}
+-	if (swap_free_init < mem_over)
++	mem_over = mem_available_init * COE_SLIGHT_OVER;
++	mem_over_max = mem_available_init * COE_DELTA;
++
++	/* at least 10MB available physical memory needed */
++	if (mem_available_init < 10240)
++		tst_brkm(TCONF, cleanup, "Not enough available mem to test.");
++
++	if (swap_free_init < mem_over_max)
+ 		tst_brkm(TCONF, cleanup, "Not enough swap space to test.");
+ }
+ 
+@@ -128,8 +129,9 @@ static void do_alloc(void)
+ 	long mem_count;
+ 	void *s;
+ 
+-	tst_resm(TINFO, "free physical memory: %ld MB", mem_free_init / 1024);
+-	mem_count = mem_free_init + mem_over;
++	tst_resm(TINFO, "available physical memory: %ld MB",
++		mem_available_init / 1024);
++	mem_count = mem_available_init + mem_over;
+ 	tst_resm(TINFO, "try to allocate: %ld MB", mem_count / 1024);
+ 	s = malloc(mem_count * 1024);
+ 	if (s == NULL)
+@@ -144,7 +146,7 @@ static void do_alloc(void)
+ static void check_swapping(void)
+ {
+ 	int status, i;
+-	long swapped;
++	long swap_free_now, swapped;
+ 
+ 	/* wait child stop */
+ 	if (waitpid(pid, &status, WUNTRACED) == -1)
+@@ -153,15 +155,24 @@ static void check_swapping(void)
+ 		tst_brkm(TBROK, cleanup, "child was not stopped.");
+ 
+ 	/* Still occupying memory, loop for a while */
+-	for (i = 0; i < 10; i++) {
+-		swapped = swap_free_init - read_meminfo("SwapFree:");
+-		if (swapped > mem_over_max) {
+-			kill(pid, SIGCONT);
+-			tst_brkm(TFAIL, cleanup, "heavy swapping detected: "
+-				 "%ld MB swapped.", swapped / 1024);
+-		}
++	i = 0;
++	while (i < 10) {
++		swap_free_now = read_meminfo("SwapFree:");
+ 		sleep(1);
++		if (abs(swap_free_now - read_meminfo("SwapFree:")) < 512)
++			break;
++
++		i++;
+ 	}
++
++	swap_free_now = read_meminfo("SwapFree:");
++	swapped = swap_free_init - swap_free_now;
++	if (swapped > mem_over_max) {
++		kill(pid, SIGCONT);
++		tst_brkm(TFAIL, cleanup, "heavy swapping detected: "
++				"%ld MB swapped.", swapped / 1024);
++	}
++
+ 	tst_resm(TPASS, "no heavy swapping detected, %ld MB swapped.",
+ 		 swapped / 1024);
+ 	kill(pid, SIGCONT);
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160510/syscalls-madvise06-Convert-to-new-test-API.patch
+++ b/distribution/ltp/include/patches/20160510/syscalls-madvise06-Convert-to-new-test-API.patch
@@ -1,0 +1,147 @@
+From 0dfbe0549c1ff248641d5f8e27282655e8dc6f93 Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Thu, 12 May 2016 16:49:53 +0800
+Subject: [PATCH] syscalls/madvise06: Convert to new test API
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+---
+ testcases/kernel/syscalls/madvise/madvise06.c | 64 +++++++++------------------
+ 1 file changed, 21 insertions(+), 43 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/madvise/madvise06.c b/testcases/kernel/syscalls/madvise/madvise06.c
+index 366827c..6b081fd 100644
+--- a/testcases/kernel/syscalls/madvise/madvise06.c
++++ b/testcases/kernel/syscalls/madvise/madvise06.c
+@@ -33,39 +33,15 @@
+  *       mm: madvise: fix MADV_WILLNEED on shmem swapouts
+  */
+ 
+-#include <stdio.h>
+ #include <errno.h>
+ #include <sys/sysinfo.h>
+-
+-#include "test.h"
+-#include "safe_macros.h"
+-
+-char *TCID = "madvise06";
+-int TST_TOTAL = 1;
++#include "tst_test.h"
+ 
+ #define GB_SZ  (1024*1024*1024)
+ 
+ static long dst_max;
+ static int pg_sz;
+ 
+-static void setup(void);
+-static int  get_page_fault_num(void);
+-static void test_advice_willneed(void);
+-
+-int main(int argc, char *argv[])
+-{
+-	int lc;
+-
+-	tst_parse_opts(argc, argv, NULL, NULL);
+-
+-	setup();
+-
+-	for (lc = 0; TEST_LOOPING(lc); lc++)
+-		test_advice_willneed();
+-
+-	tst_exit();
+-}
+-
+ static void setup(void)
+ {
+ 	struct sysinfo sys_buf;
+@@ -73,25 +49,21 @@ static void setup(void)
+ 	sysinfo(&sys_buf);
+ 
+ 	if (sys_buf.totalram < 2L * GB_SZ)
+-		tst_brkm(TCONF, NULL, "Test requires more than 2GB of RAM");
++		tst_brk(TCONF, "Test requires more than 2GB of RAM");
+ 	if (sys_buf.totalram > 100L * GB_SZ)
+-		tst_brkm(TCONF, NULL, "System RAM is too large, skip test");
++		tst_brk(TCONF, "System RAM is too large, skip test");
+ 
+ 	dst_max = sys_buf.totalram / GB_SZ;
+-	tst_resm(TINFO, "dst_max = %ld", dst_max);
++	tst_res(TINFO, "dst_max = %ld", dst_max);
+ 
+ 	pg_sz = getpagesize();
+-
+-	tst_sig(NOFORK, DEF_HANDLER, NULL);
+-
+-	TEST_PAUSE;
+ }
+ 
+ static int get_page_fault_num(void)
+ {
+ 	int pg;
+ 
+-	SAFE_FILE_SCANF(NULL, "/proc/self/stat",
++	SAFE_FILE_SCANF("/proc/self/stat",
+ 			"%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d",
+ 			&pg);
+ 
+@@ -107,13 +79,13 @@ static void test_advice_willneed(void)
+ 	int page_fault_num_2;
+ 
+ 	/* allocate source memory (1GB only) */
+-	src = SAFE_MMAP(NULL, NULL, 1 * GB_SZ, PROT_READ | PROT_WRITE,
++	src = SAFE_MMAP(NULL, 1 * GB_SZ, PROT_READ | PROT_WRITE,
+ 			MAP_SHARED | MAP_ANONYMOUS,
+ 			-1, 0);
+ 
+ 	/* allocate destination memory (array) */
+ 	for (i = 0; i < dst_max; ++i)
+-		dst[i] = SAFE_MMAP(NULL, NULL, 1 * GB_SZ,
++		dst[i] = SAFE_MMAP(NULL, 1 * GB_SZ,
+ 				PROT_READ | PROT_WRITE,
+ 				MAP_SHARED | MAP_ANONYMOUS,
+ 				-1, 0);
+@@ -122,28 +94,34 @@ static void test_advice_willneed(void)
+ 	for (i = 0; i < dst_max; ++i)
+ 		memmove(dst[i], src, 1 * GB_SZ);
+ 
+-	tst_resm(TINFO, "PageFault(no madvice): %d", get_page_fault_num());
++	tst_res(TINFO, "PageFault(no madvice): %d", get_page_fault_num());
+ 
+ 	/* Do madvice() to dst[0] */
+ 	TEST(madvise(dst[0], pg_sz, MADV_WILLNEED));
+ 	if (TEST_RETURN == -1)
+-		tst_brkm(TBROK | TERRNO, NULL, "madvise failed");
++		tst_brk(TBROK | TERRNO, "madvise failed");
+ 
+ 	page_fault_num_1 = get_page_fault_num();
+-	tst_resm(TINFO, "PageFault(madvice / no mem access): %d",
++	tst_res(TINFO, "PageFault(madvice / no mem access): %d",
+ 			page_fault_num_1);
+ 
+ 	*dst[0] = 'a';
+ 	page_fault_num_2 = get_page_fault_num();
+-	tst_resm(TINFO, "PageFault(madvice / mem access): %d",
++	tst_res(TINFO, "PageFault(madvice / mem access): %d",
+ 			page_fault_num_2);
+ 
+ 	if (page_fault_num_1 != page_fault_num_2)
+-		tst_resm(TFAIL, "Bug has been reproduced");
++		tst_res(TFAIL, "Bug has been reproduced");
+ 	else
+-		tst_resm(TPASS, "Regression test pass");
++		tst_res(TPASS, "Regression test pass");
+ 
+-	SAFE_MUNMAP(NULL, src, 1 * GB_SZ);
++	SAFE_MUNMAP(src, 1 * GB_SZ);
+ 	for (i = 0; i < dst_max; ++i)
+-		SAFE_MUNMAP(NULL, dst[i], 1 * GB_SZ);
++		SAFE_MUNMAP(dst[i], 1 * GB_SZ);
+ }
++
++static struct tst_test test = {
++	.tid = "madvice06",
++	.test_all = test_advice_willneed,
++	.setup = setup,
++};
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160510/zram01-extend-the-zram3-disksize-to-40MB.patch
+++ b/distribution/ltp/include/patches/20160510/zram01-extend-the-zram3-disksize-to-40MB.patch
@@ -1,0 +1,46 @@
+From dc48abafa1438ab75c41973b4d670038a3126ece Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Mon, 11 Jul 2016 19:57:25 +0800
+Subject: [PATCH] zram01: extend the zram3 disksize to 40MB
+
+It failed to format btrfs on /dev/zram3 device since the
+disk size is too small (btrfs-progs is v4.4.1).
+
+The error msg we catched:
+
+zram01 3 TINFO : make ext3 filesystem on /dev/zram0
+zram01 3 TINFO : make ext4 filesystem on /dev/zram1
+zram01 3 TINFO : make xfs filesystem on /dev/zram2
+zram01 3 TINFO : make btrfs filesystem on /dev/zram3
+'/dev/zram3' is too small to make a usable filesystem
+Minimum size for each btrfs device is 41943040.
+btrfs-progs v4.4.1
+See http://btrfs.wiki.kernel.org for more information.
+zram01 3 TFAIL : failed to make btrfs on /dev/zram3
+zram01 4 TINFO : zram cleanup
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Reviewed-by: Cyril Hrubis <chrubis@suse.cz>
+Reviewed-by: Alexey Kodanev <alexey.kodanev@oracle.com>
+---
+ testcases/kernel/device-drivers/zram/zram01.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/testcases/kernel/device-drivers/zram/zram01.sh b/testcases/kernel/device-drivers/zram/zram01.sh
+index 26dae90..caa0e05 100755
+--- a/testcases/kernel/device-drivers/zram/zram01.sh
++++ b/testcases/kernel/device-drivers/zram/zram01.sh
+@@ -39,8 +39,8 @@ zram_max_streams="2 3 5 8"
+ # not support mem suffixes, in some newer kernels, they use
+ # memparse() which supports mem suffixes. So here we just use
+ # bytes to make sure everything works correctly.
+-zram_sizes="26214400 26214400 26214400 26214400" # 25MB
+-zram_mem_limits="25M 25M 25M 25M"
++zram_sizes="26214400 26214400 26214400 41943040" # 25MB, 40MB for btrfs
++zram_mem_limits="25M 25M 25M 40M"
+ zram_filesystems="ext3 ext4 xfs btrfs"
+ zram_algs="lzo lzo lzo lzo"
+ 
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160920/kernel-zram-Fix-testcase-for-kernels-v4.7.patch
+++ b/distribution/ltp/include/patches/20160920/kernel-zram-Fix-testcase-for-kernels-v4.7.patch
@@ -1,0 +1,36 @@
+From 1ba749bbf9a06766e35d632967d61ec22078e9f2 Mon Sep 17 00:00:00 2001
+From: Mike Galbraith <mgalbraith@suse.de>
+Date: Tue, 27 Sep 2016 09:42:47 +0200
+Subject: [PATCH] kernel/zram: Fix testcase for kernels >= v4.7
+
+max_comp_streams is depreciated in kernels >= v4.7, bail instead
+of failing.
+
+Signed-off-by: Mike Galbraith <mgalbraith@suse.de>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/device-drivers/zram/zram_lib.sh | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/testcases/kernel/device-drivers/zram/zram_lib.sh b/testcases/kernel/device-drivers/zram/zram_lib.sh
+index d3e62e0..2144227 100755
+--- a/testcases/kernel/device-drivers/zram/zram_lib.sh
++++ b/testcases/kernel/device-drivers/zram/zram_lib.sh
+@@ -62,6 +62,14 @@ zram_load()
+ 
+ zram_max_streams()
+ {
++	tst_kvercmp 4 7 0
++	if [ $? -gt 0 ]; then
++		tst_resm TCONF "device attribute max_comp_streams is"\
++			"depriciated since kernel v4.7, the running kernel"\
++			"does not support it"
++		return
++	fi
++
+ 	tst_kvercmp 3 15 0
+ 	if [ $? -eq 0 ]; then
+ 		tst_resm TCONF "device attribute max_comp_streams is"\
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160920/lib-Add-optional-minimal-size-for-test-device.patch
+++ b/distribution/ltp/include/patches/20160920/lib-Add-optional-minimal-size-for-test-device.patch
@@ -1,0 +1,291 @@
+From d47bb550b43412273898edc1090a152762608865 Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Tue, 27 Sep 2016 14:51:23 +0800
+Subject: [PATCH] lib: Add optional minimal size for test device
+
+This patch allows testcases to request minimal size for the test block
+device. Which could be done either by setting the
+tst_test->device_min_size or by passing optional parameter to the shell
+tst_acquire_device() function. In both cases the requested size is in
+megabytes.
+
++ adds tst_device.c tests, and updates test-writing-guidelines.txt.
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Signed-off-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ doc/test-writing-guidelines.txt | 32 ++++++++++++++++++++-----
+ include/old/old_device.h        |  7 +++++-
+ include/tst_test.h              |  2 ++
+ lib/newlib_tests/.gitignore     |  1 +
+ lib/newlib_tests/tst_device.c   | 52 +++++++++++++++++++++++++++++++++++++++++
+ lib/tst_device.c                | 29 ++++++++++++++++++-----
+ lib/tst_test.c                  |  2 +-
+ testcases/lib/test.sh           |  8 +++++--
+ 8 files changed, 117 insertions(+), 16 deletions(-)
+ create mode 100644 lib/newlib_tests/tst_device.c
+
+diff --git a/doc/test-writing-guidelines.txt b/doc/test-writing-guidelines.txt
+index 8e0acae..384ff09 100644
+--- a/doc/test-writing-guidelines.txt
++++ b/doc/test-writing-guidelines.txt
+@@ -904,6 +904,10 @@ If '.needs_device' flag in the 'struct tst_test' is set the the 'tst_device'
+ structure is initialized with a path to a test device and default filesystem
+ to be used.
+ 
++You can also request minimal device size in megabytes by setting
++'.device_min_size' in the 'struct tst_test' structure. The device is
++guaranteed to have at least the requested size then.
++
+ [source,c]
+ -------------------------------------------------------------------------------
+ #include "tst_test.h"
+@@ -919,8 +923,10 @@ int tst_umount(const char *path);
+ -------------------------------------------------------------------------------
+ 
+ In case that 'LTP_DEV' is passed to the test in an environment, the library
+-checks that the file exists and that it's a block device. Otherwise a
+-temporary file is created and attached to a free loop device.
++checks that the file exists and that it's a block device, if
++'.device_min_size' is set the device size is checked as well. If 'LTP_DEV'
++wasn't set or if size requirements were not met a temporary file is created
++and attached to a free loop device.
+ 
+ If there is no usable device and loop device couldn't be initialized the test
+ exits with 'TCONF'.
+@@ -1328,12 +1334,26 @@ Following functions similar to the LTP C interface are available.
+ * tst_rmdir()
+ * tst_fs_has_free()
+ * tst_mkfs()
+-* tst_acquire_device()
+ * tst_release_device()
+ 
+-There is one more function called 'tst_check_cmds()' that gets unspecified
+-number of parameters and asserts that each parameter is a name of an
+-executable in '$PATH' and exits the test with 'TCONF' on first missing.
++tst_check_cmds
++++++++++++++++
++
++The 'tst_check_cmds()' function that gets unspecified number of parameters and
++asserts that each parameter is a name of an executable in '$PATH' and exits
++the test with 'TCONF' on first missing.
++
++tst_acquire_device
++++++++++++++++++++
++
++The 'tst_acquire_device()' can be used to obtain a block device for testing,
++the function takes optional parameter which can be used to request device
++minimal size in megabytes.
++
++The function returns device passed in 'LTP_DEV' environment variable if it's
++set, points to a block device, and if size requirements are met. If 'LTP_DEV'
++is not set or found suitable a temporary file is created and attached to a
++free loop device.
+ 
+ tst_sleep
+ +++++++++
+diff --git a/include/old/old_device.h b/include/old/old_device.h
+index 4dae05e..aabc617 100644
+--- a/include/old/old_device.h
++++ b/include/old/old_device.h
+@@ -42,7 +42,12 @@ const char *tst_dev_fs_type(void);
+  *
+  * Returns path to the device or NULL if it cannot be created.
+  */
+-const char *tst_acquire_device(void (cleanup_fn)(void));
++const char *tst_acquire_device_(void (cleanup_fn)(void), unsigned int size);
++
++static inline const char *tst_acquire_device(void (cleanup_fn)(void))
++{
++	return tst_acquire_device_(cleanup_fn, 0);
++}
+ 
+ /*
+  * @dev: device path returned by the tst_acquire_device()
+diff --git a/include/tst_test.h b/include/tst_test.h
+index 4c30134..3f7123e 100644
+--- a/include/tst_test.h
++++ b/include/tst_test.h
+@@ -106,6 +106,8 @@ struct tst_test {
+ 	int needs_device:1;
+ 	int needs_checkpoints:1;
+ 
++	unsigned int device_min_size;
++
+ 	/* override default timeout per test run */
+ 	unsigned int timeout;
+ 
+diff --git a/lib/newlib_tests/.gitignore b/lib/newlib_tests/.gitignore
+index c5b643f..1b83738 100644
+--- a/lib/newlib_tests/.gitignore
++++ b/lib/newlib_tests/.gitignore
+@@ -12,3 +12,4 @@ test11
+ test12
+ test13
+ tst_safe_fileops
++tst_device
+diff --git a/lib/newlib_tests/tst_device.c b/lib/newlib_tests/tst_device.c
+new file mode 100644
+index 0000000..72c2033
+--- /dev/null
++++ b/lib/newlib_tests/tst_device.c
+@@ -0,0 +1,52 @@
++/*
++ * Copyright (c) 2016 Linux Test Project
++ *
++ * This program is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation, either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program. If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <stdlib.h>
++#include <sys/mount.h>
++#include <stdint.h>
++
++#include "tst_test.h"
++
++static void do_test(void)
++{
++	int fd;
++	const char *dev;
++	uint64_t ltp_dev_size;
++
++	dev = tst_device->dev;
++	if (!dev)
++		tst_brk(TCONF, "Failed to acquire test device");
++
++	SAFE_MKFS(dev, "ext2", NULL, NULL);
++
++	fd = SAFE_OPEN(dev, O_RDONLY);
++	SAFE_IOCTL(fd, BLKGETSIZE64, &ltp_dev_size);
++	SAFE_CLOSE(fd);
++
++	if (ltp_dev_size/1024/1024 == 160)
++		tst_res(TPASS, "Got expected device size");
++	else
++		tst_res(TFAIL, "Got unexpected device size");
++}
++
++static struct tst_test test = {
++	.tid = "tst_device",
++	.needs_tmpdir = 1,
++	.needs_device = 1,
++	.device_min_size = 160,
++	.test_all = do_test,
++};
+diff --git a/lib/tst_device.c b/lib/tst_device.c
+index 30b1be2..3c62df0 100644
+--- a/lib/tst_device.c
++++ b/lib/tst_device.c
+@@ -29,6 +29,8 @@
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include <linux/loop.h>
++#include <stdint.h>
++#include <inttypes.h>
+ #include "test.h"
+ #include "safe_macros.h"
+ 
+@@ -182,10 +184,15 @@ static void detach_device(const char *dev)
+ 		"ioctl(%s, LOOP_CLR_FD, 0) no ENXIO for too long", dev);
+ }
+ 
+-const char *tst_acquire_device(void (cleanup_fn)(void))
++const char *tst_acquire_device_(void (cleanup_fn)(void), unsigned int size)
+ {
++	int fd;
+ 	char *dev;
+ 	struct stat st;
++	unsigned int acq_dev_size;
++	uint64_t ltp_dev_size;
++
++	acq_dev_size = size > 150 ? size : 150;
+ 
+ 	if (device_acquired)
+ 		tst_brkm(TBROK, cleanup_fn, "Device allready acquired");
+@@ -207,15 +214,25 @@ const char *tst_acquire_device(void (cleanup_fn)(void))
+ 			         "%s is not a block device", dev);
+ 		}
+ 
+-		if (tst_fill_file(dev, 0, 1024, 512)) {
+-			tst_brkm(TBROK | TERRNO, cleanup_fn,
+-				 "Failed to clear the first 512k of %s", dev);
++		fd = SAFE_OPEN(cleanup_fn, dev, O_RDONLY);
++		SAFE_IOCTL(cleanup_fn, fd, BLKGETSIZE64, &ltp_dev_size);
++		SAFE_CLOSE(cleanup_fn, fd);
++		ltp_dev_size = ltp_dev_size/1024/1024;
++
++		if (acq_dev_size <= ltp_dev_size) {
++			if (tst_fill_file(dev, 0, 1024, 512)) {
++				tst_brkm(TBROK | TERRNO, cleanup_fn,
++					"Failed to clear the first 512k of %s", dev);
++			}
++
++			return dev;
+ 		}
+ 
+-		return dev;
++		tst_resm(TINFO, "Skipping $LTP_DEV size %"PRIu64"MB, requested size %uMB",
++				ltp_dev_size, acq_dev_size);
+ 	}
+ 
+-	if (tst_fill_file(DEV_FILE, 0, 1024, 153600)) {
++	if (tst_fill_file(DEV_FILE, 0, 1024, 1024 * acq_dev_size)) {
+ 		tst_brkm(TBROK | TERRNO, cleanup_fn,
+ 		         "Failed to create " DEV_FILE);
+ 
+diff --git a/lib/tst_test.c b/lib/tst_test.c
+index 12ca051..06f0339 100644
+--- a/lib/tst_test.c
++++ b/lib/tst_test.c
+@@ -596,7 +596,7 @@ static void do_setup(int argc, char *argv[])
+ 	}
+ 
+ 	if (tst_test->needs_device) {
+-		tdev.dev = tst_acquire_device(NULL);
++		tdev.dev = tst_acquire_device_(NULL, tst_test->device_min_size);
+ 		tdev.fs_type = tst_dev_fs_type();
+ 
+ 		if (!tdev.dev)
+diff --git a/testcases/lib/test.sh b/testcases/lib/test.sh
+index a1fa2d9..76b7062 100644
+--- a/testcases/lib/test.sh
++++ b/testcases/lib/test.sh
+@@ -283,11 +283,15 @@ EXPECT_FAIL()
+ 
+ tst_acquire_device()
+ {
++	local acq_dev_size=${1:-150}
++
+ 	if [ -z ${TST_TMPDIR} ]; then
+ 		tst_brkm "Use 'tst_tmpdir' before 'tst_acquire_device'"
+ 	fi
+ 
+-	if [ -n "${LTP_DEV}" ]; then
++	ltp_dev_size=$((`blockdev --getsize64 $LTP_DEV`/1024/1024))
++
++	if [ -n "${LTP_DEV}" ] && [ ${acq_dev_size} -le ${ltp_dev_size} ]; then
+ 		tst_resm TINFO "Using test device LTP_DEV='${LTP_DEV}'"
+ 		if [ ! -b ${LTP_DEV} ]; then
+ 			tst_brkm TBROK "${LTP_DEV} is not a block device"
+@@ -300,7 +304,7 @@ tst_acquire_device()
+ 		return
+ 	fi
+ 
+-	ROD_SILENT dd if=/dev/zero of=test_dev.img bs=1024 count=153600
++	ROD_SILENT dd if=/dev/zero of=test_dev.img bs=1024 count=$((1024*$acq_dev_size))
+ 
+ 	TST_DEVICE=$(losetup -f)
+ 	if [ $? -ne 0 ]; then
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160920/lib-add-tst_res_hexd-for-newlib.patch
+++ b/distribution/ltp/include/patches/20160920/lib-add-tst_res_hexd-for-newlib.patch
@@ -1,0 +1,167 @@
+From f72ca5b9c484c00fd9eb1ba2569187d45abbb670 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 6 Oct 2016 13:34:39 +0200
+Subject: [PATCH] lib: add tst_res_hexd for newlib
+
+Locking mutex isn't necessary for oldlib, because we already
+lock at tst_res__ level. As consequence, output of tst_res_hexd
+may be interleaved with messages from other threads, but chances
+of that happening are pretty slim.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ doc/man3/tst_res.3              |  3 +++
+ include/tst_test.h              |  8 ++++++++
+ lib/newlib_tests/.gitignore     |  3 ++-
+ lib/newlib_tests/tst_res_hexd.c | 31 +++++++++++++++++++++++++++++++
+ lib/tst_res.c                   | 26 ++++++++++++++------------
+ 5 files changed, 58 insertions(+), 13 deletions(-)
+ create mode 100644 lib/newlib_tests/tst_res_hexd.c
+
+diff --git a/doc/man3/tst_res.3 b/doc/man3/tst_res.3
+index fe596b7..e1f50c2 100644
+--- a/doc/man3/tst_res.3
++++ b/doc/man3/tst_res.3
+@@ -304,6 +304,9 @@ If there are any problems opening/reading/writing the contents of \fIfname\fR.
+ If \fIfname\fR is NULL and \fItmesg\fR is NULL or empty, the result message
+ will be empty.  This allows a test to not print a message for a result, but
+ it is not advised.
++.SH NOTES
++In multithreaded environment, output of \fBtst_resm_hexd()\fR may be interleaved
++with messages produced by other threads.
+ .SH BUGS
+ .P
+ The programmer is free to alter the value of \fBtst_count\fR causing possible
+diff --git a/include/tst_test.h b/include/tst_test.h
+index 3f7123e..1492ff5 100644
+--- a/include/tst_test.h
++++ b/include/tst_test.h
+@@ -44,6 +44,14 @@ void tst_res_(const char *file, const int lineno, int ttype,
+ #define tst_res(ttype, arg_fmt, ...) \
+ 	tst_res_(__FILE__, __LINE__, (ttype), (arg_fmt), ##__VA_ARGS__)
+ 
++void tst_resm_hexd_(const char *file, const int lineno, int ttype,
++	const void *buf, size_t size, const char *arg_fmt, ...)
++	__attribute__ ((format (printf, 6, 7)));
++
++#define tst_res_hexd(ttype, buf, size, arg_fmt, ...) \
++	tst_resm_hexd_(__FILE__, __LINE__, (ttype), (buf), (size), \
++			(arg_fmt), ##__VA_ARGS__)
++
+ /*
+  * Reports result and exits a test.
+  */
+diff --git a/lib/newlib_tests/.gitignore b/lib/newlib_tests/.gitignore
+index 1b83738..bc2409c 100644
+--- a/lib/newlib_tests/.gitignore
++++ b/lib/newlib_tests/.gitignore
+@@ -11,5 +11,6 @@ test10
+ test11
+ test12
+ test13
+-tst_safe_fileops
+ tst_device
++tst_safe_fileops
++tst_res_hexd
+diff --git a/lib/newlib_tests/tst_res_hexd.c b/lib/newlib_tests/tst_res_hexd.c
+new file mode 100644
+index 0000000..333ea56
+--- /dev/null
++++ b/lib/newlib_tests/tst_res_hexd.c
+@@ -0,0 +1,31 @@
++/*
++ * Copyright (c) 2016 Linux Test Project
++ *
++ * This program is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation, either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program. If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#include <stdio.h>
++#include "tst_test.h"
++
++static void do_test(void)
++{
++	char tmp[] = "Hello from tst_res_hexd";
++
++	tst_res_hexd(TPASS, tmp, sizeof(tmp), "%s%d", "dump", 1);
++}
++
++static struct tst_test test = {
++	.tid = "tst_res_hexd",
++	.test_all = do_test,
++};
+diff --git a/lib/tst_res.c b/lib/tst_res.c
+index b388d0d..261dec0 100644
+--- a/lib/tst_res.c
++++ b/lib/tst_res.c
+@@ -500,29 +500,33 @@ void tst_resm_(const char *file, const int lineno, int ttype,
+ 		tst_res__(file, lineno, ttype, "%s", tmesg);
+ }
+ 
++typedef void (*tst_res_func_t)(const char *file, const int lineno,
++		int ttype, const char *fmt, ...);
++
+ void tst_resm_hexd_(const char *file, const int lineno, int ttype,
+ 	const void *buf, size_t size, const char *arg_fmt, ...)
+ {
+-	NO_NEWLIB_ASSERT(file, lineno);
+-
+-	pthread_mutex_lock(&tmutex);
+-
+ 	char tmesg[USERMESG];
+-
+-	EXPAND_VAR_ARGS(tmesg, arg_fmt, USERMESG);
+-
+ 	static const size_t symb_num	= 2; /* xx */
+ 	static const size_t size_max	= 16;
+ 	size_t offset = strlen(tmesg);
++	size_t i;
+ 	char *pmesg = tmesg;
++	tst_res_func_t res_func;
++
++	if (tst_test)
++		res_func = tst_res_;
++	else
++		res_func = tst_res__;
++
++	EXPAND_VAR_ARGS(tmesg, arg_fmt, USERMESG);
+ 
+ 	if (size > size_max || size == 0 ||
+ 		(offset + size * (symb_num + 1)) >= USERMESG)
+-		tst_res__(file, lineno, ttype, "%s", tmesg);
++		res_func(file, lineno, ttype, "%s", tmesg);
+ 	else
+ 		pmesg += offset;
+ 
+-	size_t i;
+ 	for (i = 0; i < size; ++i) {
+ 		/* add space before byte except first one */
+ 		if (pmesg != tmesg)
+@@ -531,12 +535,10 @@ void tst_resm_hexd_(const char *file, const int lineno, int ttype,
+ 		sprintf(pmesg, "%02x", ((unsigned char *)buf)[i]);
+ 		pmesg += symb_num;
+ 		if ((i + 1) % size_max == 0 || i + 1 == size) {
+-			tst_res__(file, lineno, ttype, "%s", tmesg);
++			res_func(file, lineno, ttype, "%s", tmesg);
+ 			pmesg = tmesg;
+ 		}
+ 	}
+-
+-	pthread_mutex_unlock(&tmutex);
+ }
+ 
+ void tst_brkm_(const char *file, const int lineno, int ttype,
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160920/move_pages04-fix-zero-page-status-code-for-kernels-4.patch
+++ b/distribution/ltp/include/patches/20160920/move_pages04-fix-zero-page-status-code-for-kernels-4.patch
@@ -1,0 +1,77 @@
+From d539a004dde3b760f610ef7cae90a96de8489ec8 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Mon, 3 Oct 2016 15:32:00 +0200
+Subject: [PATCH] move_pages04: fix zero page status code for kernels >= 4.3
+
+d899844e9c98 "mm: fix status code which move_pages() returns for zero
+page" changed status code for zero pages (allocated but not written
+to yet) from -ENOENT to -EFAULT.
+
+This patch mirros the change for move_pages04 testcase.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ .../kernel/syscalls/move_pages/move_pages04.c      | 31 +++++++++++++++-------
+ 1 file changed, 22 insertions(+), 9 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/move_pages/move_pages04.c b/testcases/kernel/syscalls/move_pages/move_pages04.c
+index 1657bee..0182538 100644
+--- a/testcases/kernel/syscalls/move_pages/move_pages04.c
++++ b/testcases/kernel/syscalls/move_pages/move_pages04.c
+@@ -30,9 +30,14 @@
+  *
+  * ALGORITHM
+  *
+- *      1. Pass a page that does not exit as one of the page addresses
+- *         to move_pages().
+- *      2. Check if the corresponding status is set to -ENOENT.
++ *      1. Pass zero page (allocated, but not written to) as one of the
++ *         page addresses to move_pages().
++ *      2. Check if the corresponding status is set to:
++ *         -ENOENT for kernels < 4.3
++ *         -EFAULT for kernels >= 4.3 [1]
++ *
++ * [1]
++ * d899844e9c98 "mm: fix status code which move_pages() returns for zero page"
+  *
+  * USAGE:  <for command-line>
+  *      move_pages04 [-c n] [-i n] [-I x] [-P x] [-t]
+@@ -84,7 +89,12 @@ int main(int argc, char **argv)
+ 	int lc;
+ 	unsigned int from_node;
+ 	unsigned int to_node;
+-	int ret;
++	int ret, exp_status;
++
++	if ((tst_kvercmp(4, 3, 0)) >= 0)
++		exp_status = -EFAULT;
++	else
++		exp_status = -ENOENT;
+ 
+ 	ret = get_allowed_nodes(NH_MEMS, 2, &from_node, &to_node);
+ 	if (ret < 0)
+@@ -123,12 +133,15 @@ int main(int argc, char **argv)
+ 			goto err_free_pages;
+ 		}
+ 
+-		if (status[UNTOUCHED_PAGE] == -ENOENT)
+-			tst_resm(TPASS, "status[%d] set to expected -ENOENT",
++		if (status[UNTOUCHED_PAGE] == exp_status) {
++			tst_resm(TPASS, "status[%d] has expected value",
+ 				 UNTOUCHED_PAGE);
+-		else
+-			tst_resm(TFAIL, "status[%d] is %d", UNTOUCHED_PAGE,
+-				 status[UNTOUCHED_PAGE]);
++		} else {
++			tst_resm(TFAIL, "status[%d] is %s, expected %s",
++				UNTOUCHED_PAGE,
++				tst_strerrno(-status[UNTOUCHED_PAGE]),
++				tst_strerrno(-exp_status));
++		}
+ 
+ err_free_pages:
+ 		/* This is capable of freeing both the touched and
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160920/syscalls-new-test-writev07.patch
+++ b/distribution/ltp/include/patches/20160920/syscalls-new-test-writev07.patch
@@ -1,0 +1,241 @@
+From db19194527060a962955a7db54a2f5710e69bec9 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Wed, 5 Oct 2016 14:02:58 +0200
+Subject: [PATCH] syscalls: new test writev07
+
+Verify writev() behaviour with partially valid iovec list.
+Kernel <4.8 used to shorten write up to first bad invalid
+iovec. Starting with 4.8, a writev with short data (under
+page size) is likely to get shorten to 0 bytes and return
+EFAULT.
+
+This test doesn't make assumptions how much will write get
+shortened. It only tests that file content/offset after
+syscall corresponds to return value of writev().
+
+See: [RFC] writev() semantics with invalid iovec in the middle
+     https://marc.info/?l=linux-kernel&m=147388891614289&w=2
+
+This test is meant to be replacement for writev03/writev04
+and part of writev01, which all deal with partially invalid
+iovec lists, and all currently fail with 4.8 kernel.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ runtest/ltplite                             |   1 +
+ runtest/stress.part3                        |   1 +
+ runtest/syscalls                            |   1 +
+ testcases/kernel/syscalls/.gitignore        |   1 +
+ testcases/kernel/syscalls/writev/writev07.c | 151 ++++++++++++++++++++++++++++
+ 5 files changed, 155 insertions(+)
+ create mode 100644 testcases/kernel/syscalls/writev/writev07.c
+
+diff --git a/runtest/ltplite b/runtest/ltplite
+index 42d9a03..1b4c5f6 100644
+--- a/runtest/ltplite
++++ b/runtest/ltplite
+@@ -1047,6 +1047,7 @@ writev03 writev03
+ writev04 writev04
+ writev05 writev05
+ writev06 writev06
++writev07 writev07
+ 
+ #DESCRIPTION:Memory Mgmt tests
+ mm01 mmap001 -m 10000
+diff --git a/runtest/stress.part3 b/runtest/stress.part3
+index fa75b5c..effa5fd 100644
+--- a/runtest/stress.part3
++++ b/runtest/stress.part3
+@@ -908,6 +908,7 @@ writev03 writev03
+ writev04 writev04
+ writev05 writev05
+ writev06 writev06
++writev07 writev07
+ 
+ pty01 pty01
+ hangup01 hangup01
+diff --git a/runtest/syscalls b/runtest/syscalls
+index 01839e8..88f7597 100644
+--- a/runtest/syscalls
++++ b/runtest/syscalls
+@@ -1426,6 +1426,7 @@ writev03 writev03
+ writev04 writev04
+ writev05 writev05
+ writev06 writev06
++writev07 writev07
+ 
+ perf_event_open01 perf_event_open01
+ perf_event_open02 perf_event_open02
+diff --git a/testcases/kernel/syscalls/.gitignore b/testcases/kernel/syscalls/.gitignore
+index a13dbb3..f2aeab4 100644
+--- a/testcases/kernel/syscalls/.gitignore
++++ b/testcases/kernel/syscalls/.gitignore
+@@ -1104,6 +1104,7 @@
+ /writev/writev04
+ /writev/writev05
+ /writev/writev06
++/writev/writev07
+ /fanotify/fanotify01
+ /fanotify/fanotify02
+ /fanotify/fanotify03
+diff --git a/testcases/kernel/syscalls/writev/writev07.c b/testcases/kernel/syscalls/writev/writev07.c
+new file mode 100644
+index 0000000..43dc09f
+--- /dev/null
++++ b/testcases/kernel/syscalls/writev/writev07.c
+@@ -0,0 +1,151 @@
++/*
++ *
++ *   Copyright (c) Linux Test Project, 2016
++ *
++ *   This program is free software;  you can redistribute it and/or modify
++ *   it under the terms of the GNU General Public License as published by
++ *   the Free Software Foundation; either version 2 of the License, or
++ *   (at your option) any later version.
++ *
++ *   This program is distributed in the hope that it will be useful,
++ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
++ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
++ *   the GNU General Public License for more details.
++ */
++
++/*
++ * Test Description:
++ *   Verify writev() behaviour with partially valid iovec list.
++ *   Kernel <4.8 used to shorten write up to first bad invalid
++ *   iovec. Starting with 4.8, a writev with short data (under
++ *   page size) is likely to get shorten to 0 bytes and return
++ *   EFAULT.
++ *
++ *   This test doesn't make assumptions how much will write get
++ *   shortened. It only tests that file content/offset after
++ *   syscall corresponds to return value of writev().
++ *
++ *   See: [RFC] writev() semantics with invalid iovec in the middle
++ *        https://marc.info/?l=linux-kernel&m=147388891614289&w=2
++ */
++
++#include <errno.h>
++#include <fcntl.h>
++#include <stdio.h>
++#include <sys/mman.h>
++#include <sys/stat.h>
++#include <sys/types.h>
++#include <sys/uio.h>
++#include "tst_test.h"
++
++#define TESTFILE "testfile"
++#define CHUNK 64
++#define BUFSIZE (CHUNK * 4)
++
++static void *bad_addr;
++
++static void test_partially_valid_iovec(int initial_file_offset)
++{
++	int i, fd;
++	unsigned char buffer[BUFSIZE], fpattern[BUFSIZE], tmp[BUFSIZE];
++	long off_after;
++	struct iovec wr_iovec[] = {
++		{ buffer, CHUNK },
++		{ bad_addr, CHUNK },
++		{ buffer + CHUNK, CHUNK },
++		{ buffer + CHUNK * 2, CHUNK },
++	};
++
++	tst_res(TINFO, "starting test with initial file offset: %d ",
++		initial_file_offset);
++
++	for (i = 0; i < BUFSIZE; i++)
++		buffer[i] = i % (CHUNK - 1);
++
++	memset(fpattern, 0xff, BUFSIZE);
++	tst_fill_file(TESTFILE, 0xff, CHUNK, BUFSIZE / CHUNK);
++
++	fd = SAFE_OPEN(TESTFILE, O_RDWR, 0644);
++	SAFE_LSEEK(fd, initial_file_offset, SEEK_SET);
++	TEST(writev(fd, wr_iovec, ARRAY_SIZE(wr_iovec)));
++	off_after = (long) SAFE_LSEEK(fd, 0, SEEK_CUR);
++
++	/* bad errno */
++	if (TEST_RETURN == -1 && TEST_ERRNO != EFAULT) {
++		tst_res(TFAIL | TTERRNO, "unexpected errno");
++		SAFE_CLOSE(fd);
++		return;
++	}
++
++	/* nothing has been written */
++	if (TEST_RETURN == -1 && TEST_ERRNO == EFAULT) {
++		tst_res(TINFO, "got EFAULT");
++		/* initial file content remains untouched */
++		SAFE_LSEEK(fd, 0, SEEK_SET);
++		SAFE_READ(1, fd, tmp, BUFSIZE);
++		if (memcmp(tmp, fpattern, BUFSIZE))
++			tst_res(TFAIL, "file was written to");
++		else
++			tst_res(TPASS, "file stayed untouched");
++
++		/* offset hasn't changed */
++		if (off_after == initial_file_offset)
++			tst_res(TPASS, "offset stayed unchanged");
++		else
++			tst_res(TFAIL, "offset changed to %ld",
++				off_after);
++
++		SAFE_CLOSE(fd);
++		return;
++	}
++
++	/* writev() wrote more bytes than bytes preceding invalid iovec */
++	tst_res(TINFO, "writev() has written %ld bytes", TEST_RETURN);
++	if (TEST_RETURN > (long) wr_iovec[0].iov_base) {
++		tst_res(TFAIL, "writev wrote more than expected");
++		SAFE_CLOSE(fd);
++		return;
++	}
++
++	/* file content matches written bytes */
++	SAFE_LSEEK(fd, initial_file_offset, SEEK_SET);
++	SAFE_READ(1, fd, tmp, TEST_RETURN);
++	if (memcmp(tmp, wr_iovec[0].iov_base, TEST_RETURN) == 0) {
++		tst_res(TPASS, "file has expected content");
++	} else {
++		tst_res(TFAIL, "file has unexpected content");
++		tst_res_hexd(TFAIL, wr_iovec[0].iov_base, TEST_RETURN,
++				"expected:");
++		tst_res_hexd(TFAIL, tmp, TEST_RETURN,
++				"actual file content:");
++	}
++
++	/* file offset has been updated according to written bytes */
++	if (off_after == initial_file_offset + TEST_RETURN)
++		tst_res(TPASS, "offset at %ld as expected", off_after);
++	else
++		tst_res(TFAIL, "offset unexpected %ld", off_after);
++
++	SAFE_CLOSE(fd);
++}
++
++static void test_writev(void)
++{
++	test_partially_valid_iovec(0);
++	test_partially_valid_iovec(CHUNK + 1);
++	test_partially_valid_iovec(getpagesize());
++	test_partially_valid_iovec(getpagesize() + 1);
++}
++
++static void setup(void)
++{
++	bad_addr = SAFE_MMAP(0, 1, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS,
++			0, 0);
++}
++
++static struct tst_test test = {
++	.tid = "writev07",
++	.needs_tmpdir = 1,
++	.setup = setup,
++	.test_all = test_writev,
++};
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160920/utimensat-fix-immutable-file-retcodes-for-4.8.0-and-.patch
+++ b/distribution/ltp/include/patches/20160920/utimensat-fix-immutable-file-retcodes-for-4.8.0-and-.patch
@@ -1,0 +1,65 @@
+From 8cc1e10d725c9104c0fc2a31527be8b1d9baa252 Mon Sep 17 00:00:00 2001
+From: Artem Savkov <asavkov@redhat.com>
+Date: Thu, 1 Sep 2016 11:06:13 +0200
+Subject: [PATCH] utimensat: fix immutable file retcodes for 4.8.0 and newer.
+
+Kernel 4.8.0 contains patch "337684a fs: return EPERM on immutable inode" that
+makes operations on immutable files return EPERM instead of EACCESS.
+
+Adjust utimensat test to check new retcode for kernels 4.8.0 and newer.
+
+Signed-off-by: Artem Savkov <asavkov@redhat.com>
+Reviewed-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/syscalls/utimensat/utimensat_tests.sh | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/utimensat/utimensat_tests.sh b/testcases/kernel/syscalls/utimensat/utimensat_tests.sh
+index 4ae8651..708d454 100755
+--- a/testcases/kernel/syscalls/utimensat/utimensat_tests.sh
++++ b/testcases/kernel/syscalls/utimensat/utimensat_tests.sh
+@@ -30,6 +30,15 @@ if tst_kvercmp 2 6 22 ; then
+ 	tst_brkm TCONF "System kernel version is less than 2.6.22,cannot execute test"
+ fi
+ 
++# Starting with 4.8.0 operations on immutable files return EPERM instead of
++# EACCES.
++if tst_kvercmp 4 8 0; then
++	imaccess=EACCES
++else
++	imaccess=EPERM
++fi
++
++
+ RESULT_FILE=$TMPDIR/utimensat.result
+ 
+ TEST_DIR=$TMPDIR/utimensat_tests
+@@ -415,10 +424,10 @@ echo "Testing immutable file, owned by self"
+ echo
+ 
+ echo "***** Testing times==NULL case *****"
+-run_test -W "" 600 "+i" "" EACCES
++run_test -W "" 600 "+i" "" $imaccess
+ 
+ echo "***** Testing times=={ UTIME_NOW, UTIME_NOW } case *****"
+-run_test -W "" 600 "+i" "0 n 0 n" EACCES
++run_test -W "" 600 "+i" "0 n 0 n" $imaccess
+ 
+ echo "***** Testing times=={ UTIME_OMIT, UTIME_OMIT } case *****"
+ run_test -W "" 600 "+i" "0 o 0 o" SUCCESS n n
+@@ -441,10 +450,10 @@ echo "Testing immutable append-only file, owned by self"
+ echo
+ 
+ echo "***** Testing times==NULL case *****"
+-run_test -W "" 600 "+ai" "" EACCES
++run_test -W "" 600 "+ai" "" $imaccess
+ 
+ echo "***** Testing times=={ UTIME_NOW, UTIME_NOW } case *****"
+-run_test -W "" 600 "+ai" "0 n 0 n" EACCES
++run_test -W "" 600 "+ai" "0 n 0 n" $imaccess
+ 
+ echo "***** Testing times=={ UTIME_OMIT, UTIME_OMIT } case *****"
+ run_test -W "" 600 "+ai" "0 o 0 o" SUCCESS n n
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160920/writev-remove-writev03-and-writev04.patch
+++ b/distribution/ltp/include/patches/20160920/writev-remove-writev03-and-writev04.patch
@@ -1,0 +1,761 @@
+From 9a62652bb67a9d5279de6dbbf2576c8aba33eeeb Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Wed, 5 Oct 2016 14:10:57 +0200
+Subject: [PATCH] writev: remove writev03 and writev04
+
+Removed tests are almost identical, and there is now a new
+test: writev07, which is meant to be a replacement.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ doc/testcases/kernel.txt                    |  23 --
+ runtest/ltplite                             |   2 -
+ runtest/stress.part3                        |   2 -
+ runtest/syscalls                            |   2 -
+ testcases/kernel/syscalls/.gitignore        |   2 -
+ testcases/kernel/syscalls/writev/Makefile   |   2 +-
+ testcases/kernel/syscalls/writev/writev03.c | 271 ---------------------
+ testcases/kernel/syscalls/writev/writev04.c | 353 ----------------------------
+ 8 files changed, 1 insertion(+), 656 deletions(-)
+ delete mode 100644 testcases/kernel/syscalls/writev/writev03.c
+ delete mode 100644 testcases/kernel/syscalls/writev/writev04.c
+
+diff --git a/doc/testcases/kernel.txt b/doc/testcases/kernel.txt
+index fa5d686..518ef87 100644
+--- a/doc/testcases/kernel.txt
++++ b/doc/testcases/kernel.txt
+@@ -6897,29 +6897,6 @@
+ 		ltp/testcases/kernel/syscalls/writev/writev02.c
+ 	<\test_location>
+ <\testname>
+-<testname=writev03>
+-	<description>
+-		The testcases are written calling writev() with partially valid data
+-		to overwrite the contents, to write in the beginning and to write in
+-		the end of the file.
+-
+-	<\description>
+-	<test_location>
+-		ltp/testcases/kernel/syscalls/writev/writev03.c
+-	<\test_location>
+-<\testname>
+-<testname=writev04>
+-	<description>
+-		The testcases are written calling writev() with partially valid data
+-		to overwrite the contents, to write in the beginning and to write in
+-		the end of the file. This is same as writev03, but the length of
+-		buffer used here is 8192 bytes.
+-
+-	<\description>
+-	<test_location>
+-		ltp/testcases/kernel/syscalls/writev/writev04.c
+-	<\test_location>
+-<\testname>
+ <testname=writev05>
+ 	<description>
+ 		These testcases are written to test writev() on sparse files. This
+diff --git a/runtest/ltplite b/runtest/ltplite
+index 1b4c5f6..338d6eb 100644
+--- a/runtest/ltplite
++++ b/runtest/ltplite
+@@ -1043,8 +1043,6 @@ write05 write05
+ 
+ writev01 writev01
+ writev02 writev02
+-writev03 writev03
+-writev04 writev04
+ writev05 writev05
+ writev06 writev06
+ writev07 writev07
+diff --git a/runtest/stress.part3 b/runtest/stress.part3
+index effa5fd..8abed95 100644
+--- a/runtest/stress.part3
++++ b/runtest/stress.part3
+@@ -904,8 +904,6 @@ write05 write05
+ 
+ writev01 writev01
+ writev02 writev02
+-writev03 writev03
+-writev04 writev04
+ writev05 writev05
+ writev06 writev06
+ writev07 writev07
+diff --git a/runtest/syscalls b/runtest/syscalls
+index 88f7597..b781241 100644
+--- a/runtest/syscalls
++++ b/runtest/syscalls
+@@ -1422,8 +1422,6 @@ write05 write05
+ 
+ writev01 writev01
+ writev02 writev02
+-writev03 writev03
+-writev04 writev04
+ writev05 writev05
+ writev06 writev06
+ writev07 writev07
+diff --git a/testcases/kernel/syscalls/.gitignore b/testcases/kernel/syscalls/.gitignore
+index f2aeab4..f53cc05 100644
+--- a/testcases/kernel/syscalls/.gitignore
++++ b/testcases/kernel/syscalls/.gitignore
+@@ -1100,8 +1100,6 @@
+ /write/write05
+ /writev/writev01
+ /writev/writev02
+-/writev/writev03
+-/writev/writev04
+ /writev/writev05
+ /writev/writev06
+ /writev/writev07
+diff --git a/testcases/kernel/syscalls/writev/Makefile b/testcases/kernel/syscalls/writev/Makefile
+index 4aa38be..85965e4 100644
+--- a/testcases/kernel/syscalls/writev/Makefile
++++ b/testcases/kernel/syscalls/writev/Makefile
+@@ -19,7 +19,7 @@
+ top_srcdir		?= ../../../..
+ 
+ ifeq ($(UCLINUX),1)
+-FILTER_OUT_MAKE_TARGETS	+= writev02 writev03
++FILTER_OUT_MAKE_TARGETS	+= writev02
+ endif
+ 
+ include $(top_srcdir)/include/mk/testcases.mk
+diff --git a/testcases/kernel/syscalls/writev/writev03.c b/testcases/kernel/syscalls/writev/writev03.c
+deleted file mode 100644
+index e5cdf4b..0000000
+--- a/testcases/kernel/syscalls/writev/writev03.c
++++ /dev/null
+@@ -1,271 +0,0 @@
+-/*
+- *
+- *   Copyright (c) International Business Machines  Corp., 2001
+- *
+- *   This program is free software;  you can redistribute it and/or modify
+- *   it under the terms of the GNU General Public License as published by
+- *   the Free Software Foundation; either version 2 of the License, or
+- *   (at your option) any later version.
+- *
+- *   This program is distributed in the hope that it will be useful,
+- *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+- *   the GNU General Public License for more details.
+- *
+- *   You should have received a copy of the GNU General Public License
+- *   along with this program;  if not, write to the Free Software
+- *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+- */
+-
+-/*
+- * NAME
+- *	writev03.c
+- *
+- * DESCRIPTION
+- *	The testcases are written calling writev() with partially valid data
+- *	to overwrite the contents, to write in the beginning and to write in
+- *	the end of the file.
+- *
+- * USAGE:  <for command-line>
+- *      writev03 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+- *      where,  -c n : Run n copies concurrently.
+- *              -e   : Turn on errno logging.
+- *              -i n : Execute test n times.
+- *              -I x : Execute test for x seconds.
+- *              -P x : Pause for x seconds between iterations.
+- *              -t   : Turn on syscall timing.
+- *
+- * History
+- *	07/2001 John George
+- *		-Ported
+- *      04/2002 wjhuie sigset cleanups
+- *
+- * Restrictions
+- *	NONE
+- */
+-
+-#include <sys/types.h>
+-#include <sys/uio.h>
+-#include <sys/mman.h>
+-#include <unistd.h>
+-#include <signal.h>
+-#include <fcntl.h>
+-#include <memory.h>
+-#include <errno.h>
+-#include "test.h"
+-
+-#define	K_1	1024
+-
+-#define	NBUFS		4
+-#define	CHUNK		64	/* single chunk */
+-#define	MAX_IOVEC	4
+-#define	DATA_FILE	"writev_data_file"
+-
+-char buf1[K_1], buf2[K_1], buf3[K_1];
+-char *bad_addr = 0;
+-
+-struct iovec wr_iovec[MAX_IOVEC] = {
+-	/* testcase #1 */
+-	{buf1 + (CHUNK * 6), CHUNK},
+-	{(caddr_t) - 1, CHUNK},
+-	{buf1 + (CHUNK * 8), CHUNK},
+-	{NULL, 0}
+-};
+-
+-char name[K_1], f_name[K_1];
+-int fd[2], in_sighandler;
+-char *buf_list[NBUFS];
+-
+-char *TCID = "writev03";
+-int TST_TOTAL = 1;
+-
+-void sighandler(int);
+-void l_seek(int, off_t, int);
+-void setup(void);
+-void cleanup(void);
+-
+-int main(int argc, char **argv)
+-{
+-	int lc;
+-
+-	int nbytes;
+-
+-	tst_parse_opts(argc, argv, NULL, NULL);
+-
+-	setup();
+-
+-	for (lc = 0; TEST_LOOPING(lc); lc++) {
+-
+-		tst_count = 0;
+-
+-		buf_list[0] = buf1;
+-		buf_list[1] = buf2;
+-		buf_list[2] = buf3;
+-		buf_list[3] = NULL;
+-
+-		fd[1] = -1;	/* Invalid file descriptor */
+-
+-		if (signal(SIGTERM, sighandler) == SIG_ERR)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "signal(SIGTERM, ..) failed");
+-
+-		if (signal(SIGPIPE, sighandler) == SIG_ERR)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "signal(SIGPIPE, ..) failed");
+-
+-		memset(buf_list[0], 0, K_1);
+-		memset(buf_list[1], 0, K_1);
+-
+-		if ((fd[0] = open(f_name, O_WRONLY | O_CREAT, 0666)) == -1)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "open(.., O_WRONLY|O_CREAT, ..) failed");
+-		else if ((nbytes = write(fd[0], buf_list[1], K_1)) != K_1)
+-			tst_brkm(TFAIL | TERRNO, cleanup, "write failed");
+-
+-		if (close(fd[0]) < 0)
+-			tst_brkm(TBROK | TERRNO, cleanup, "close failed");
+-
+-		if ((fd[0] = open(f_name, O_RDWR, 0666)) == -1)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "open(.., O_RDWR, ..) failed");
+-//block1:
+-		tst_resm(TINFO, "Enter block 1");
+-
+-		/*
+-		 * In this block we are trying to call writev() with
+-		 * partially valid data. This should return the valid number
+-		 * of bytes written in the vector. If it returns EFAULT, it
+-		 * is an error. And after returning the number of valid
+-		 * bytes written, the check should be made to verify the
+-		 * contents of the first valid write() scheduled.
+-		 */
+-
+-		if (writev(fd[0], wr_iovec, 3) == -1) {
+-			if (errno == EFAULT)
+-				tst_resm(TFAIL, "Got EFAULT");
+-		} else {
+-			l_seek(fd[0], 0, 0);
+-			read(fd[0], buf_list[0], CHUNK);
+-			if (memcmp(buf_list[0], buf_list[1], CHUNK) != 0)
+-				tst_resm(TFAIL, "writev overwrote the file");
+-		}
+-		tst_resm(TINFO, "Exit block 1");
+-
+-//block2:
+-		tst_resm(TINFO, "Enter block 2");
+-
+-		/*
+-		 * In this block we are trying to over write the contents by
+-		 * calling writev() with partially valid data. It should
+-		 * return the valid number of bytes written but not EFAULT.
+-		 * Also the check should be made whether the initial write()
+-		 * scheduled is done correctly or not.
+-		 */
+-		l_seek(fd[0], 0, 0);
+-		if (writev(fd[0], wr_iovec, 3) == -1) {
+-			if (errno == EFAULT)
+-				tst_resm(TFAIL, "Got EFAULT");
+-		} else {
+-			l_seek(fd[0], 0, 0);
+-			read(fd[0], buf_list[0], CHUNK);
+-			if (memcmp(buf_list[0], buf_list[1], CHUNK) != 0)
+-				tst_resm(TFAIL, "writev overwrote the file");
+-		}
+-		tst_resm(TINFO, "Exit block 2");
+-
+-//block3:
+-		tst_resm(TINFO, "Enter block 3");
+-
+-		/*
+-		 * In this block, we are trying to call writev() by going to
+-		 * some end position of the file. Here writev() is called
+-		 * with partially valid data, and this will return the
+-		 * number of valid bytes written and not EFAULT. Also, the
+-		 * check should be made whether the inital write() that is
+-		 * scheduled with valid data is done correctly done or not.
+-		 */
+-
+-		l_seek(fd[0], 8192, 0);
+-		if (writev(fd[0], wr_iovec, 3) == -1) {
+-			if (errno == EFAULT)
+-				tst_resm(TFAIL, "Got EFAULT");
+-		} else {
+-			l_seek(fd[0], 0, 0);
+-			read(fd[0], buf_list[0], CHUNK);
+-			if (memcmp(buf_list[0], buf_list[1], CHUNK) != 0) {
+-				tst_resm(TFAIL, "writev overwrote the file");
+-			}
+-		}
+-
+-		tst_resm(TINFO, "Exit block 3");
+-	}
+-	cleanup();
+-	tst_exit();
+-}
+-
+-/*
+- * setup()
+- *	performs all ONE TIME setup for this test
+- */
+-void setup(void)
+-{
+-
+-	tst_sig(FORK, DEF_HANDLER, cleanup);
+-
+-	/* Pause if that option was specified.
+-	 * TEST_PAUSE contains the code to fork the test with the -i option.
+-	 * You want to make sure you do this before you create your temporary
+-	 * directory.
+-	 */
+-	TEST_PAUSE;
+-
+-	strcpy(name, DATA_FILE);
+-	sprintf(f_name, "%s.%d", name, getpid());
+-
+-	bad_addr = mmap(0, 1, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+-	if (bad_addr == MAP_FAILED) {
+-		tst_brkm(TBROK, cleanup, "mmap failed");
+-	}
+-	wr_iovec[1].iov_base = bad_addr;
+-	tst_tmpdir();
+-}
+-
+-/*
+- * cleanup()
+- *	performs all ONE TIME cleanup for this test at
+- *	completion or premature exit
+- */
+-void cleanup(void)
+-{
+-	close(fd[0]);
+-	close(fd[1]);
+-
+-	if (unlink(f_name) == -1)
+-		tst_resm(TFAIL, "unlink failed");
+-	tst_rmdir();
+-
+-}
+-
+-void sighandler(int sig)
+-{
+-	switch (sig) {
+-	case SIGTERM:
+-		break;
+-	case SIGPIPE:
+-		++in_sighandler;
+-		return;
+-	default:
+-		tst_resm(TBROK, "sighandler received invalid signal : %d", sig);
+-		break;
+-	}
+-}
+-
+-/*
+- * l_seek()
+- *	Wrap around for regular lseek function for giving error message
+- */
+-void l_seek(int fdesc, off_t offset, int whence)
+-{
+-	if (lseek(fdesc, offset, whence) == -1)
+-		tst_brkm(TBROK | TERRNO, cleanup, "lseek failed");
+-}
+diff --git a/testcases/kernel/syscalls/writev/writev04.c b/testcases/kernel/syscalls/writev/writev04.c
+deleted file mode 100644
+index 954b1fa..0000000
+--- a/testcases/kernel/syscalls/writev/writev04.c
++++ /dev/null
+@@ -1,353 +0,0 @@
+-/*
+- *
+- *   Copyright (c) International Business Machines  Corp., 2001
+- *
+- *   This program is free software;  you can redistribute it and/or modify
+- *   it under the terms of the GNU General Public License as published by
+- *   the Free Software Foundation; either version 2 of the License, or
+- *   (at your option) any later version.
+- *
+- *   This program is distributed in the hope that it will be useful,
+- *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+- *   the GNU General Public License for more details.
+- *
+- *   You should have received a copy of the GNU General Public License
+- *   along with this program;  if not, write to the Free Software
+- *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+- */
+-
+-/*
+- * NAME
+- *	writev04.c
+- *
+- * DESCRIPTION
+- *	The testcases are written calling writev() with partially valid data
+- *	to overwrite the contents, to write in the beginning and to write in
+- *	the end of the file. This is same as writev03.c, but the length of
+- *	buffer used here is 8192 bytes.
+- *
+- * USAGE:  <for command-line>
+- *      writev04 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+- *      where,  -c n : Run n copies concurrently.
+- *              -e   : Turn on errno logging.
+- *              -i n : Execute test n times.
+- *              -I x : Execute test for x seconds.
+- *              -P x : Pause for x seconds between iterations.
+- *              -t   : Turn on syscall timing.
+- *
+- * History
+- *	07/2001 John George
+- *		-Ported
+- *      04/2002 wjhuie sigset cleanups
+- *
+- * Restrictions
+- *	NONE
+- */
+-#include <sys/types.h>
+-#include <sys/uio.h>
+-#include <sys/mman.h>
+-#include <unistd.h>
+-#include <signal.h>
+-#include <fcntl.h>
+-#include <memory.h>
+-#include <errno.h>
+-#include "test.h"
+-
+-#define	K_1	8192
+-
+-#define	NBUFS		4
+-#define	CHUNK		64	/* single chunk */
+-#define	MAX_IOVEC	4
+-#define	DATA_FILE	"writev_data_file"
+-
+-char buf1[K_1], buf2[K_1], buf3[K_1];
+-char *bad_addr = 0;
+-
+-struct iovec wr_iovec[MAX_IOVEC] = {
+-	/* testcase #1 */
+-	{buf1 + (CHUNK * 6), CHUNK},
+-	{(caddr_t) - 1, CHUNK},
+-	{buf1 + (CHUNK * 8), CHUNK},
+-	{NULL, 0}
+-};
+-
+-char name[K_1], f_name[K_1];
+-int fd[2], in_sighandler;
+-char *buf_list[NBUFS];
+-
+-char *TCID = "writev04";
+-int TST_TOTAL = 1;
+-
+-void sighandler(int);
+-long l_seek(int, long, int);
+-void setup(void);
+-void cleanup(void);
+-int fail;
+-
+-#if !defined(UCLINUX)
+-
+-int main(int argc, char **argv)
+-{
+-	int lc;
+-
+-	int nbytes;
+-
+-	tst_parse_opts(argc, argv, NULL, NULL);
+-
+-	setup();		/* set "tstdir", and "testfile" vars */
+-
+-	/* The following loop checks looping state if -i option given */
+-	for (lc = 0; TEST_LOOPING(lc); lc++) {
+-
+-		/* reset tst_count in case we are looping */
+-		tst_count = 0;
+-
+-		buf_list[0] = buf1;
+-		buf_list[1] = buf2;
+-		buf_list[2] = buf3;
+-		buf_list[3] = NULL;
+-
+-		fd[1] = -1;	/* Invalid file descriptor */
+-
+-		if (signal(SIGTERM, sighandler) == SIG_ERR) {
+-			perror("signal");
+-			tst_resm(TFAIL, "signal() SIGTERM FAILED");
+-			cleanup();
+-		}
+-
+-		if (signal(SIGPIPE, sighandler) == SIG_ERR) {
+-			perror("signal");
+-			tst_resm(TFAIL, "signal() SIGPIPE FAILED");
+-			cleanup();
+-		}
+-
+-		memset(buf_list[0], 0, K_1);
+-		memset(buf_list[1], 0, K_1);
+-
+-		if ((fd[0] = open(f_name, O_WRONLY | O_CREAT, 0666)) < 0) {
+-			tst_resm(TFAIL, "open(2) failed: fname = %s, "
+-				 "errno = %d", f_name, errno);
+-			cleanup();
+-		} else {
+-			if ((nbytes = write(fd[0], buf_list[1], K_1)) != K_1) {
+-				tst_resm(TFAIL, "write(2) failed: nbytes "
+-					 "= %d, errno = %d", nbytes, errno);
+-				cleanup();
+-			}
+-		}
+-
+-		if (close(fd[0]) < 0) {
+-			tst_resm(TFAIL, "close failed: errno = %d", errno);
+-			cleanup();
+-		}
+-
+-		if ((fd[0] = open(f_name, O_RDWR, 0666)) < 0) {
+-			tst_brkm(TFAIL, cleanup, "open failed: fname = %s, errno = %d",
+-				 f_name, errno);
+-		}
+-//block1:
+-		tst_resm(TINFO, "Enter block 1");
+-		fail = 0;
+-
+-		/*
+-		 * In this block we are trying to call writev() with
+-		 * partially valid data. This should return the valid number
+-		 * of bytes written in the vector. If it returns EFAULT, it
+-		 * is an error. And after returning the number of valid
+-		 * bytes written, the check should be made to verify the
+-		 * contents of the first valid write() scheduled.
+-		 */
+-		if (writev(fd[0], wr_iovec, 3) < 0) {
+-			fail = 1;
+-			if (errno == EFAULT) {
+-				tst_resm(TFAIL, "Got error EFAULT");
+-			} else {
+-				tst_resm(TFAIL, "Received unexpected error: %d",
+-					 errno);
+-			}
+-		} else {
+-			l_seek(fd[0], 0, 0);
+-			read(fd[0], buf_list[0], CHUNK);
+-			if (memcmp(buf_list[0], buf_list[1], CHUNK) != 0) {
+-				tst_resm(TFAIL, "writev overwrote the file");
+-				fail = 1;
+-			}
+-		}
+-
+-		if (fail) {
+-			tst_resm(TINFO, "block 1 FAILED");
+-		} else {
+-			tst_resm(TINFO, "block 1 PASSED");
+-		}
+-		tst_resm(TINFO, "Exit block 1");
+-
+-//block2:
+-		tst_resm(TINFO, "Enter block 2");
+-		fail = 0;
+-
+-		/*
+-		 * In this block we are trying to over write the contents by
+-		 * calling writev() with partially valid data. It should
+-		 * return the valid number of bytes written but not EFAULT.
+-		 * Also the check should be made whether the initial write()
+-		 * scheduled is done correctly or not.
+-		 */
+-		l_seek(fd[0], 0, 0);
+-		if (writev(fd[0], wr_iovec, 3) < 0) {
+-			fail = 1;
+-			if (errno == EFAULT) {
+-				tst_resm(TFAIL, "Got error EFAULT");
+-			} else {
+-				tst_resm(TFAIL, "Received unexpected error: %d",
+-					 errno);
+-			}
+-		} else {
+-			l_seek(fd[0], 0, 0);
+-			read(fd[0], buf_list[0], CHUNK);
+-			if (memcmp(buf_list[0], buf_list[1], CHUNK) != 0) {
+-				tst_resm(TFAIL, "writev overwrote the file");
+-				fail = 1;
+-			}
+-		}
+-
+-		if (fail) {
+-			tst_resm(TINFO, "block 2 FAILED");
+-		} else {
+-			tst_resm(TINFO, "block 2 PASSED");
+-		}
+-		tst_resm(TINFO, "Exit block 2");
+-
+-//block3:
+-		tst_resm(TINFO, "Enter block 3");
+-		fail = 0;
+-
+-		/*
+-		 * In this block, we are trying to call writev() by going to
+-		 * some end position of the file. Here writev() is called
+-		 * with partially valid data, and this will return the
+-		 * number of valid bytes written and not EFAULT. Also, the
+-		 * check should be made whether the inital write() that is
+-		 * scheduled with valid data is done correctly.
+-		 */
+-
+-		l_seek(fd[0], 8192, 0);
+-		if (writev(fd[0], wr_iovec, 3) < 0) {
+-			fail = 1;
+-			if (errno == EFAULT) {
+-				tst_resm(TFAIL, "Got error EFAULT");
+-			} else {
+-				tst_resm(TFAIL, "Received unexpected error: %d",
+-					 errno);
+-			}
+-		} else {
+-			l_seek(fd[0], 0, 0);
+-			read(fd[0], buf_list[0], CHUNK);
+-			if (memcmp(buf_list[0], buf_list[1], CHUNK) != 0) {
+-				tst_resm(TFAIL, "writev overwrote the file");
+-				fail = 1;
+-			}
+-		}
+-
+-		if (fail) {
+-			tst_resm(TINFO, "block 3 FAILED");
+-		} else {
+-			tst_resm(TINFO, "block 3 PASSED");
+-		}
+-		tst_resm(TINFO, "Exit block 3");
+-	}
+-	close(fd[0]);
+-	close(fd[1]);
+-	cleanup();
+-	tst_exit();
+-}
+-
+-#else
+-
+-int main(void)
+-{
+-	tst_resm(TINFO, "test is not available on uClinux");
+-	tst_exit();
+-}
+-
+-#endif /* if !defined(UCLINUX) */
+-
+-/*
+- * setup()
+- *	performs all ONE TIME setup for this test
+- */
+-void setup(void)
+-{
+-
+-	tst_sig(FORK, DEF_HANDLER, cleanup);
+-
+-	TEST_PAUSE;
+-
+-	/* Create a unique temporary directory and chdir() to it. */
+-	tst_tmpdir();
+-
+-	strcpy(name, DATA_FILE);
+-	sprintf(f_name, "%s.%d", name, getpid());
+-
+-	bad_addr = mmap(0, 1, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+-	if (bad_addr == MAP_FAILED) {
+-		tst_brkm(TBROK, cleanup, "mmap failed");
+-	}
+-	wr_iovec[1].iov_base = bad_addr;
+-
+-}
+-
+-/*
+- * cleanup()
+- *	performs all ONE TIME cleanup for this test at
+- *	completion or premature exit
+- */
+-void cleanup(void)
+-{
+-
+-	if (unlink(f_name) < 0) {
+-		tst_resm(TFAIL, "unlink Failed--file = %s, errno = %d",
+-			 f_name, errno);
+-	}
+-	tst_rmdir();
+-
+-}
+-
+-/*
+- * sighandler()
+- *	Signal handler function for SIGTERM and SIGPIPE
+- */
+-void sighandler(int sig)
+-{
+-	switch (sig) {
+-	case SIGTERM:
+-		break;
+-	case SIGPIPE:
+-		++in_sighandler;
+-		return;
+-	default:
+-		tst_resm(TFAIL, "sighandler() received invalid signal "
+-			 ": %d", sig);
+-		break;
+-	}
+-
+-	if ((unlink(f_name) < 0) && (errno != ENOENT)) {
+-		tst_resm(TFAIL, "unlink Failed--file = %s, errno = %d",
+-			 f_name, errno);
+-		cleanup();
+-	}
+-	exit(sig);
+-}
+-
+-/*
+- * l_seek()
+- *	Wrap around for regular lseek function for giving error message
+- */
+-long l_seek(int fdesc, long offset, int whence)
+-{
+-	if (lseek(fdesc, offset, whence) < 0) {
+-		tst_resm(TFAIL, "lseek Failed : errno = %d", errno);
+-		fail = 1;
+-	}
+-	return 0;
+-}
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20160920/writev01-rewrite-and-drop-partially-valid-iovec-test.patch
+++ b/distribution/ltp/include/patches/20160920/writev01-rewrite-and-drop-partially-valid-iovec-test.patch
@@ -1,0 +1,525 @@
+From b3671b7fa9444c2a9ad71f48817c7ef4afaa148b Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 6 Oct 2016 15:43:33 +0200
+Subject: [PATCH] writev01: rewrite and drop partially valid iovec tests
+
+Convert to newlib style, and drop tests for partially valid
+iovec lists, there are now tested in writev07.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/syscalls/writev/writev01.c | 465 +++++++---------------------
+ 1 file changed, 110 insertions(+), 355 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/writev/writev01.c b/testcases/kernel/syscalls/writev/writev01.c
+index 8e4f756..b02abba 100644
+--- a/testcases/kernel/syscalls/writev/writev01.c
++++ b/testcases/kernel/syscalls/writev/writev01.c
+@@ -1,6 +1,6 @@
+ /*
+- *
+  *   Copyright (c) International Business Machines  Corp., 2001
++ *                 Linux Test Project, 2016
+  *
+  *   This program is free software;  you can redistribute it and/or modify
+  *   it under the terms of the GNU General Public License as published by
+@@ -13,386 +13,141 @@
+  *   the GNU General Public License for more details.
+  *
+  *   You should have received a copy of the GNU General Public License
+- *   along with this program;  if not, write to the Free Software
+- *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ *   along with this program;
+  */
+ 
+ /*
+- * NAME
+- *	writev01.c
+- *
+  * DESCRIPTION
+  *	Testcase to check the basic functionality of writev(2) system call.
+- *
+- * ALGORITHM
+- *	Create a IO vector, and attempt to writev various components of it.
+- *
+- * USAGE:  <for command-line>
+- *	writev01 [-c n] [-e] [-i n] [-I x] [-P x] [-t]
+- *	where,	-c n : Run n copies concurrently.
+- *		-e   : Turn on errno logging.
+- *		-i n : Execute test n times.
+- *		-I x : Execute test for x seconds.
+- *		-P x : Pause for x seconds between iterations.
+- *		-t   : Turn on syscall timing.
+- *
+- * History
+- *	07/2001 John George
+- *		-Ported
+- *      04/2002 wjhuie sigset cleanups
+- *     06/2002 Shaobo Li
+- *             fix testcase 7, add each testcase comment.
+- *
+- * Restrictions
+- *	None
++ *	Create IO vectors and attempt to writev various components of it.
+  */
+ 
+-#include <stdio.h>
+-#include <sys/types.h>
++#include <errno.h>
+ #include <signal.h>
+ #include <sys/uio.h>
+-#include <sys/fcntl.h>
+-#include <memory.h>
+-#include <errno.h>
+-#include "test.h"
+-#include <sys/mman.h>
+-
+-#define	K_1	1024
+-#define	M_1	K_1 * K_1
+-#define	G_1	M_1 * K_1
+-
+-#define	NBUFS		4
+-#define	CHUNK		64	/* single chunk */
+-#define	MAX_IOVEC	16
+-#define	DATA_FILE	"writev_data_file"
+-
+-char buf1[K_1], buf2[K_1], buf3[K_1];
++#include "tst_test.h"
+ 
+-struct iovec wr_iovec[MAX_IOVEC] = {
+-	/* iov_base *//* iov_len */
++#define	CHUNK		64
++#define	TESTFILE	"writev_data_file"
+ 
+-	/* testcase# 1 */
+-	{buf1, -1},
+-	{(buf1 + CHUNK), CHUNK},
+-	{(buf1 + CHUNK * 2), CHUNK},
++static int valid_fd;
++static int invalid_fd = -1;
++static int pipe_fd[2];
+ 
+-	/* testcase# 2 */
+-	{(buf1 + CHUNK * 3), G_1},
+-	{(buf1 + CHUNK * 4), G_1},
+-	{(buf1 + CHUNK * 5), G_1},
++static char buf[CHUNK * 4];
+ 
+-	/* testcase# 3 */
+-	{(buf1 + CHUNK * 6), CHUNK},
+-	{(caddr_t) - 1, CHUNK},
+-	{(buf1 + CHUNK * 8), CHUNK},
+-
+-	/* testcase# 4 */
+-	{(buf1 + CHUNK * 9), CHUNK},
+-
+-	/* testcase# 5 */
+-	{(buf1 + CHUNK * 10), CHUNK},
+-
+-	/* testcase# 6 */
+-	{(buf1 + CHUNK * 11), CHUNK},
+-
+-	/* testcase# 7 */
+-	{(buf1 + CHUNK * 12), CHUNK},
+-
+-	/* testcase# 8 */
+-	{(buf1 + CHUNK * 13), 0},
+-
+-	/* testcase# 7 */
+-	{NULL, 0},
+-	{NULL, 0}
++struct iovec iovec_badlen[] = {
++	{ buf, -1 },
++	{ buf + CHUNK, CHUNK },
++	{ buf + CHUNK * 2, CHUNK },
+ };
+ 
+-char name[K_1], f_name[K_1];
+-
+-char *bad_addr = 0;
+-
+-int fd[4], in_sighandler;
+-int pfd[2];			/* pipe fd's */
+-char *buf_list[NBUFS];
+-
+-void sighandler(int);
+-int fill_mem(char *, int, int);
+-void init_buffs(char *[]);
+-void setup(void);
+-void cleanup(void);
+-
+-char *TCID = "writev01";
+-int TST_TOTAL = 1;
+-
+-int main(int argc, char **argv)
+-{
+-	int nbytes, ret;
+-
+-	int lc;
+-
+-	tst_parse_opts(argc, argv, NULL, NULL);
+-
+-	setup();
+-
+-	for (lc = 0; TEST_LOOPING(lc); lc++) {
+-
+-		tst_count = 0;
+-
+-		buf_list[0] = buf1;
+-		buf_list[1] = buf2;
+-		buf_list[2] = buf3;
+-		buf_list[3] = NULL;
+-
+-		fd[1] = -1;	/* Invalid file descriptor  */
+-
+-		if (signal(SIGTERM, sighandler) == SIG_ERR)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "signal(SIGTERM, ..) failed");
+-
+-		if (signal(SIGPIPE, sighandler) == SIG_ERR)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "signal(SIGPIPE, ..) failed");
+-
+-		init_buffs(buf_list);
+-
+-		if ((fd[0] = open(f_name, O_WRONLY | O_CREAT, 0666)) == -1)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "open(.., O_WRONLY|O_CREAT, ..) failed");
+-		else if ((nbytes = write(fd[0], buf_list[2], K_1)) != K_1)
+-			tst_brkm(TBROK | TERRNO, cleanup, "write failed");
+-
+-		if (close(fd[0]) == -1)
+-			tst_brkm(TBROK | TERRNO, cleanup, "close failed");
+-
+-		if ((fd[0] = open(f_name, O_RDWR, 0666)) == -1)
+-			tst_brkm(TBROK | TERRNO, cleanup, "open failed");
+-//block1: /* given vector length -1, writev return EINVAL. */
+-		tst_resm(TPASS, "Enter Block 1");
+-
+-		TEST(writev(fd[0], wr_iovec, 1));
+-		if (TEST_RETURN == -1) {
+-			if (TEST_ERRNO == EINVAL)
+-				tst_resm(TPASS, "Received EINVAL as expected");
+-			else
+-				tst_resm(TFAIL, "Expected errno = EINVAL, "
+-					 "got %d", TEST_ERRNO);
+-		} else
+-			tst_resm(TFAIL, "writev failed to fail");
+-		tst_resm(TINFO, "Exit block 1");
+-
+-//block2:
+-		/* This testcases doesn't look like what it intent to do
+-		 * 1. it is not using the wr_iovec initialized
+-		 * 2. read() and following message is not consistent
+-		 */
+-		tst_resm(TPASS, "Enter block 2");
+-
+-		if (lseek(fd[0], CHUNK * 6, 0) == -1)
+-			tst_resm(TBROK | TERRNO, "block2: 1st lseek failed");
+-
+-		if ((ret = writev(fd[0], (wr_iovec + 6), 3)) == CHUNK) {
+-			if (lseek(fd[0], CHUNK * 6, 0) == -1)
+-				tst_brkm(TBROK | TERRNO, cleanup,
+-					 "block2: 2nd lseek failed");
+-			if ((nbytes = read(fd[0], buf_list[0], CHUNK)) != CHUNK)
+-				tst_resm(TFAIL, "read failed; expected nbytes "
+-					 "= 1024, got = %d", nbytes);
+-			else if (memcmp((buf_list[0] + CHUNK * 6),
+-					(buf_list[2] + CHUNK * 6), CHUNK) != 0)
+-				tst_resm(TFAIL, "writev over "
+-					 "wrote %s", f_name);
+-		} else
+-			tst_resm(TFAIL | TERRNO, "writev failed unexpectedly");
+-		tst_resm(TINFO, "Exit block 2");
+-
+-//block3: /* given 1 bad vector buffer with good ones, writev success */
+-		tst_resm(TPASS, "Enter block 3");
+-
+-		if (lseek(fd[0], CHUNK * 6, 0) == -1)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "block3: 1st lseek failed");
+-		if ((nbytes = writev(fd[0], (wr_iovec + 6), 3)) == -1) {
+-			if (errno == EFAULT)
+-				tst_resm(TFAIL, "Got EFAULT");
+-		}
+-		if (lseek(fd[0], 0, 0) == -1)
+-			tst_brkm(TBROK, cleanup, "block3: 2nd lseek failed");
+-		if ((nbytes = read(fd[0], buf_list[0], K_1)) != K_1) {
+-			tst_resm(TFAIL | TERRNO,
+-				 "read failed; expected nbytes = 1024, got = %d",
+-				 nbytes);
+-		} else if (memcmp((buf_list[0] + CHUNK * 6),
+-				  (buf_list[2] + CHUNK * 6), CHUNK * 3) != 0)
+-			tst_resm(TFAIL, "writev overwrote file");
+-
+-		tst_resm(TINFO, "Exit block 3");
+-
+-//block4: /* given bad file descriptor, writev return EBADF. */
+-		tst_resm(TPASS, "Enter block 4");
+-
+-		TEST(writev(fd[1], (wr_iovec + 9), 1));
+-		if (TEST_RETURN == -1) {
+-			if (TEST_ERRNO == EBADF)
+-				tst_resm(TPASS, "Received EBADF as expected");
+-			else
+-				tst_resm(TFAIL, "expected errno = EBADF, "
+-					 "got %d", TEST_ERRNO);
+-		} else
+-			tst_resm(TFAIL, "writev returned a " "positive value");
+-
+-		tst_resm(TINFO, "Exit block 4");
+-
+-//block5: /* given invalid vector count, writev return EINVAL */
+-		tst_resm(TPASS, "Enter block 5");
+-
+-		TEST(writev(fd[0], (wr_iovec + 10), -1));
+-		if (TEST_RETURN == -1) {
+-			if (TEST_ERRNO == EINVAL)
+-				tst_resm(TPASS, "Received EINVAL as expected");
+-			else
+-				tst_resm(TFAIL, "expected errno = EINVAL, "
+-					 "got %d", TEST_ERRNO);
+-		} else
+-			tst_resm(TFAIL, "writev returned a " "positive value");
+-
+-		tst_resm(TINFO, "Exit block 5");
+-
+-//block6: /* given no buffer vector, writev success */
+-		tst_resm(TPASS, "Enter block 6");
+-
+-		TEST(writev(fd[0], (wr_iovec + 11), 0));
+-		if (TEST_RETURN == -1)
+-			tst_resm(TFAIL | TTERRNO, "writev failed");
+-		else
+-			tst_resm(TPASS, "writev wrote 0 iovectors");
+-
+-		tst_resm(TINFO, "Exit block 6");
+-
+-//block7:
+-		/* given 4 vectors, 2 are NULL, 1 with 0 length and 1 with fixed length,
+-		 * writev success writing fixed length.
+-		 */
+-		tst_resm(TPASS, "Enter block 7");
+-
+-		if (lseek(fd[0], CHUNK * 12, 0) == -1)
+-			tst_resm(TBROK, "lseek failed");
+-		else if ((ret = writev(fd[0], (wr_iovec + 12), 4)) != CHUNK)
+-			tst_resm(TFAIL, "writev failed writing %d bytes, "
+-				 "followed by two NULL vectors", CHUNK);
+-		else
+-			tst_resm(TPASS, "writev passed writing %d bytes, "
+-				 "followed by two NULL vectors", CHUNK);
+-
+-		tst_resm(TINFO, "Exit block 7");
++struct iovec iovec_simple[] = {
++	{ buf, CHUNK },
++};
+ 
+-//block8: /* try to write to a closed pipe, writev return EPIPE. */
+-		tst_resm(TPASS, "Enter block 8");
++struct iovec iovec_zero_null[] = {
++	{ buf, CHUNK },
++	{ buf + CHUNK, 0 },
++	{ NULL, 0 },
++	{ NULL, 0 }
++};
+ 
+-		if (pipe(pfd) == -1)
+-			tst_resm(TFAIL | TERRNO, "pipe failed");
+-		else {
+-			if (close(pfd[0]) == -1)
+-				tst_resm(TFAIL | TERRNO, "close failed");
+-			else if (writev(pfd[1], (wr_iovec + 12), 1) == -1 &&
+-				 in_sighandler) {
+-				if (errno == EPIPE)
+-					tst_resm(TPASS, "Received EPIPE as "
+-						 "expected");
+-				else
+-					tst_resm(TFAIL | TERRNO,
+-						 "didn't get EPIPE");
+-			} else
+-				tst_resm(TFAIL, "writev returned a positive "
+-					 "value");
+-		}
+-		tst_resm(TINFO, "Exit block 8");
+-	}
+-	cleanup();
+-	tst_exit();
+-}
++struct testcase_t {
++	const char *desc;
++	int *pfd;
++	struct iovec (*piovec)[];
++	int iovcnt;
++	int exp_ret;
++	int exp_errno;
++} testcases[] = {
++	{
++		.desc = "invalid iov_len",
++		.pfd = &valid_fd,
++		.piovec = &iovec_badlen,
++		.iovcnt = ARRAY_SIZE(iovec_badlen),
++		.exp_ret = -1,
++		.exp_errno = EINVAL
++	},
++	{
++		.desc = "invalid fd",
++		.pfd = &invalid_fd,
++		.piovec = &iovec_simple,
++		.iovcnt = ARRAY_SIZE(iovec_simple),
++		.exp_ret = -1,
++		.exp_errno = EBADF
++	},
++	{
++		.desc = "invalid iovcnt",
++		.pfd = &valid_fd,
++		.piovec = &iovec_simple,
++		.iovcnt = -1,
++		.exp_ret = -1,
++		.exp_errno = EINVAL
++	},
++	{
++		.desc = "zero iovcnt",
++		.pfd = &valid_fd,
++		.piovec = &iovec_simple,
++		.iovcnt = 0,
++		.exp_ret = 0,
++	},
++	{
++		.desc = "NULL and zero length iovec",
++		.pfd = &valid_fd,
++		.piovec = &iovec_zero_null,
++		.iovcnt = ARRAY_SIZE(iovec_zero_null),
++		.exp_ret = CHUNK,
++	},
++	{
++		.desc = "write to closed pipe",
++		.pfd = &(pipe_fd[1]),
++		.piovec = &iovec_simple,
++		.iovcnt = ARRAY_SIZE(iovec_simple),
++		.exp_ret = -1,
++		.exp_errno = EPIPE,
++	},
++};
+ 
+ void setup(void)
+ {
++	sigset_t block_mask;
+ 
+-	tst_sig(FORK, sighandler, cleanup);
+-
+-	TEST_PAUSE;
+-
+-	tst_tmpdir();
+-
+-	strcpy(name, DATA_FILE);
+-	sprintf(f_name, "%s.%d", name, getpid());
+-
+-	bad_addr = mmap(0, 1, PROT_NONE,
+-			MAP_PRIVATE_EXCEPT_UCLINUX | MAP_ANONYMOUS, 0, 0);
+-	if (bad_addr == MAP_FAILED)
+-		tst_brkm(TBROK | TERRNO, cleanup, "mmap failed");
+-	wr_iovec[7].iov_base = bad_addr;
+-
+-}
+-
+-void cleanup(void)
+-{
+-	if (munmap(bad_addr, 1) == -1)
+-		tst_resm(TBROK | TERRNO, "munmap failed");
+-
+-	close(fd[0]);
+-	close(fd[1]);
+-
+-	if (unlink(f_name) == -1)
+-		tst_resm(TBROK | TERRNO, "unlink failed");
++	sigemptyset(&block_mask);
++	sigaddset(&block_mask, SIGPIPE);
++	sigprocmask(SIG_BLOCK, &block_mask, NULL);
+ 
+-	tst_rmdir();
++	valid_fd = SAFE_OPEN(TESTFILE, O_RDWR | O_CREAT, 0644);
+ 
++	SAFE_PIPE(pipe_fd);
++	SAFE_CLOSE(pipe_fd[0]);
+ }
+ 
+-void init_buffs(char *pbufs[])
++static void test_writev(unsigned int i)
+ {
+-	int i;
+-
+-	for (i = 0; pbufs[i] != NULL; i++) {
+-		switch (i) {
+-		case 0:
+-
+-		case 1:
+-			fill_mem(pbufs[i], 0, 1);
+-			break;
+-
+-		case 2:
+-			fill_mem(pbufs[i], 1, 0);
+-			break;
+-
+-		default:
+-			tst_brkm(TBROK, cleanup, "error detected: init_buffs");
+-		}
++	struct testcase_t *tcase = &testcases[i];
++	int ret;
++
++	TEST(writev(*(tcase->pfd), *(tcase->piovec), tcase->iovcnt));
++
++	ret = (TEST_RETURN == tcase->exp_ret);
++	if (TEST_RETURN < 0 || tcase->exp_ret < 0) {
++		ret &= (TEST_ERRNO == tcase->exp_errno);
++		tst_res((ret ? TPASS : TFAIL),
++			"%s, expected: %d (%s), got: %ld (%s)", tcase->desc,
++			tcase->exp_ret, tst_strerrno(tcase->exp_errno),
++			TEST_RETURN, tst_strerrno(TEST_ERRNO));
++	} else {
++		tst_res((ret ? TPASS : TFAIL),
++			"%s, expected: %d, got: %ld", tcase->desc,
++			tcase->exp_ret, TEST_RETURN);
+ 	}
+ }
+ 
+-int fill_mem(char *c_ptr, int c1, int c2)
+-{
+-	int count;
+-
+-	for (count = 1; count <= K_1 / CHUNK; count++) {
+-		if (count & 0x01) {	/* if odd */
+-			memset(c_ptr, c1, CHUNK);
+-		} else {	/* if even */
+-			memset(c_ptr, c2, CHUNK);
+-		}
+-	}
+-	return 0;
+-}
+-
+-void sighandler(int sig)
+-{
+-	switch (sig) {
+-	case SIGTERM:
+-		break;
+-
+-	case SIGPIPE:
+-		in_sighandler++;
+-		return;
+-
+-	default:
+-		tst_resm(TFAIL, "sighandler received invalid signal:%d", sig);
+-		break;
+-	}
+-}
++static struct tst_test test = {
++	.tid = "writev01",
++	.needs_tmpdir = 1,
++	.setup = setup,
++	.test = test_writev,
++	.tcnt = ARRAY_SIZE(testcases),
++};
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170116/0001-checkpoints-Add-TST_SAFE_CHECKPOINT_WAIT2.patch
+++ b/distribution/ltp/include/patches/20170116/0001-checkpoints-Add-TST_SAFE_CHECKPOINT_WAIT2.patch
@@ -1,0 +1,136 @@
+From 554c270986c758a7ecbf315b5785d57a0957528b Mon Sep 17 00:00:00 2001
+Message-Id: <554c270986c758a7ecbf315b5785d57a0957528b.1486995736.git.jstancek@redhat.com>
+From: Cyril Hrubis <chrubis@suse.cz>
+Date: Mon, 13 Feb 2017 14:51:23 +0100
+Subject: [PATCH] checkpoints: Add TST_SAFE_CHECKPOINT_WAIT2()
+
+The new macro allows user to pass timeout parameter as well.
+
+Signed-off-by: Cyril Hrubis <chrubis@suse.cz>
+Acked-by: Jan Stancek <jstancek@redhat.com>
+---
+ doc/test-writing-guidelines.txt |  6 ++++--
+ include/old/old_checkpoint.h    |  7 +++++--
+ include/tst_checkpoint.h        |  7 +++++--
+ include/tst_checkpoint_fn.h     |  3 ++-
+ lib/tst_checkpoint.c            | 12 +++++++++---
+ 5 files changed, 25 insertions(+), 10 deletions(-)
+
+diff --git a/doc/test-writing-guidelines.txt b/doc/test-writing-guidelines.txt
+index ee9e08e42efd..41cee58c6c48 100644
+--- a/doc/test-writing-guidelines.txt
++++ b/doc/test-writing-guidelines.txt
+@@ -689,6 +689,8 @@ checkpoints before the 'test()' function is called.
+ 
+ TST_CHECKPOINT_WAIT(id)
+ 
++TST_CHECKPOINT_WAIT2(id, msec_timeout)
++
+ TST_CHECKPOINT_WAKE(id)
+ 
+ TST_CHECKPOINT_WAKE2(id, nr_wake)
+@@ -701,8 +703,8 @@ unsigned integer which specifies checkpoint to wake/wait for. As a matter of
+ fact it's an index to an array stored in a shared memory, so it starts on
+ '0' and there should be enough room for at least of hundred of them.
+ 
+-The 'TST_CHECKPOINT_WAIT()' suspends process execution until it's woken
+-up or until timeout is reached.
++The 'TST_CHECKPOINT_WAIT()' and 'TST_CHECKPOINT_WAIT2()' suspends process
++execution until it's woken up or until timeout is reached.
+ 
+ The 'TST_CHECKPOINT_WAKE()' wakes one process waiting on the checkpoint.
+ If no process is waiting the function retries until it success or until
+diff --git a/include/old/old_checkpoint.h b/include/old/old_checkpoint.h
+index 37bdf92c8fd2..c8ffc92da76c 100644
+--- a/include/old/old_checkpoint.h
++++ b/include/old/old_checkpoint.h
+@@ -41,7 +41,10 @@
+ 	tst_checkpoint_init(__FILE__, __LINE__, cleanup_fn)
+ 
+ #define TST_SAFE_CHECKPOINT_WAIT(cleanup_fn, id) \
+-        tst_safe_checkpoint_wait(__FILE__, __LINE__, cleanup_fn, id);
++        tst_safe_checkpoint_wait(__FILE__, __LINE__, cleanup_fn, id, 0);
++
++#define TST_SAFE_CHECKPOINT_WAIT2(cleanup_fn, id, msec_timeout) \
++        tst_safe_checkpoint_wait(__FILE__, __LINE__, cleanup_fn, id, msec_timeout);
+ 
+ #define TST_SAFE_CHECKPOINT_WAKE(cleanup_fn, id) \
+         tst_safe_checkpoint_wake(__FILE__, __LINE__, cleanup_fn, id, 1);
+@@ -51,6 +54,6 @@
+ 
+ #define TST_SAFE_CHECKPOINT_WAKE_AND_WAIT(cleanup_fn, id) \
+         tst_safe_checkpoint_wake(__FILE__, __LINE__, cleanup_fn, id, 1); \
+-        tst_safe_checkpoint_wait(__FILE__, __LINE__, cleanup_fn, id);
++        tst_safe_checkpoint_wait(__FILE__, __LINE__, cleanup_fn, id, 0);
+ 
+ #endif /* OLD_CHECKPOINT__ */
+diff --git a/include/tst_checkpoint.h b/include/tst_checkpoint.h
+index ae5a68b7839a..fdce2d6f70b6 100644
+--- a/include/tst_checkpoint.h
++++ b/include/tst_checkpoint.h
+@@ -21,7 +21,10 @@
+ #include "tst_checkpoint_fn.h"
+ 
+ #define TST_CHECKPOINT_WAIT(id) \
+-        tst_safe_checkpoint_wait(__FILE__, __LINE__, NULL, id);
++        tst_safe_checkpoint_wait(__FILE__, __LINE__, NULL, id, 0);
++
++#define TST_CHECKPOINT_WAIT2(id, msec_timeout) \
++        tst_safe_checkpoint_wait(__FILE__, __LINE__, NULL, id, msec_timeout);
+ 
+ #define TST_CHECKPOINT_WAKE(id) \
+         tst_safe_checkpoint_wake(__FILE__, __LINE__, NULL, id, 1);
+@@ -31,7 +34,7 @@
+ 
+ #define TST_CHECKPOINT_WAKE_AND_WAIT(id) \
+         tst_safe_checkpoint_wake(__FILE__, __LINE__, NULL, id, 1); \
+-        tst_safe_checkpoint_wait(__FILE__, __LINE__, NULL, id);
++        tst_safe_checkpoint_wait(__FILE__, __LINE__, NULL, id, 0);
+ 
+ extern const char *tst_ipc_path;
+ extern char *const tst_ipc_envp[];
+diff --git a/include/tst_checkpoint_fn.h b/include/tst_checkpoint_fn.h
+index ebfd22be0ada..0730fb06ad50 100644
+--- a/include/tst_checkpoint_fn.h
++++ b/include/tst_checkpoint_fn.h
+@@ -45,7 +45,8 @@ int tst_checkpoint_wake(unsigned int id, unsigned int nr_wake,
+                         unsigned int msec_timeout);
+ 
+ void tst_safe_checkpoint_wait(const char *file, const int lineno,
+-                              void (*cleanup_fn)(void), unsigned int id);
++                              void (*cleanup_fn)(void), unsigned int id,
++			      unsigned int msec_timeout);
+ 
+ void tst_safe_checkpoint_wake(const char *file, const int lineno,
+                               void (*cleanup_fn)(void), unsigned int id,
+diff --git a/lib/tst_checkpoint.c b/lib/tst_checkpoint.c
+index 5d12ac95d6f5..a23bd02ac38b 100644
+--- a/lib/tst_checkpoint.c
++++ b/lib/tst_checkpoint.c
+@@ -126,14 +126,20 @@ int tst_checkpoint_wake(unsigned int id, unsigned int nr_wake,
+ }
+ 
+ void tst_safe_checkpoint_wait(const char *file, const int lineno,
+-                              void (*cleanup_fn)(void), unsigned int id)
++                              void (*cleanup_fn)(void), unsigned int id,
++			      unsigned int msec_timeout)
+ {
+-	int ret = tst_checkpoint_wait(id, DEFAULT_MSEC_TIMEOUT);
++	int ret;
++
++	if (!msec_timeout)
++		msec_timeout = DEFAULT_MSEC_TIMEOUT;
++
++	ret = tst_checkpoint_wait(id, msec_timeout);
+ 
+ 	if (ret) {
+ 		tst_brkm(TBROK | TERRNO, cleanup_fn,
+ 		         "%s:%d: tst_checkpoint_wait(%u, %i)",
+-		         file, lineno, id, DEFAULT_MSEC_TIMEOUT);
++		         file, lineno, id, msec_timeout);
+ 	}
+ }
+ 
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170116/0001-getrandom02-relax-check-for-returned-data.patch
+++ b/distribution/ltp/include/patches/20170116/0001-getrandom02-relax-check-for-returned-data.patch
@@ -1,0 +1,36 @@
+From 886b49c2db9b9b6f65f7d92a2e91dbf3943e9607 Mon Sep 17 00:00:00 2001
+Message-Id: <886b49c2db9b9b6f65f7d92a2e91dbf3943e9607.1486562481.git.jstancek@redhat.com>
+From: Jan Stancek <jstancek@redhat.com>
+Date: Wed, 8 Feb 2017 14:53:31 +0100
+Subject: [PATCH v2] getrandom02: relax check for returned data
+
+"nb * 0.1" can easily fail for nb < 20, since all we need
+are 2 identical bytes. Worst case (nb == 19) is almost
+identical to "birthday problem", but with smaller pool.
+Chance of hitting 2 identical bytes in pool of 19
+is close to 50%.
+
+Adjust formula to allow small repetitions in small pools.
+Chance we fail now should be pretty unlikely, ~10^-16.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/syscalls/getrandom/getrandom02.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testcases/kernel/syscalls/getrandom/getrandom02.c b/testcases/kernel/syscalls/getrandom/getrandom02.c
+index 0ac8bd28aed0..ec19f0fb32c5 100644
+--- a/testcases/kernel/syscalls/getrandom/getrandom02.c
++++ b/testcases/kernel/syscalls/getrandom/getrandom02.c
+@@ -83,7 +83,7 @@ static int check_content(int nb)
+ 
+ 	memset(table, 0, sizeof(table));
+ 
+-	max = nb * 0.10;
++	max = 6 + nb * 0.2;
+ 
+ 	for (i = 0; i < nb; i++) {
+ 		index = buf[i];
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170116/0001-kmsg01-fix-race-in-SEEK_SET-0-test.patch
+++ b/distribution/ltp/include/patches/20170116/0001-kmsg01-fix-race-in-SEEK_SET-0-test.patch
@@ -1,0 +1,174 @@
+From 92811fc726756b25ce09f3320d06a07d8b086a68 Mon Sep 17 00:00:00 2001
+Message-Id: <92811fc726756b25ce09f3320d06a07d8b086a68.1488895682.git.jstancek@redhat.com>
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 2 Mar 2017 10:17:59 +0100
+Subject: [PATCH] kmsg01: fix race in SEEK_SET 0 test
+
+This test does following:
+1. open /dev/kmsg
+2. read seqno
+3. calls SEEK_SET 0
+4. read seqno again
+5. compare if they match
+
+Problem is that SEEK_SET resets index and sequence number to first
+record stored in the buffer (see devkmsg_llseek() in kernel/printk.c).
+So, if first record gets overwritten between 2) and 3) we don't get
+EPIPE from second read, test doesn't retry and fails.
+
+This patch opens one more file descriptor (fd2) at the beginning
+of test, solely for the purpose to check if first record went away.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/logging/kmsg/kmsg01.c | 107 +++++++++++++++++++++------------
+ 1 file changed, 67 insertions(+), 40 deletions(-)
+
+diff --git a/testcases/kernel/logging/kmsg/kmsg01.c b/testcases/kernel/logging/kmsg/kmsg01.c
+index 07419da05de0..5fd3e8b58fa0 100644
+--- a/testcases/kernel/logging/kmsg/kmsg01.c
++++ b/testcases/kernel/logging/kmsg/kmsg01.c
+@@ -393,8 +393,8 @@ static void test_read_returns_first_message(void)
+ 		else
+ 			tst_resm(TFAIL|TTERRNO, "read failed");
+ 
+-		/* give a second to whoever overwrote first message to finish */
+-		sleep(1);
++		/* give a moment to whoever overwrote first message to finish */
++		usleep(100000);
+ 		j--;
+ 	}
+ 
+@@ -473,63 +473,90 @@ static void test_messages_overwritten(void)
+ 	SAFE_CLOSE(cleanup, fd);
+ }
+ 
++static int read_msg_seqno(int fd, unsigned long *seqno)
++{
++	char msg[MAX_MSGSIZE];
++
++	TEST(read(fd, msg, sizeof(msg)));
++	if (TEST_RETURN == -1 && TEST_ERRNO != EPIPE) {
++		tst_brkm(TBROK|TTERRNO, cleanup,
++			"failed to read /dev/kmsg");
++	}
++
++	if (TEST_ERRNO == EPIPE)
++		return -1;
++
++	if (get_msg_fields(msg, NULL, seqno) != 0) {
++		tst_resm(TFAIL, "failed to parse seqid: %s", msg);
++		return -1;
++	}
++
++	return 0;
++}
++
+ static void test_seek(void)
+ {
+-	int k, j = NUM_READ_RETRY, fd;
++	int j, fd, fd2;
+ 	char msg[MAX_MSGSIZE];
+-	unsigned long seqno[2];
++	unsigned long seqno[2], tmp;
++	int ret = 0;
+ 
+ 	/* 1. read() after SEEK_SET 0 returns same (first) message */
+ 	tst_resm(TINFO, "TEST: seek SEEK_SET 0");
+ 
+-	fd = open("/dev/kmsg", O_RDONLY | O_NONBLOCK);
+-	if (fd < 0)
+-		tst_brkm(TBROK|TERRNO, cleanup,	"failed to open /dev/kmsg");
+-
+-	while (j) {
+-		for (k = 0; k < 2; k++) {
+-			TEST(read(fd, msg, sizeof(msg)));
+-			if (TEST_RETURN == -1) {
+-				if (errno == EPIPE)
+-					break;
+-				else
+-					tst_brkm(TBROK|TTERRNO, cleanup,
+-						"failed to read /dev/kmsg");
+-			}
+-			if (get_msg_fields(msg, NULL, &seqno[k]) != 0)
+-				tst_resm(TFAIL, "failed to parse seqid: %s",
+-					msg);
+-			if (k == 0)
+-				if (lseek(fd, 0, SEEK_SET) == -1)
+-					tst_resm(TFAIL|TERRNO,
+-						"SEEK_SET 0 failed");
++	for (j = 0; j < NUM_READ_RETRY && !ret; j++) {
++		/*
++		 * j > 0 means we are trying again, because we most likely
++		 * failed on read returning EPIPE - first message in buffer
++		 * has been overwrittern. Give a moment to whoever overwrote
++		 * first message to finish.
++		 */
++		if (j)
++			usleep(100000);
++
++		/*
++		 * Open 2 fds. Use fd1 to read seqno1, then seek to
++		 * begininng and read seqno2. Use fd2 to check if
++		 * first entry in buffer got overwritten. If so,
++		 * we'll have to repeat the test.
++		 */
++		fd = SAFE_OPEN(cleanup, "/dev/kmsg", O_RDONLY | O_NONBLOCK);
++		fd2 = SAFE_OPEN(cleanup, "/dev/kmsg", O_RDONLY | O_NONBLOCK);
++
++		if (read_msg_seqno(fd, &seqno[0]))
++			goto close_fds;
++
++		if (lseek(fd, 0, SEEK_SET) == -1) {
++			tst_resm(TFAIL|TERRNO, "SEEK_SET 0 failed");
++			ret = -1;
++			goto close_fds;
+ 		}
+ 
+-		if (TEST_RETURN != -1)
+-			break;
++		if (read_msg_seqno(fd, &seqno[1]))
++			goto close_fds;
+ 
+-		/* give a second to whoever overwrote first message to finish */
+-		sleep(1);
+-		j--;
++		if (read_msg_seqno(fd2, &tmp))
++			goto close_fds;
+ 
+-		/* read above has returned EPIPE, reopen fd and try again */
++		ret = 1;
++close_fds:
+ 		SAFE_CLOSE(cleanup, fd);
+-		fd = open("/dev/kmsg", O_RDONLY | O_NONBLOCK);
+-		if (fd < 0)
+-			tst_brkm(TBROK|TERRNO, cleanup,
+-				"failed to open /dev/kmsg");
++		SAFE_CLOSE(cleanup, fd2);
+ 	}
+ 
+-	if (!j) {
++	if (j == NUM_READ_RETRY) {
+ 		tst_resm(TWARN, "exceeded: %d attempts", NUM_READ_RETRY);
+-	} else {
+-		if (seqno[0] != seqno[1])
+-			tst_resm(TFAIL, "SEEK_SET 0");
+-		else
++	} else if (ret > 0) {
++		if (seqno[0] != seqno[1]) {
++			tst_resm(TFAIL, "SEEK_SET 0, %lu != %lu",
++				seqno[0], seqno[1]);
++		} else {
+ 			tst_resm(TPASS, "SEEK_SET 0");
++		}
+ 	}
+ 
+ 	/* 2. messages after SEEK_END 0 shouldn't contain MSG_PREFIX */
++	fd = SAFE_OPEN(cleanup, "/dev/kmsg", O_RDONLY | O_NONBLOCK);
+ 	tst_resm(TINFO, "TEST: seek SEEK_END 0");
+ 	if (lseek(fd, 0, SEEK_END) == -1)
+ 		tst_resm(TFAIL|TERRNO, "lseek SEEK_END 0 failed");
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170116/0001-mmap16-extend-checkpoint-wait-time-during-fs-fill.patch
+++ b/distribution/ltp/include/patches/20170116/0001-mmap16-extend-checkpoint-wait-time-during-fs-fill.patch
@@ -1,0 +1,47 @@
+From aa5252d455458cc553c0c475ed84b927dd07e3dc Mon Sep 17 00:00:00 2001
+Message-Id: <aa5252d455458cc553c0c475ed84b927dd07e3dc.1486995276.git.jstancek@redhat.com>
+From: Jan Stancek <jstancek@redhat.com>
+Date: Fri, 10 Feb 2017 14:28:57 +0100
+Subject: [COMMITTED][PATCH] mmap16: extend checkpoint wait time during fs fill
+
+I'm seeing this test rarely failing on slower systems:
+mmap16      0  TINFO  :  Using test device LTP_DEV='/dev/loop0'
+mmap16      0  TINFO  :  Formatting /dev/loop0 with ext4 opts='-b 1024' extra opts='10240'
+mmap16      1  TBROK  :  tst_checkpoint.c:136: mmap16.c:223: tst_checkpoint_wait(0, 10000): errno=ETIMEDOUT(110): Connection timed out
+mmap16      2  TBROK  :  tst_checkpoint.c:136: Remaining cases broken
+mmap16      1  TBROK  :  tst_checkpoint.c:149: mmap16.c:125: tst_checkpoint_wake(0, 1, 10000): errno=ETIMEDOUT(110): Connection timed out
+mmap16      2  TBROK  :  tst_checkpoint.c:149: Remaining cases broken
+
+duration=52 termination_type=exited termination_id=2 corefile=no
+cutime=0 cstime=132
+
+What appears to be happening is that filling entire fs with 1024 chunks
+takes longer than 10 seconds, so child hits TBROK while waiting for
+parent. Parent eventually finishes, but then is unable to wake
+child, which already finished.
+
+Based on output above it looks like it took ~30 seconds to fill the fs
+and then we hit 2 timeouts, making total of ~50 seconds. This patch
+extends this particular checkpoint wait to 60 seconds.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/syscalls/mmap/mmap16.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testcases/kernel/syscalls/mmap/mmap16.c b/testcases/kernel/syscalls/mmap/mmap16.c
+index 3f2676bdc2d2..52c291f45bcf 100644
+--- a/testcases/kernel/syscalls/mmap/mmap16.c
++++ b/testcases/kernel/syscalls/mmap/mmap16.c
+@@ -220,7 +220,7 @@ static void do_child(void)
+ 	 * kernel writepage is called, that means data corruption.
+ 	 */
+ 	TST_SAFE_CHECKPOINT_WAKE(NULL, 0);
+-	TST_SAFE_CHECKPOINT_WAIT(NULL, 0);
++	TST_SAFE_CHECKPOINT_WAIT2(NULL, 0, 60*1000);
+ 
+ 	for (offset = FS_BLOCKSIZE; offset < page_size; offset += FS_BLOCKSIZE)
+ 		addr[offset] = 'a';
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170116/0001-quotactl02-flags-for-Q_XQUOTA-ON-OFF-is-32bit-int.patch
+++ b/distribution/ltp/include/patches/20170116/0001-quotactl02-flags-for-Q_XQUOTA-ON-OFF-is-32bit-int.patch
@@ -1,0 +1,32 @@
+From 15e9701e3cb8c79bfec874ddc2ee2f920d7aecee Mon Sep 17 00:00:00 2001
+Message-Id: <15e9701e3cb8c79bfec874ddc2ee2f920d7aecee.1486461207.git.jstancek@redhat.com>
+From: Jan Stancek <jstancek@redhat.com>
+Date: Tue, 7 Feb 2017 10:50:13 +0100
+Subject: [COMMITTED][PATCH] quotactl02: flags for Q_XQUOTA{ON,OFF} is 32bit int
+
+This fixes failure on ppc64 big endian systems:
+  quotactl02.c:163: FAIL: quotactl() failed to turn off xfs quota and get xfs quota off status: EEXIST
+  quotactl02.c:163: FAIL: quotactl() failed to turn on xfs quota and get xfs quota on status: EINVAL
+  quotactl02.c:136: PASS: quoactl() succeeded to set and get xfs disk quota limits
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/syscalls/quotactl/quotactl02.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testcases/kernel/syscalls/quotactl/quotactl02.c b/testcases/kernel/syscalls/quotactl/quotactl02.c
+index 97e784480f2b..d3bd94624a8a 100644
+--- a/testcases/kernel/syscalls/quotactl/quotactl02.c
++++ b/testcases/kernel/syscalls/quotactl/quotactl02.c
+@@ -52,7 +52,7 @@ static struct fs_disk_quota set_dquota = {
+ 	.d_rtb_softlimit = 1000,
+ 	.d_fieldmask = FS_DQ_RTBSOFT
+ };
+-static unsigned short qflag = XFS_QUOTA_UDQ_ENFD;
++static uint32_t qflag = XFS_QUOTA_UDQ_ENFD;
+ static const char mntpoint[] = "mnt_point";
+ 
+ static struct t_case {
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170116/0001-sem_post-8-1-improve-child-blocked-on-semaphore-dete.patch
+++ b/distribution/ltp/include/patches/20170116/0001-sem_post-8-1-improve-child-blocked-on-semaphore-dete.patch
@@ -1,0 +1,128 @@
+From 62ddd8c7a35ffe25f1da6075e9c8bf0abe74dbd3 Mon Sep 17 00:00:00 2001
+Message-Id: <62ddd8c7a35ffe25f1da6075e9c8bf0abe74dbd3.1488900167.git.jstancek@redhat.com>
+From: Jan Stancek <jstancek@redhat.com>
+Date: Fri, 3 Mar 2017 10:30:07 +0100
+Subject: [PATCH] sem_post/8-1: improve "child blocked on semaphore" detection
+
+With POSIX semaphore we can't tell how many processes are waiting
+on semaphore. Each child process in this test uses 2 semaphores,
+first can always be taken and is used only for its semval (as counter),
+to tell if child started and presumably will soon block on the second
+semaphore.
+
+Test assumes that if child holds first semaphore, then it will
+take second one within 100us.
+
+This patch replaces that sleep with a wait until child process
+state changes to 'S' (sleeping).
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ .../conformance/interfaces/sem_post/8-1.c          |  6 ++-
+ testcases/open_posix_testsuite/include/proc.h      | 62 ++++++++++++++++++++++
+ 2 files changed, 66 insertions(+), 2 deletions(-)
+ create mode 100644 testcases/open_posix_testsuite/include/proc.h
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/sem_post/8-1.c b/testcases/open_posix_testsuite/conformance/interfaces/sem_post/8-1.c
+index 08e94639acaf..d41a7e47ea91 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/sem_post/8-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/sem_post/8-1.c
+@@ -44,6 +44,7 @@
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include <stdlib.h>
++#include "proc.h"
+ 
+ #define TEST "sem_post_8-1"
+ 
+@@ -184,7 +185,8 @@ int main(void)
+ 		usleep(100);
+ 		sem_getvalue(sem_1, &val);
+ 	} while (val != 1);
+-	usleep(100);
++	tst_process_state_wait3(c_1, 'S', 2000);
++	tst_process_state_wait3(c_2, 'S', 2000);
+ 
+ 	c_3 = fork();
+ 	switch (c_3) {
+@@ -204,7 +206,7 @@ int main(void)
+ 		usleep(100);
+ 		sem_getvalue(sem_1, &val);
+ 	} while (val != 0);
+-	usleep(100);
++	tst_process_state_wait3(c_3, 'S', 2000);
+ 
+ 	/* Ok, let's release the lock */
+ 	fprintf(stderr, "P: release lock\n");
+diff --git a/testcases/open_posix_testsuite/include/proc.h b/testcases/open_posix_testsuite/include/proc.h
+new file mode 100644
+index 000000000000..8272d9df1e49
+--- /dev/null
++++ b/testcases/open_posix_testsuite/include/proc.h
+@@ -0,0 +1,62 @@
++/*
++ * Copyright (c) 2017 Linux Test Project
++ *
++ * This program is free software;  you can redistribute it and/or modify
++ * it under the terms in version 2 of the GNU General Public License as
++ * published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY;  without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
++ * the GNU General Public License for more details.
++ */
++
++#ifdef __linux__
++# include <errno.h>
++# include <string.h>
++int tst_process_state_wait3(pid_t pid, const char state,
++	unsigned long maxwait_ms)
++{
++	char proc_path[128], cur_state;
++	int wait_step_ms = 10;
++	unsigned long waited_ms = 0;
++
++	snprintf(proc_path, sizeof(proc_path), "/proc/%i/stat", pid);
++
++	for (;;) {
++		FILE *f = fopen(proc_path, "r");
++
++		if (!f) {
++			fprintf(stderr, "Failed to open '%s': %s\n",
++				proc_path, strerror(errno));
++			return 1;
++		}
++
++		if (fscanf(f, "%*i %*s %c", &cur_state) != 1) {
++			fclose(f);
++			fprintf(stderr, "Failed to read '%s': %s\n",
++				proc_path, strerror(errno));
++			return 1;
++		}
++		fclose(f);
++
++		if (state == cur_state)
++			return 0;
++
++		usleep(wait_step_ms * 1000);
++		waited_ms += wait_step_ms;
++
++		if (waited_ms >= maxwait_ms) {
++			fprintf(stderr, "Reached max wait time\n");
++			return 1;
++		}
++	}
++}
++#else
++int tst_process_state_wait3(pid_t pid, const char state,
++	unsigned long maxwait_ms)
++{
++	usleep(maxwait_ms * 1000);
++	return 0;
++}
++#endif
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170116/0001-syscalls-syslog-added-debugging-and-message-loss-che.patch
+++ b/distribution/ltp/include/patches/20170116/0001-syscalls-syslog-added-debugging-and-message-loss-che.patch
@@ -1,0 +1,427 @@
+From e81fc5e46d0a4a4f02c01d75a4088eb6582b0881 Mon Sep 17 00:00:00 2001
+From: Jakub Racek <jracek@redhat.com>
+Date: Mon, 3 Apr 2017 11:50:00 +0200
+Subject: [PATCH] syscalls/syslog: added debugging and message loss check for
+ some scripts
+
+syslog0{2,4,8} scripts are occasionally quietly failing. Get more information
+on failure (strace, services status, syslog content). Also, check if message
+was delayed or lost.
+
+This is a squash of several patches, since these have been used to
+gather data for some time. Also, the delay after service restart is
+increased to possibly rule out some cases in futher testing.
+
+Signed-off-by: Jakub Racek <jracek@redhat.com>
+---
+ testcases/kernel/syscalls/syslog/syslog-lib.sh |  52 +++++++
+ testcases/kernel/syscalls/syslog/syslog02      |  24 ++-
+ testcases/kernel/syscalls/syslog/syslog04      |  23 ++-
+ testcases/kernel/syscalls/syslog/syslog08      | 202 +++++++++++++++++--------
+ 4 files changed, 233 insertions(+), 68 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/syslog/syslog-lib.sh b/testcases/kernel/syscalls/syslog/syslog-lib.sh
+index 35c13da..c399e6b 100755
+--- a/testcases/kernel/syscalls/syslog/syslog-lib.sh
++++ b/testcases/kernel/syscalls/syslog/syslog-lib.sh
+@@ -32,6 +32,56 @@ RSYSLOG_CONFIG=
+ # number of seconds to wait for another syslog test to complete
+ WAIT_COUNT=60
+ 
++OUTPUT_FILE_PREFIX=`mktemp -u syslog-tmp.XXXXXX`
++GET_OUTPUT_FILE_CMD="ls -la $OUTPUT_FILE_PREFIX* | grep ^- | awk '{print \$9}'"
++
++LAST_PID=""
++
++get_more_info()
++{
++	if command -v systemctl >/dev/null 2>&1; then
++		systemctl status rsyslog
++		systemctl status systemd-journald
++	else
++		"no systemd, skipping debug dump"
++	fi
++
++	cat $@ | grep tst
++	echo "<---->"
++	journalctl | grep tst
++
++	FILES=`eval $GET_OUTPUT_FILE_CMD`
++	for OUTPUT_FILE in $FILES
++	do
++		if [ -f $OUTPUT_FILE ]; then
++			cat $OUTPUT_FILE
++		fi
++	done
++	remove_temp_files
++}
++
++remove_temp_files()
++{
++	rm -f $OUTPUT_FILE_PREFIX* > /dev/null 2>&1
++}
++
++wrap_syslogtst()
++{
++	remove_temp_files
++	strace -ff -t -vv -o $OUTPUT_FILE_PREFIX syslogtst "$@" 2>&1
++	if [ $? -ne 0 ]; then
++		return $?
++	fi
++
++	# save last pid
++	LAST_PID=`eval $GET_OUTPUT_FILE_CMD | cut -f3 -d "."`
++}
++
++get_last_pid()
++{
++	echo $LAST_PID
++}
++
+ cleanup()
+ {
+ 	# Reentrant cleanup -> bad. Especially since rsyslogd on Fedora 13
+@@ -39,6 +89,8 @@ cleanup()
+ 	disable_traps
+ 	exit_code=$1
+ 
++	remove_temp_files
++
+ 	# Restore the previous syslog daemon state.
+ 	if [ -f "$CONFIG_FILE.ltpback" ]; then
+ 		if mv "$CONFIG_FILE.ltpback" "$CONFIG_FILE"; then
+diff --git a/testcases/kernel/syscalls/syslog/syslog02 b/testcases/kernel/syscalls/syslog/syslog02
+index 2213ce3..d06ddab 100755
+--- a/testcases/kernel/syscalls/syslog/syslog02
++++ b/testcases/kernel/syscalls/syslog/syslog02
+@@ -54,6 +54,8 @@ syslog_case2()
+ 			# Create the configuration file specific to this level
+ 			echo "$RSYSLOG_CONFIG" > $CONFIG_FILE
+ 			echo "mail.$level	$MAILLOG" >> $CONFIG_FILE
++			echo "\$DebugFile /tmp/rsyslog_debug" >> $CONFIG_FILE
++			echo "\$DebugLevel 2" >> $CONFIG_FILE
+ 			;;
+ 
+ 		/etc/syslog-ng/syslog-ng.conf)
+@@ -64,6 +66,7 @@ syslog_case2()
+ 		esac
+ 
+ 		restart_syslog_daemon
++		sleep 5
+ 
+ 		# Grepping pattern has to be changed whenever the executable name
+ 		# changes, ex: syslogtst executable.
+@@ -76,7 +79,9 @@ syslog_case2()
+ 		fi
+ 
+ 		# syslogtst has to be called with additional level argument(0-7)
+-		if ! syslogtst 2 $level_no 2>/dev/null; then
++
++		if ! wrap_syslogtst 2 $level_no; then
++			get_more_info $MAILLOG
+ 			cleanup 1
+ 		fi
+ 		sleep 2
+@@ -92,9 +97,26 @@ syslog_case2()
+ 		if [ $diff -eq 0 ]; then
+ 			tst_resm TFAIL "***** Level $level failed *****"
+ 			status_flag=1
++			get_more_info $MAILLOG
++			cat /tmp/rsyslog_debug
++
++			# check if this was caused by delay
++			time_to_sleep=5
++			tst_resm TINFO "Trying to check if message was merely delayed, or lost."
++			tst_resm TINFO "Sleeping $time_to_sleep more seconds."
++
++			newvalue=`grep -c "syslogtst: mail $level test" $MAILLOG`
++			diff=$(( $newvalue - $oldvalue ))
++			if [ $diff -eq 0 ]; then
++				tst_resm TINFO "It's possible that message was lost."
++			elif [ $diff -ge 1 ]; then
++				tst_resm TINFO "It seems that message was delayed."
++			fi
+ 		elif [ $diff -ge 1 ]; then
+ 			tst_resm TPASS "***** Level $level passed *****"
+ 		fi
++
++
+ 		# Increment the level_no for next level...
+ 		: $(( level_no += 1 ))
+ 
+diff --git a/testcases/kernel/syscalls/syslog/syslog04 b/testcases/kernel/syscalls/syslog/syslog04
+index d1739d3..a7f04b2 100755
+--- a/testcases/kernel/syscalls/syslog/syslog04
++++ b/testcases/kernel/syscalls/syslog/syslog04
+@@ -55,12 +55,13 @@ syslog_case4()
+ 	restart_syslog_daemon
+ 
+ 	# Run syslogtst in the background and get the process id.
+-	syslogtst 4 2>/dev/null &
+-	log_pid=$!
+-	if ! wait $log_pid; then
++	if ! wrap_syslogtst 4; then
++		get_more_info /var/log/messages
+ 		cleanup 1
+ 	fi
+ 
++	log_pid=`get_last_pid`
++
+ 	sleep 2
+ 
+ 	# check if /var/log/messages script exists
+@@ -72,7 +73,23 @@ syslog_case4()
+ 	found=`grep -c "\[$log_pid\]: syslogtst: user info test." /var/log/messages`
+ 	if [ $found -ne 1 ]; then
+ 		status_flag=1
++		get_more_info /var/log/messages
++
++		# check if this was caused by delay
++		time_to_sleep=5
++		tst_resm TINFO "Trying to check if message was merely delayed, or lost."
++		tst_resm TINFO "Sleeping $time_to_sleep more seconds."
++
++		sleep $time_to_sleep
++		new_found=`grep -c "\[$log_pid\]: syslogtst: user info test." /var/log/messages`
++		if [ $found -eq $new_found ]; then
++			tst_resm TINFO "It's possible that message was lost."
++		elif [ $found+1 -eq $new_found ]; then
++			tst_resm TINFO "It seems that message was delayed."
++		fi
++
+ 	fi
++
+ }
+ 
+ tst_resm TINFO "case4: Test the logging option: LOG_PID"
+diff --git a/testcases/kernel/syscalls/syslog/syslog08 b/testcases/kernel/syscalls/syslog/syslog08
+index 5388620..ec72971 100755
+--- a/testcases/kernel/syscalls/syslog/syslog08
++++ b/testcases/kernel/syscalls/syslog/syslog08
+@@ -36,85 +36,159 @@
+ 
+ . syslog-lib.sh || exit 1
+ 
+-syslog_case8()
++evaluate_test_result()
+ {
+-	local facility_no=1
+-	local facilities="user mail daemon auth lpr"
+-
+-	tst_resm TINFO "testing all the facilities"
+-
+-	for facility in $facilities; do
++	local succ_cond=$1
++	local facility=$2
++	local log_src=$3
++	local delay_detection_attempt=$4
++	local last_attempt=$5
++
++	if [ $delay_detection_attempt -eq 1 ]; then
++		if [ $succ_cond ]; then
++			tst_resm TINFO " Message was probably just delayed."
++			return 0
++		else
++			if [ $last_attempt -eq 1 ]; then
++				tst_resm TINFO " Message was probably lost completely!"
++			fi
++			return 1
++		fi
++	fi
++
++	if [ $succ_cond ]; then
++		tst_resm TPASS " Facility $facility passed"
++		return 0
++	else
++		tst_resm TFAIL " Facility $facility failed"
++		status_flag=1
++		get_more_info $log_src
++		return 1
++	fi
++}
+ 
+-		tst_resm TINFO "Doing facility: $facility..."
+ 
+-		# Create the configuration file specific to this facility
+-		# Level is fixed at info.
+-		case "$CONFIG_FILE" in
+-		/etc/syslog.conf|/etc/rsyslog.conf)
+-			echo "$RSYSLOG_CONFIG" > $CONFIG_FILE
+-			echo "$facility.info	/var/log/messages" >> $CONFIG_FILE
+-			echo "$facility.info	/var/log/maillog" >> $CONFIG_FILE
+-			;;
++do_test()
++{
++	local facility=$1
++	local oldvalue=$2
++	local old_mail_check=$3
++	local attempts=$4
++	local delay_detection=$5
+ 
+-		/etc/syslog-ng/syslog-ng.conf)
+-			echo "source src{ internal(); unix-dgram(\"/dev/log\"); udp(ip(\"0.0.0.0\") port(514)); };" > $CONFIG_FILE
+-			echo "filter f_syslog-$facility { level(info) and facility($facility); };" >> $CONFIG_FILE
+-			echo "destination syslog-messages { file(\"/var/log/messages\"); };" >> $CONFIG_FILE
+-			echo "destination syslog-mail { file(\"/var/log/maillog\");};" >> $CONFIG_FILE
+-			echo "log { source(src); filter(f_syslog-$facility); destination(syslog-mail); };"  >> $CONFIG_FILE
+-			echo "log { source(src); filter(f_syslog-$facility); destination(syslog-messages); };"  >> $CONFIG_FILE
+-			;;
++	local last_ret=0
+ 
+-		esac
++	for i in `seq 1 $attempts`;
++	do
++		new_mail_check=`grep -c "syslogtst: $facility info test." /var/log/maillog`
++		newvalue=`grep -c "syslogtst: $facility info test." /var/log/messages`
++		diff=$(( $newvalue - $oldvalue ))
++		mail_check=$(( $new_mail_check - $old_mail_check ))
+ 
+-		restart_syslog_daemon
++		last_attempt=$(( i == attempts ))
++		if [ $facility = "mail" ]; then
++			evaluate_test_result "$mail_check -eq 1" $facility /var/log/maillog $delay_detection $last_attempt
+ 
+-		if [ -e /var/log/messages ]; then
+-			oldvalue=`grep -c "syslogtst: $facility info test." /var/log/messages`
+ 		else
+-			oldvalue=0
++			evaluate_test_result "$diff -eq 1" $facility /var/log/messages $delay_detection $last_attempt
+ 		fi
+ 
+-		if [ -e /var/log/maillog ]; then
+-			old_mail_check=`grep -c "syslogtst: $facility info test." /var/log/maillog`
+-		else
+-			old_mail_check=0
+-		fi
++		last_ret=$?
+ 
+-		# syslogtst has to be called with one more
+-				# additional facility argument(1-6)
+-		if ! syslogtst 8 $facility_no 2>/dev/null; then
+-			status_flag=1
+-			return
++		if [ $last_ret -eq 0 ]; then
++			return 0
+ 		fi
+-		sleep 2
+-		# check if /var/log/maillog script exists
+-		for logf in messages maillog
+-		do
+-			if [ ! -e /var/log/$logf ]; then
+-				tst_resm TBROK "/var/log/$logf no such log file"
+-				cleanup 1
+-			fi
+-		done
+ 
+-		new_mail_check=`grep -c "syslogtst: $facility info test." /var/log/maillog`
+-		newvalue=`grep -c "syslogtst: $facility info test." /var/log/messages`
+-		diff=$(( $newvalue - $oldvalue ))
+-		mail_check=$(( $new_mail_check - $old_mail_check ))
++		sleep 3
++	done
+ 
+-		if [ $facility = "mail" ]; then
+-			if [ $mail_check -ne 1 ]; then
+-				tst_resm TFAIL " Facility $facility failed"
+-				status_flag=1
+-			elif [ $mail_check -eq 1 ]; then
+-				tst_resm TPASS " Facility $facility passed"
+-			fi
+-		elif [ $diff -ne 1 ]; then
+-			tst_resm TFAIL " Facility $facility failed"
+-			status_flag=1
+-		else
+-			tst_resm TPASS " Facility $facility passed"
++	return $last_ret
++}
++
++write_config_file()
++{
++	# Create the configuration file specific to this facility
++	# Level is fixed at info.
++	case "$CONFIG_FILE" in
++	/etc/syslog.conf|/etc/rsyslog.conf)
++		echo "$RSYSLOG_CONFIG" > $CONFIG_FILE
++		echo "$facility.info	/var/log/messages" >> $CONFIG_FILE
++		echo "$facility.info	/var/log/maillog" >> $CONFIG_FILE
++		;;
++
++	/etc/syslog-ng/syslog-ng.conf)
++		echo "source src{ internal(); unix-dgram(\"/dev/log\"); udp(ip(\"0.0.0.0\") port(514)); };" > $CONFIG_FILE
++		echo "filter f_syslog-$facility { level(info) and facility($facility); };" >> $CONFIG_FILE
++		echo "destination syslog-messages { file(\"/var/log/messages\"); };" >> $CONFIG_FILE
++		echo "destination syslog-mail { file(\"/var/log/maillog\");};" >> $CONFIG_FILE
++		echo "log { source(src); filter(f_syslog-$facility); destination(syslog-mail); };"  >> $CONFIG_FILE
++		echo "log { source(src); filter(f_syslog-$facility); destination(syslog-messages); };"  >> $CONFIG_FILE
++		;;
++
++	esac
++}
++
++do_loop_test()
++{
++	local facility=$1
++	local facility_no=$2
++
++	tst_resm TINFO "Doing facility: $facility..."
++
++	write_config_file
++
++	restart_syslog_daemon
++
++	if [ -e /var/log/messages ]; then
++		oldvalue=`grep -c "syslogtst: $facility info test." /var/log/messages`
++	else
++		oldvalue=0
++	fi
++
++	if [ -e /var/log/maillog ]; then
++		old_mail_check=`grep -c "syslogtst: $facility info test." /var/log/maillog`
++	else
++		old_mail_check=0
++	fi
++
++	# syslogtst has to be called with one more
++			# additional facility argument(1-6)
++	if ! wrap_syslogtst 8 $facility_no ; then
++		status_flag=1
++		get_more_info /var/log/maillog /var/log/messages
++		return
++	fi
++	sleep 2
++	# check if /var/log/maillog script exists
++	for logf in messages maillog
++	do
++		if [ ! -e /var/log/$logf ]; then
++			tst_resm TBROK "/var/log/$logf no such log file"
++			cleanup 1
+ 		fi
++	done
++
++	# 1 attempt, no delay detection
++	do_test $facility $oldvalue $old_mail_check 1 0
++
++	if [ $? -ne 0 ]; then
++		# 2 attempts, check if message was merely delayed
++		do_test $facility $oldvalue $old_mail_check 2 1
++	fi
++
++}
++
++syslog_case8()
++{
++	local facility_no=1
++	local facilities="user mail daemon auth lpr"
++
++	tst_resm TINFO "testing all the facilities"
++
++	for facility in $facilities; do
++
++		do_loop_test $facility $facility_no
++
+ 		# Increment the facility_no for next...
+ 		: $(( facility_no += 1 ))
+ 	done
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170116/0001-syscalls-syslog02-fix-typo.patch
+++ b/distribution/ltp/include/patches/20170116/0001-syscalls-syslog02-fix-typo.patch
@@ -1,0 +1,28 @@
+If for whatever reason $MAILLOG file doesn't exist, then test of
+arbitrary log level may fail, since number of grepped messages
+(oldvalue) isn't set to 0 because of typo.
+
+Signed-off-by: Jakub Racek <jracek@redhat.com>
+---
+ testcases/kernel/syscalls/syslog/syslog02 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testcases/kernel/syscalls/syslog/syslog02 b/testcases/kernel/syscalls/syslog/syslog02
+index 7a55a84..2213ce3 100755
+--- a/testcases/kernel/syscalls/syslog/syslog02
++++ b/testcases/kernel/syscalls/syslog/syslog02
+@@ -72,7 +72,7 @@ syslog_case2()
+ 		if [ -e "$MAILLOG" ]; then
+ 			oldvalue=`grep -c "syslogtst: mail $level test\." $MAILLOG`
+ 		else
+-			oldvalue1=0
++			oldvalue=0
+ 		fi
+ 
+ 		# syslogtst has to be called with additional level argument(0-7)
+-- 
+1.8.3.1
+
+
+-- 
+Mailing list info: https://lists.linux.it/listinfo/ltp

--- a/distribution/ltp/include/patches/20170516/0001-configure.ac-Generate-linux_syscall_headers.h.patch
+++ b/distribution/ltp/include/patches/20170516/0001-configure.ac-Generate-linux_syscall_headers.h.patch
@@ -1,0 +1,49 @@
+From a07008fbecdf65ef7ffd9b90ae3a5c0efb422d46 Mon Sep 17 00:00:00 2001
+Message-Id: <a07008fbecdf65ef7ffd9b90ae3a5c0efb422d46.1497521630.git.jstancek@redhat.com>
+From: Cyril Hrubis <chrubis@suse.cz>
+Date: Wed, 14 Jun 2017 17:25:09 +0200
+Subject: [PATCH] configure.ac: Generate linux_syscall_headers.h
+
+This avoids a race in generating the linux_syscall_headers.h on a
+parallel build with many CPUs.
+
+Note that the race has been reduced in commit:
+
+commit 3f385652efe811fe7491474f8513baf44cf0a12d
+Author: Cyril Hrubis <chrubis@suse.cz>
+Date:   Wed Jan 13 14:13:31 2016 +0100
+
+    build: regen.sh (linux_syscall_numbers.h): Fix race
+
+But was not completely fixed.
+
+After discussing the problem the easiest solution is to generate the
+header before the build processes starts otherwise we would have to make
+complex changes to the LTP build system. So this commits piggy backs the
+regen.sh script invocation at the end of the configure script.
+
+Fixes #161
+
+Signed-off-by: Cyril Hrubis <chrubis@suse.cz>
+Acked-by: Jan Stancek <jstancek@redhat.com>
+---
+ configure.ac | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index ecc9a2699109..cbe01d34f681 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -132,6 +132,9 @@ fi
+ 
+ AC_CONFIG_SUBDIRS([utils/ffsb-6.0-rc2])
+ 
++AC_CONFIG_COMMANDS([linux_syscall_headers.h],
++		   [cd testcases/kernel/include; ./regen.sh])
++
+ # END testsuites knobs
+ LTP_CHECK_FORTIFY_SOURCE
+ LTP_CHECK_CC_WARN_OLDSTYLE
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170516/0001-dio-reduce-the-number-of-cycles.patch
+++ b/distribution/ltp/include/patches/20170516/0001-dio-reduce-the-number-of-cycles.patch
@@ -1,0 +1,52 @@
+From b246897a5a8e31b47442d15d7854a0eb8e64e949 Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Wed, 14 Jun 2017 11:38:30 +0800
+Subject: [PATCH] dio: reduce the number of cycles
+
+These two cases (dio29/30) takes about 100 minutes, but they're not
+stress test, so I suggest reducing the number of cycles.
+
+After the change on my RHEL-7.3 (23G RAM, 24 CPU(s), x86_64) box, it
+still takes almost 9 mins.
+
+  diotest06    1  TPASS  :  Read with Direct IO, Write without
+  diotest06    2  TPASS  :  Write with Direct IO, Read without
+  diotest06    3  TPASS  :  Read, Write with Direct IO
+  diotest06    0  TINFO  :  3 testblocks 1000 iterations with 100 children completed
+
+  real	8m4.805s
+  user	71m36.722s
+  sys	8m51.649s
+
+[From Eryu:
+
+ I ran diotest30 10 times with "-i 100" and 8 of them failed. IIRC, it
+ was not 100% reproduced either when I first saw the test failure in
+ 4.10-rc kernel testing. So I think ~80% probability to reproduce is
+ fine.]
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Acked-by: Eryu Guan <eguan@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ runtest/dio | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/runtest/dio b/runtest/dio
+index a26e001..185cd57 100644
+--- a/runtest/dio
++++ b/runtest/dio
+@@ -40,8 +40,8 @@ dio27 diotest6 -b 8192 -o 1024000 -i 1000 -v 100
+ dio28 diotest6 -b 8192 -o 1024000 -i 1000 -v 200
+ 
+ ### Run the tests with more children
+-dio29 diotest3 -b 65536 -n 100 -i 1000 -o 1024000
+-dio30 diotest6 -b 65536 -n 100 -i 1000 -o 1024000
++dio29 diotest3 -b 65536 -n 100 -i 100 -o 1024000
++dio30 diotest6 -b 65536 -n 100 -i 100 -o 1024000
+ #
+ # RAW DEVICE TEST SECTION
+ #   DEV1 and DEV2 should be exported prior to execution or
+-- 
+2.9.3
+

--- a/distribution/ltp/include/patches/20170516/0001-kmsg01-convert-to-newlib.patch
+++ b/distribution/ltp/include/patches/20170516/0001-kmsg01-convert-to-newlib.patch
@@ -1,0 +1,547 @@
+From 5a36e489a161c1348233b015fbad6a6690e71585 Mon Sep 17 00:00:00 2001
+Message-Id: <5a36e489a161c1348233b015fbad6a6690e71585.1498131209.git.jstancek@redhat.com>
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 22 Jun 2017 13:10:20 +0200
+Subject: [PATCH] kmsg01: convert to newlib
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/logging/kmsg/kmsg01.c | 224 +++++++++++++++------------------
+ 1 file changed, 100 insertions(+), 124 deletions(-)
+
+diff --git a/testcases/kernel/logging/kmsg/kmsg01.c b/testcases/kernel/logging/kmsg/kmsg01.c
+index 5fd3e8b58fa0..17a1edaf8f03 100644
+--- a/testcases/kernel/logging/kmsg/kmsg01.c
++++ b/testcases/kernel/logging/kmsg/kmsg01.c
+@@ -43,8 +43,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ #include "config.h"
+-#include "test.h"
+-#include "safe_macros.h"
++#include "tst_test.h"
+ #include "linux_syscall_numbers.h"
+ 
+ #define MSG_PREFIX "LTP kmsg01 "
+@@ -54,9 +53,6 @@
+ #define NUM_OVERWRITE_MSGS 1024
+ #define READ_TIMEOUT 5
+ 
+-char *TCID = "kmsg01";
+-static void setup(void);
+-static void cleanup(void);
+ 
+ /*
+  * inject_msg - write message to /dev/kmsg
+@@ -71,9 +67,9 @@ static int inject_msg(const char *msg)
+ 	int f;
+ 	f = open("/dev/kmsg", O_WRONLY);
+ 	if (f < 0)
+-		tst_brkm(TBROK | TERRNO, cleanup, "failed to open /dev/kmsg");
++		tst_brk(TBROK | TERRNO, "failed to open /dev/kmsg");
+ 	TEST(write(f, msg, strlen(msg)));
+-	SAFE_CLOSE(cleanup, f);
++	SAFE_CLOSE(f);
+ 	errno = TEST_ERRNO;
+ 	return TEST_RETURN;
+ }
+@@ -99,7 +95,7 @@ static int find_msg(int fd, const char *text_to_find, char *buf, int bufsize,
+ 	if (fd < 0) {
+ 		f = open("/dev/kmsg", O_RDONLY | O_NONBLOCK);
+ 		if (f < 0)
+-			tst_brkm(TBROK, cleanup, "failed to open /dev/kmsg");
++			tst_brk(TBROK, "failed to open /dev/kmsg");
+ 	} else {
+ 		f = fd;
+ 	}
+@@ -114,8 +110,7 @@ static int find_msg(int fd, const char *text_to_find, char *buf, int bufsize,
+ 				/* current message was overwritten */
+ 				continue;
+ 			else
+-				tst_brkm(TBROK|TTERRNO, cleanup,
+-					"failed to read /dev/kmsg");
++				tst_brk(TBROK|TTERRNO, "err reading /dev/kmsg");
+ 		} else if (TEST_RETURN < bufsize) {
+ 			/* lines from kmsg are not NULL terminated */
+ 			msg[TEST_RETURN] = '\0';
+@@ -128,7 +123,7 @@ static int find_msg(int fd, const char *text_to_find, char *buf, int bufsize,
+ 		}
+ 	}
+ 	if (fd < 0)
+-		SAFE_CLOSE(cleanup, f);
++		SAFE_CLOSE(f);
+ 
+ 	if (msg_found)
+ 		return 0;
+@@ -175,7 +170,7 @@ static int timed_read(int fd, int timeout_sec)
+ 	ret = select(fd + 1, &read_fds, 0, 0, &timeout);
+ 	switch (ret) {
+ 	case -1:
+-		tst_brkm(TBROK|TERRNO, cleanup, "select failed");
++		tst_brk(TBROK|TERRNO, "select failed");
+ 	case 0:
+ 		/* select timed out */
+ 		return -2;
+@@ -203,19 +198,19 @@ static int timed_read_kmsg(int fd, int timeout_sec)
+ 	char msg[MAX_MSGSIZE];
+ 
+ 	if (pipe(pipefd) != 0)
+-		tst_brkm(TBROK|TERRNO, cleanup, "pipe failed");
++		tst_brk(TBROK|TERRNO, "pipe failed");
+ 
+ 	child = fork();
+ 	switch (child) {
+ 	case -1:
+-		tst_brkm(TBROK|TERRNO, cleanup, "failed to fork");
++		tst_brk(TBROK|TERRNO, "failed to fork");
+ 	case 0:
+ 		/* child does all the reading and keeps writing to
+ 		 * pipe to let parent know that it didn't block */
+ 		close(pipefd[0]);
+ 		while (1) {
+ 			if (write(pipefd[1], "", 1) == -1)
+-				tst_brkm(TBROK|TERRNO, NULL, "write to pipe");
++				tst_brk(TBROK|TERRNO, "write to pipe");
+ 			TEST(read(fd, msg, MAX_MSGSIZE));
+ 			if (TEST_RETURN == 0)
+ 				break;
+@@ -228,19 +223,19 @@ static int timed_read_kmsg(int fd, int timeout_sec)
+ 		close(pipefd[1]);
+ 		exit(ret);
+ 	}
+-	SAFE_CLOSE(cleanup, pipefd[1]);
++	SAFE_CLOSE(pipefd[1]);
+ 
+ 	/* parent reads pipe until it reaches eof or until read times out */
+ 	do {
+ 		TEST(timed_read(pipefd[0], timeout_sec));
+ 	} while (TEST_RETURN > 0);
+-	SAFE_CLOSE(cleanup, pipefd[0]);
++	SAFE_CLOSE(pipefd[0]);
+ 
+ 	/* child is blocked, kill it */
+ 	if (TEST_RETURN == -2)
+ 		kill(child, SIGTERM);
+ 	if (waitpid(child, &status, 0) == -1)
+-		tst_brkm(TBROK | TERRNO, cleanup, "waitpid");
++		tst_brk(TBROK | TERRNO, "waitpid");
+ 	if (WIFEXITED(status)) {
+ 		if (WEXITSTATUS(status) == 0) {
+ 			return 0;
+@@ -256,35 +251,35 @@ static void test_read_nonblock(void)
+ {
+ 	int fd;
+ 
+-	tst_resm(TINFO, "TEST: nonblock read");
++	tst_res(TINFO, "TEST: nonblock read");
+ 	fd = open("/dev/kmsg", O_RDONLY | O_NONBLOCK);
+ 	if (fd < 0)
+-		tst_brkm(TBROK|TERRNO, cleanup, "failed to open /dev/kmsg");
++		tst_brk(TBROK|TERRNO, "failed to open /dev/kmsg");
+ 
+ 	TEST(timed_read_kmsg(fd, READ_TIMEOUT));
+ 	if (TEST_RETURN == -1 && TEST_ERRNO == EAGAIN)
+-		tst_resm(TPASS, "non-block read returned EAGAIN");
++		tst_res(TPASS, "non-block read returned EAGAIN");
+ 	else
+-		tst_resm(TFAIL|TTERRNO, "non-block read returned: %ld",
++		tst_res(TFAIL|TTERRNO, "non-block read returned: %ld",
+ 			TEST_RETURN);
+-	SAFE_CLOSE(cleanup, fd);
++	SAFE_CLOSE(fd);
+ }
+ 
+ static void test_read_block(void)
+ {
+ 	int fd;
+ 
+-	tst_resm(TINFO, "TEST: blocking read");
++	tst_res(TINFO, "TEST: blocking read");
+ 	fd = open("/dev/kmsg", O_RDONLY);
+ 	if (fd < 0)
+-		tst_brkm(TBROK|TERRNO, cleanup, "failed to open /dev/kmsg");
++		tst_brk(TBROK|TERRNO, "failed to open /dev/kmsg");
+ 
+ 	TEST(timed_read_kmsg(fd, READ_TIMEOUT));
+ 	if (TEST_RETURN == -2)
+-		tst_resm(TPASS, "read blocked");
++		tst_res(TPASS, "read blocked");
+ 	else
+-		tst_resm(TFAIL|TTERRNO, "read returned: %ld", TEST_RETURN);
+-	SAFE_CLOSE(cleanup, fd);
++		tst_res(TFAIL|TTERRNO, "read returned: %ld", TEST_RETURN);
++	SAFE_CLOSE(fd);
+ }
+ 
+ static void test_partial_read(void)
+@@ -292,17 +287,17 @@ static void test_partial_read(void)
+ 	char msg[MAX_MSGSIZE];
+ 	int fd;
+ 
+-	tst_resm(TINFO, "TEST: partial read");
++	tst_res(TINFO, "TEST: partial read");
+ 	fd = open("/dev/kmsg", O_RDONLY | O_NONBLOCK);
+ 	if (fd < 0)
+-		tst_brkm(TBROK|TERRNO, cleanup, "failed to open /dev/kmsg");
++		tst_brk(TBROK|TERRNO, "failed to open /dev/kmsg");
+ 
+ 	TEST(read(fd, msg, 1));
+ 	if (TEST_RETURN < 0)
+-		tst_resm(TPASS|TTERRNO, "read failed as expected");
++		tst_res(TPASS|TTERRNO, "read failed as expected");
+ 	else
+-		tst_resm(TFAIL, "read returned: %ld", TEST_RETURN);
+-	SAFE_CLOSE(cleanup, fd);
++		tst_res(TFAIL, "read returned: %ld", TEST_RETURN);
++	SAFE_CLOSE(fd);
+ }
+ 
+ static void test_inject(void)
+@@ -312,8 +307,9 @@ static void test_inject(void)
+ 	unsigned long prefix, seqno, seqno_last = 0;
+ 	int i, facility, prio;
+ 
+-	tst_resm(TINFO, "TEST: injected messages appear in /dev/kmsg");
++	tst_res(TINFO, "TEST: injected messages appear in /dev/kmsg");
+ 
++	srand(time(NULL));
+ 	/* test all combinations of prio 0-7, facility 0-15 */
+ 	for (i = 0; i < 127; i++) {
+ 		prio = (i & 7);
+@@ -323,23 +319,23 @@ static void test_inject(void)
+ 		sprintf(imsg_prefixed, "<%d>%s", i, imsg);
+ 
+ 		if (inject_msg(imsg_prefixed) == -1) {
+-			tst_resm(TFAIL|TERRNO, "inject failed");
++			tst_res(TFAIL|TERRNO, "inject failed");
+ 			return;
+ 		}
+ 
+ 		/* check that message appears in log */
+ 		if (find_msg(-1, imsg, tmp, sizeof(tmp), 0) == -1) {
+-			tst_resm(TFAIL, "failed to find: %s", imsg);
++			tst_res(TFAIL, "failed to find: %s", imsg);
+ 			return;
+ 		}
+ 
+ 		/* check that facility is not 0 (LOG_KERN). */
+ 		if (get_msg_fields(tmp, &prefix, &seqno) != 0) {
+-			tst_resm(TFAIL, "failed to parse seqid: %s", tmp);
++			tst_res(TFAIL, "failed to parse seqid: %s", tmp);
+ 			return;
+ 		}
+ 		if (prefix >> 3 == 0) {
+-			tst_resm(TFAIL, "facility 0 found: %s", tmp);
++			tst_res(TFAIL, "facility 0 found: %s", tmp);
+ 			return;
+ 		}
+ 
+@@ -347,14 +343,14 @@ static void test_inject(void)
+ 		if (seqno > seqno_last) {
+ 			seqno_last = seqno;
+ 		} else {
+-			tst_resm(TFAIL, "seqno doesn't grow: %lu, "
++			tst_res(TFAIL, "seqno doesn't grow: %lu, "
+ 				"last: %lu", seqno, seqno_last);
+ 			return;
+ 		}
+ 	}
+ 
+-	tst_resm(TPASS, "injected messages found in log");
+-	tst_resm(TPASS, "sequence numbers grow as expected");
++	tst_res(TPASS, "injected messages found in log");
++	tst_res(TPASS, "sequence numbers grow as expected");
+ }
+ 
+ static void test_read_returns_first_message(void)
+@@ -368,30 +364,29 @@ static void test_read_returns_first_message(void)
+ 	 * If this read fails with EPIPE, first message was overwritten and
+ 	 * we should retry the whole test. If it still fails after
+ 	 * NUM_READ_RETRY attempts, report TWARN */
+-	tst_resm(TINFO, "TEST: mult. readers will get same first message");
++	tst_res(TINFO, "TEST: mult. readers will get same first message");
+ 	while (j) {
+ 		fd = open("/dev/kmsg", O_RDONLY | O_NONBLOCK);
+ 		if (fd < 0)
+-			tst_brkm(TBROK|TERRNO, cleanup,
+-				"failed to open /dev/kmsg");
++			tst_brk(TBROK|TERRNO, "failed to open /dev/kmsg");
+ 
+ 		for (i = 0; i < NUM_READ_MSGS; i++) {
+ 			if (find_msg(-1, "", msg, sizeof(msg), 1) != 0)
+-				tst_resm(TFAIL, "failed to find any message");
++				tst_res(TFAIL, "failed to find any message");
+ 			if (get_msg_fields(msg, NULL, &seqno[i]) != 0)
+-				tst_resm(TFAIL, "failed to parse seqid: %s",
++				tst_res(TFAIL, "failed to parse seqid: %s",
+ 					msg);
+ 		}
+ 
+ 		TEST(read(fd, msg, sizeof(msg)));
+-		SAFE_CLOSE(cleanup, fd);
++		SAFE_CLOSE(fd);
+ 		if (TEST_RETURN != -1)
+ 			break;
+ 
+ 		if (TEST_ERRNO == EPIPE)
+-			tst_resm(TINFO, "msg overwritten, retrying");
++			tst_res(TINFO, "msg overwritten, retrying");
+ 		else
+-			tst_resm(TFAIL|TTERRNO, "read failed");
++			tst_res(TFAIL|TTERRNO, "read failed");
+ 
+ 		/* give a moment to whoever overwrote first message to finish */
+ 		usleep(100000);
+@@ -399,7 +394,7 @@ static void test_read_returns_first_message(void)
+ 	}
+ 
+ 	if (!j) {
+-		tst_resm(TWARN, "exceeded: %d attempts", NUM_READ_RETRY);
++		tst_res(TWARN, "exceeded: %d attempts", NUM_READ_RETRY);
+ 		return;
+ 	}
+ 
+@@ -407,11 +402,11 @@ static void test_read_returns_first_message(void)
+ 		if (seqno[i] != seqno[i + 1])
+ 			msgs_match = 0;
+ 	if (msgs_match) {
+-		tst_resm(TPASS, "all readers got same message on first read");
++		tst_res(TPASS, "all readers got same message on first read");
+ 	} else {
+-		tst_resm(TFAIL, "readers got different messages");
++		tst_res(TFAIL, "readers got different messages");
+ 		for (i = 0; i < NUM_READ_MSGS; i++)
+-			tst_resm(TINFO, "msg%d: %lu\n", i, seqno[i]);
++			tst_res(TINFO, "msg%d: %lu\n", i, seqno[i]);
+ 	}
+ }
+ 
+@@ -424,53 +419,52 @@ static void test_messages_overwritten(void)
+ 
+ 	/* Keep injecting messages until we overwrite first one.
+ 	 * We know first message is overwritten when its seqno changes */
+-	tst_resm(TINFO, "TEST: read returns EPIPE when messages get "
++	tst_res(TINFO, "TEST: read returns EPIPE when messages get "
+ 		"overwritten");
+ 	fd = open("/dev/kmsg", O_RDONLY | O_NONBLOCK);
+ 	if (fd < 0)
+-		tst_brkm(TBROK|TERRNO, cleanup, "failed to open /dev/kmsg");
++		tst_brk(TBROK|TERRNO, "failed to open /dev/kmsg");
+ 
+ 	if (find_msg(-1, "", msg, sizeof(msg), 1) == 0
+ 		&& get_msg_fields(msg, NULL, &first_seqno) == 0) {
+-		tst_resm(TINFO, "first seqno: %lu", first_seqno);
++		tst_res(TINFO, "first seqno: %lu", first_seqno);
+ 	} else {
+-		tst_brkm(TBROK, cleanup, "failed to get first seq. number");
++		tst_brk(TBROK, "failed to get first seq. number");
+ 	}
+ 
+ 	while (1) {
+ 		if (find_msg(-1, "", msg, sizeof(msg), 1) != 0
+ 				|| get_msg_fields(msg, NULL, &seqno) != 0) {
+-			tst_resm(TFAIL, "failed to get first seq. number");
++			tst_res(TFAIL, "failed to get first seq. number");
+ 			break;
+ 		}
+ 		if (first_seqno != seqno) {
+ 			/* first message was overwritten */
+-			tst_resm(TINFO, "first seqno now: %lu", seqno);
++			tst_res(TINFO, "first seqno now: %lu", seqno);
+ 			break;
+ 		}
+ 		for (i = 0; i < NUM_OVERWRITE_MSGS; i++) {
+ 			if (inject_msg(filler_str) == -1)
+-				tst_brkm(TBROK|TERRNO, cleanup,
+-					"failed write to /dev/kmsg");
++				tst_brk(TBROK|TERRNO, "err write to /dev/kmsg");
+ 		}
+ 	}
+ 
+ 	/* first message is overwritten, so this next read should fail */
+ 	TEST(read(fd, msg, sizeof(msg)));
+ 	if (TEST_RETURN == -1 && TEST_ERRNO == EPIPE)
+-		tst_resm(TPASS, "read failed with EPIPE as expected");
++		tst_res(TPASS, "read failed with EPIPE as expected");
+ 	else
+-		tst_resm(TFAIL|TTERRNO, "read returned: %ld", TEST_RETURN);
++		tst_res(TFAIL|TTERRNO, "read returned: %ld", TEST_RETURN);
+ 
+ 	/* seek position is updated to the next available record */
+-	tst_resm(TINFO, "TEST: Subsequent reads() will return available "
++	tst_res(TINFO, "TEST: Subsequent reads() will return available "
+ 		"records again");
+ 	if (find_msg(fd, "", msg, sizeof(msg), 1) != 0)
+-		tst_resm(TFAIL|TTERRNO, "read returned: %ld", TEST_RETURN);
++		tst_res(TFAIL|TTERRNO, "read returned: %ld", TEST_RETURN);
+ 	else
+-		tst_resm(TPASS, "after EPIPE read returned next record");
++		tst_res(TPASS, "after EPIPE read returned next record");
+ 
+-	SAFE_CLOSE(cleanup, fd);
++	SAFE_CLOSE(fd);
+ }
+ 
+ static int read_msg_seqno(int fd, unsigned long *seqno)
+@@ -478,16 +472,14 @@ static int read_msg_seqno(int fd, unsigned long *seqno)
+ 	char msg[MAX_MSGSIZE];
+ 
+ 	TEST(read(fd, msg, sizeof(msg)));
+-	if (TEST_RETURN == -1 && TEST_ERRNO != EPIPE) {
+-		tst_brkm(TBROK|TTERRNO, cleanup,
+-			"failed to read /dev/kmsg");
+-	}
++	if (TEST_RETURN == -1 && TEST_ERRNO != EPIPE)
++		tst_brk(TBROK|TTERRNO, "failed to read /dev/kmsg");
+ 
+ 	if (TEST_ERRNO == EPIPE)
+ 		return -1;
+ 
+ 	if (get_msg_fields(msg, NULL, seqno) != 0) {
+-		tst_resm(TFAIL, "failed to parse seqid: %s", msg);
++		tst_res(TFAIL, "failed to parse seqid: %s", msg);
+ 		return -1;
+ 	}
+ 
+@@ -502,7 +494,7 @@ static void test_seek(void)
+ 	int ret = 0;
+ 
+ 	/* 1. read() after SEEK_SET 0 returns same (first) message */
+-	tst_resm(TINFO, "TEST: seek SEEK_SET 0");
++	tst_res(TINFO, "TEST: seek SEEK_SET 0");
+ 
+ 	for (j = 0; j < NUM_READ_RETRY && !ret; j++) {
+ 		/*
+@@ -520,14 +512,14 @@ static void test_seek(void)
+ 		 * first entry in buffer got overwritten. If so,
+ 		 * we'll have to repeat the test.
+ 		 */
+-		fd = SAFE_OPEN(cleanup, "/dev/kmsg", O_RDONLY | O_NONBLOCK);
+-		fd2 = SAFE_OPEN(cleanup, "/dev/kmsg", O_RDONLY | O_NONBLOCK);
++		fd = SAFE_OPEN("/dev/kmsg", O_RDONLY | O_NONBLOCK);
++		fd2 = SAFE_OPEN("/dev/kmsg", O_RDONLY | O_NONBLOCK);
+ 
+ 		if (read_msg_seqno(fd, &seqno[0]))
+ 			goto close_fds;
+ 
+ 		if (lseek(fd, 0, SEEK_SET) == -1) {
+-			tst_resm(TFAIL|TERRNO, "SEEK_SET 0 failed");
++			tst_res(TFAIL|TERRNO, "SEEK_SET 0 failed");
+ 			ret = -1;
+ 			goto close_fds;
+ 		}
+@@ -540,79 +532,63 @@ static void test_seek(void)
+ 
+ 		ret = 1;
+ close_fds:
+-		SAFE_CLOSE(cleanup, fd);
+-		SAFE_CLOSE(cleanup, fd2);
++		SAFE_CLOSE(fd);
++		SAFE_CLOSE(fd2);
+ 	}
+ 
+ 	if (j == NUM_READ_RETRY) {
+-		tst_resm(TWARN, "exceeded: %d attempts", NUM_READ_RETRY);
++		tst_res(TWARN, "exceeded: %d attempts", NUM_READ_RETRY);
+ 	} else if (ret > 0) {
+ 		if (seqno[0] != seqno[1]) {
+-			tst_resm(TFAIL, "SEEK_SET 0, %lu != %lu",
++			tst_res(TFAIL, "SEEK_SET 0, %lu != %lu",
+ 				seqno[0], seqno[1]);
+ 		} else {
+-			tst_resm(TPASS, "SEEK_SET 0");
++			tst_res(TPASS, "SEEK_SET 0");
+ 		}
+ 	}
+ 
+ 	/* 2. messages after SEEK_END 0 shouldn't contain MSG_PREFIX */
+-	fd = SAFE_OPEN(cleanup, "/dev/kmsg", O_RDONLY | O_NONBLOCK);
+-	tst_resm(TINFO, "TEST: seek SEEK_END 0");
++	fd = SAFE_OPEN("/dev/kmsg", O_RDONLY | O_NONBLOCK);
++	tst_res(TINFO, "TEST: seek SEEK_END 0");
+ 	if (lseek(fd, 0, SEEK_END) == -1)
+-		tst_resm(TFAIL|TERRNO, "lseek SEEK_END 0 failed");
++		tst_res(TFAIL|TERRNO, "lseek SEEK_END 0 failed");
+ 	if (find_msg(fd, MSG_PREFIX, msg, sizeof(msg), 0) != 0)
+-		tst_resm(TPASS, "SEEK_END 0");
++		tst_res(TPASS, "SEEK_END 0");
+ 	else
+-		tst_resm(TFAIL, "SEEK_END 0 found: %s", msg);
++		tst_res(TFAIL, "SEEK_END 0 found: %s", msg);
+ 
+ #ifdef SEEK_DATA
+ 	/* 3. messages after SEEK_DATA 0 shouldn't contain MSG_PREFIX */
+-	tst_resm(TINFO, "TEST: seek SEEK_DATA 0");
++	tst_res(TINFO, "TEST: seek SEEK_DATA 0");
+ 
+ 	/* clear ring buffer */
+-	if (ltp_syscall(__NR_syslog, 5, NULL, 0) == -1)
+-		tst_brkm(TBROK|TERRNO, cleanup, "syslog clear failed");
++	if (tst_syscall(__NR_syslog, 5, NULL, 0) == -1)
++		tst_brk(TBROK|TERRNO, "syslog clear failed");
+ 	if (lseek(fd, 0, SEEK_DATA) == -1)
+-		tst_resm(TFAIL|TERRNO, "lseek SEEK_DATA 0 failed");
++		tst_res(TFAIL|TERRNO, "lseek SEEK_DATA 0 failed");
+ 	if (find_msg(fd, MSG_PREFIX, msg, sizeof(msg), 0) != 0)
+-		tst_resm(TPASS, "SEEK_DATA 0");
++		tst_res(TPASS, "SEEK_DATA 0");
+ 	else
+-		tst_resm(TFAIL, "SEEK_DATA 0 found: %s", msg);
++		tst_res(TFAIL, "SEEK_DATA 0 found: %s", msg);
+ #endif
+-	SAFE_CLOSE(cleanup, fd);
++	SAFE_CLOSE(fd);
+ }
+ 
+-int main(int argc, char *argv[])
++static void test_kmsg(void)
+ {
+-	int lc;
+-
+-	tst_parse_opts(argc, argv, NULL, NULL);
+-
+-	setup();
+-	for (lc = 0; TEST_LOOPING(lc); lc++) {
+-		/* run test_inject first so log isn't empty for other tests */
+-		test_inject();
+-		test_read_nonblock();
+-		test_read_block();
+-		test_partial_read();
+-		test_read_returns_first_message();
+-		test_messages_overwritten();
+-		test_seek();
+-	}
+-	cleanup();
+-	tst_exit();
++	/* run test_inject first so log isn't empty for other tests */
++	test_inject();
++	test_read_nonblock();
++	test_read_block();
++	test_partial_read();
++	test_read_returns_first_message();
++	test_messages_overwritten();
++	test_seek();
+ }
+ 
+-static void setup(void)
+-{
+-	tst_require_root();
+-	if (tst_kvercmp(3, 5, 0) < 0)
+-		tst_brkm(TCONF, NULL, "This test requires kernel"
+-			" >= 3.5.0");
+-	srand(getpid());
+-	TEST_PAUSE;
+-}
+-
+-static void cleanup(void)
+-{
+-}
++static struct tst_test test = {
++	.tid = "kmsg01",
++	.needs_root = 1,
++	.test_all = test_kmsg,
++	.min_kver = "3.5.0"
++};
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170516/0001-move_pages12-replace-memset-with-mlock.patch
+++ b/distribution/ltp/include/patches/20170516/0001-move_pages12-replace-memset-with-mlock.patch
@@ -1,0 +1,44 @@
+From 328e7f914751b218116ab0d9cd62d77750cc3265 Mon Sep 17 00:00:00 2001
+Message-Id: <328e7f914751b218116ab0d9cd62d77750cc3265.1496216821.git.jstancek@redhat.com>
+From: Jan Stancek <jstancek@redhat.com>
+Date: Wed, 31 May 2017 09:40:31 +0200
+Subject: [PATCH] move_pages12: replace memset with mlock
+
+Use mlock instead of memset to avoid running into SIGBUS
+in low memory conditions.
+
+MAP_POPULATE wouldn't work, as it's only best effort,
+for details see:
+  http://www.serverphorums.com/read.php?12,1204538,1204539#msg-1204539
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/syscalls/move_pages/move_pages12.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/move_pages/move_pages12.c b/testcases/kernel/syscalls/move_pages/move_pages12.c
+index e1d956dba67e..4c7d5c2c01b0 100644
+--- a/testcases/kernel/syscalls/move_pages/move_pages12.c
++++ b/testcases/kernel/syscalls/move_pages/move_pages12.c
+@@ -165,9 +165,15 @@ static void alloc_free_huge_on_node(unsigned int node, size_t size)
+ 		tst_brk(TBROK | TERRNO, "mbind() failed");
+ 	}
+ 
+-	numa_bitmask_free(bm);
++	TEST(mlock(mem, size));
++	if (TEST_RETURN) {
++		SAFE_MUNMAP(mem, size);
++		if (TEST_ERRNO == ENOMEM || TEST_ERRNO == EAGAIN)
++			tst_brk(TCONF, "Cannot lock huge pages");
++		tst_brk(TBROK | TTERRNO, "mlock failed");
++	}
+ 
+-	memset(mem, 0, size);
++	numa_bitmask_free(bm);
+ 
+ 	SAFE_MUNMAP(mem, size);
+ }
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170516/0001-pipeio-avoid-SAFE-macros-in-cleanup.patch
+++ b/distribution/ltp/include/patches/20170516/0001-pipeio-avoid-SAFE-macros-in-cleanup.patch
@@ -1,0 +1,56 @@
+From d96efcf348d74718bdde273efe8a680f7397dd86 Mon Sep 17 00:00:00 2001
+Message-Id: <d96efcf348d74718bdde273efe8a680f7397dd86.1495439260.git.jstancek@redhat.com>
+From: Jan Stancek <jstancek@redhat.com>
+Date: Mon, 22 May 2017 09:36:53 +0200
+Subject: [PATCH] pipeio: avoid SAFE macros in cleanup()
+
+Only newlib testcases support SAFE macros in cleanup().
+When SAFE_UNLINK fails, it creates infinite loop between
+tst_brk_ and cleanup:
+
+ #0  tst_res__ at tst_res.c:153
+ #1  0x0000000000407ba8 in tst_brk__ at tst_res.c:480
+ #2  0x00000000004081fe in tst_brkm_ at tst_res.c:577
+ #3  0x000000000040a7c9 in safe_unlink at safe_macros.c:358
+ #4  0x0000000000404abd in cleanup () at pipeio.c:497
+ #5  0x0000000000407bc7 in tst_brk__ at tst_res.c:498
+ #6  0x00000000004081fe in tst_brkm_ at tst_res.c:577
+ #7  0x000000000040c1d6 in def_handler at tst_sig.c:231
+ #8  <signal handler called>
+ #9  0x00007f29c2cbd1f7 in __GI_raise at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
+ #10 0x00007f29c2cbe8e8 in __GI_abort () at abort.c:90
+ #11 0x00000000004081af in tst_brkm_ at tst_res.c:581
+ #12 0x000000000040a7c9 in safe_unlink at safe_macros.c:358
+ #13 0x0000000000404abd in cleanup () at pipeio.c:497
+ #14 0x0000000000407bc7 in tst_brk__ at tst_res.c:498
+ #15 0x00000000004081fe in tst_brkm_ at tst_res.c:577
+ #16 0x000000000040c1d6 in def_handler at tst_sig.c:231
+ #17 <signal handler called>
+ #18 0x00007f29c2cbd1f7 in __GI_raise at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
+ #19 0x00007f29c2cbe8e8 in __GI_abort () at abort.c:90
+ #20 0x00000000004081af in tst_brkm_ at tst_res.c:581
+ #21 0x000000000040a7c9 in safe_unlink at safe_macros.c:358
+ #22 0x0000000000404abd in cleanup () at pipeio.c:497
+ ...
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/ipc/pipeio/pipeio.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testcases/kernel/ipc/pipeio/pipeio.c b/testcases/kernel/ipc/pipeio/pipeio.c
+index 8426fb0e6b53..5aa082fd579b 100644
+--- a/testcases/kernel/ipc/pipeio/pipeio.c
++++ b/testcases/kernel/ipc/pipeio/pipeio.c
+@@ -494,7 +494,7 @@ static void cleanup(void)
+ 	semctl(sem_id, 0, IPC_RMID);
+ 
+ 	if (!unpipe)
+-		SAFE_UNLINK(NULL, pname);
++		unlink(pname);
+ 
+ 	tst_rmdir();
+ }
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170516/0001-recvmsg03-avoid-close-and-recvmsg-racing.patch
+++ b/distribution/ltp/include/patches/20170516/0001-recvmsg03-avoid-close-and-recvmsg-racing.patch
@@ -1,0 +1,65 @@
+From b349949b516eb7328bf637196abb6f8a2d69b675 Mon Sep 17 00:00:00 2001
+Message-Id: <b349949b516eb7328bf637196abb6f8a2d69b675.1497508909.git.jstancek@redhat.com>
+From: Sabrina Dubroca <sdubroca@redhat.com>
+Date: Tue, 13 Jun 2017 16:48:46 +0200
+Subject: [PATCH] recvmsg03: avoid close() and recvmsg() racing
+
+This testcase rarely hangs on single CPU systems. Problem
+appears to be between recvmsg() and close():
+1. sendmsg(), packet gets queued
+2. close(), packet is dropped
+3. recvmsg(), nothing to fetch
+
+strace of a buggy run:
+  [pid 17284] 16:04:41.042617 socket(AF_RDS, SOCK_SEQPACKET, 0) = 3
+  [pid 17284] 16:04:41.049549 close(3)    = 0
+  strace: Process 17290 attached
+  [pid 17284] 16:04:41.050765 socket(AF_RDS, SOCK_SEQPACKET, 0 <unfinished ...>
+  [pid 17290] 16:04:41.050894 futex(0x7f95dfc57014, FUTEX_WAIT, 0, {tv_sec=10, tv_nsec=0} <unfinished ...>
+  [pid 17284] 16:04:41.051001 <... socket resumed> ) = 3
+  [pid 17284] 16:04:41.051111 bind(3, {sa_family=AF_INET, sin_port=htons(4000), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
+  [pid 17284] 16:04:41.051374 futex(0x7f95dfc57014, FUTEX_WAKE, 2147483647) = 1
+  [pid 17290] 16:04:41.051432 <... futex resumed> ) = 0
+  [pid 17284] 16:04:41.051442 recvmsg(3,  <unfinished ...>
+  [pid 17290] 16:04:41.051455 socket(AF_RDS, SOCK_SEQPACKET, 0) = 3
+  [pid 17290] 16:04:41.051666 bind(3, {sa_family=AF_INET, sin_port=htons(4001), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
+  [pid 17290] 16:04:41.051724 sendmsg(3, {msg_name={sa_family=AF_INET, sin_port=htons(4000), sin_addr=inet_addr("127.0.0.1")}, msg_namelen=16, msg_iov=[{iov_base="hello world\0", iov_len=12}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 12
+  [pid 17290] 16:04:41.051975 close(3)    = 0
+  [pid 17290] 16:04:41.052492 +++ exited with 0 +++
+  [pid 17284] 16:04:41.052598 <... recvmsg resumed> {msg_namelen=32}, 0) = ? ERESTARTSYS (To be restarted if SA_RESTART is set)
+  [pid 17284] 16:04:41.052631 --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=17290, si_uid=0, si_status=0, si_utime=0, si_stime=0} ---
+  [pid 17284] 16:04:41.052718 recvmsg(3, // hang
+
+Signed-off-by: Sabrina Dubroca <sdubroca@redhat.com>
+[ wrote changelog message ]
+Acked-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/syscalls/recvmsg/recvmsg03.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/testcases/kernel/syscalls/recvmsg/recvmsg03.c b/testcases/kernel/syscalls/recvmsg/recvmsg03.c
+index 31e7585b66ab..8bbdaceeb464 100644
+--- a/testcases/kernel/syscalls/recvmsg/recvmsg03.c
++++ b/testcases/kernel/syscalls/recvmsg/recvmsg03.c
+@@ -90,6 +90,8 @@ static void client(void)
+ 			"sendmsg() failed to send data to server");
+ 	}
+ 
++	TST_CHECKPOINT_WAIT(1);
++
+ 	SAFE_CLOSE(sock_fd1);
+ }
+ 
+@@ -137,6 +139,8 @@ static void server(void)
+ 			msg.msg_namelen);
+ 	}
+ 
++	TST_CHECKPOINT_WAKE(1);
++
+ 	SAFE_CLOSE(sock_fd2);
+ }
+ 
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170516/0001-syscalls-add_key02-add-the-logon-key-type.patch
+++ b/distribution/ltp/include/patches/20170516/0001-syscalls-add_key02-add-the-logon-key-type.patch
@@ -1,0 +1,28 @@
+From e59c0a09a31fc6adc3bda0d1dc30c01d45fcabf6 Mon Sep 17 00:00:00 2001
+From: Xiao Yang <yangx.jy@cn.fujitsu.com>
+Date: Wed, 14 Jun 2017 15:39:09 +0800
+Subject: [PATCH] syscalls/add_key02: add the "logon" key type
+
+This key type is introduced in kernel:
+'9f6ed2ca257f(keys: add a "logon" key type)'
+
+Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>
+---
+ testcases/kernel/syscalls/add_key/add_key02.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/testcases/kernel/syscalls/add_key/add_key02.c b/testcases/kernel/syscalls/add_key/add_key02.c
+index 2e3308d..979f668 100644
+--- a/testcases/kernel/syscalls/add_key/add_key02.c
++++ b/testcases/kernel/syscalls/add_key/add_key02.c
+@@ -56,6 +56,7 @@ struct tcase {
+ 	{ "rxrpc",		64 },
+ 	{ "rxrpc_s",		 8 },
+ 	{ "user",		64 },
++	{ "logon",              64 },
+ };
+ #endif /* HAVE_LINUX_KEYCTL_H */
+ 
+-- 
+2.9.3
+

--- a/distribution/ltp/include/patches/20170516/0001-syscalls-add_key02-update-to-test-fix-for-nonempty-N.patch
+++ b/distribution/ltp/include/patches/20170516/0001-syscalls-add_key02-update-to-test-fix-for-nonempty-N.patch
@@ -1,0 +1,135 @@
+From 25045624e941ee76a13febd36187e23c6c435507 Mon Sep 17 00:00:00 2001
+From: Eric Biggers <ebiggers@google.com>
+Date: Mon, 12 Jun 2017 11:55:21 -0700
+Subject: [PATCH] syscalls/add_key02: update to test fix for nonempty NULL
+ payload
+
+add_key02 was supposed to be a "Basic test for the add_key() syscall",
+but it actually happened to test the obscure case of passing a NULL
+payload with nonzero length.  This case was mishandled by the kernel,
+which either returned EINVAL or crashed with a NULL pointer dereference,
+depending on the key type.  (The former applied to the test, as it used
+the "user" key type.)  The expected behavior in this case is that the
+syscall fail with EFAULT.
+
+Update the test to expect the fixed behavior from v4.12-rc5, and make
+the test more thorough by testing additional key types, including ones
+that caused a NULL pointer dereference in unfixed kernels.
+
+Signed-off-by: Eric Biggers <ebiggers@google.com>
+---
+ testcases/kernel/syscalls/add_key/add_key02.c | 69 ++++++++++++++++++++-------
+ 1 file changed, 51 insertions(+), 18 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/add_key/add_key02.c b/testcases/kernel/syscalls/add_key/add_key02.c
+index 866800d..2e3308d 100644
+--- a/testcases/kernel/syscalls/add_key/add_key02.c
++++ b/testcases/kernel/syscalls/add_key/add_key02.c
+@@ -1,5 +1,6 @@
+ /******************************************************************************
+  * Copyright (c) Crackerjack Project., 2007				      *
++ * Copyright (c) 2017 Google, Inc.                                            *
+  *									      *
+  * This program is free software;  you can redistribute it and/or modify      *
+  * it under the terms of the GNU General Public License as published by       *
+@@ -18,10 +19,17 @@
+  ******************************************************************************/
+ 
+ /*
+- * Basic test for the add_key() syscall.
++ * Test that the add_key() syscall correctly handles a NULL payload with nonzero
++ * length.  Specifically, it should fail with EFAULT rather than oopsing the
++ * kernel with a NULL pointer dereference or failing with EINVAL, as it did
++ * before (depending on the key type).  This is a regression test for commit
++ * 5649645d725c ("KEYS: fix dereferencing NULL payload with nonzero length").
+  *
+- * History:   Porting from Crackerjack to LTP is done by
+- *	      Manas Kumar Nayak maknayak@in.ibm.com>
++ * Note that none of the key types that exhibited the NULL pointer dereference
++ * are guaranteed to be built into the kernel, so we just test as many as we
++ * can, in the hope of catching one.  We also test with the "user" key type for
++ * good measure, although it was one of the types that failed with EINVAL rather
++ * than dereferencing NULL.
+  */
+ 
+ #include "config.h"
+@@ -33,36 +41,61 @@
+ 
+ #ifdef HAVE_LINUX_KEYCTL_H
+ struct tcase {
+-	char *type;
+-	char *desc;
+-	void *payload;
+-	int plen;
+-	int exp_errno;
++	const char *type;
++	size_t plen;
+ } tcases[] = {
+-	{"user", "firstkey", NULL, 1, EINVAL}
++	/*
++	 * The payload length we test for each key type needs to pass initial
++	 * validation but is otherwise arbitrary.  Note: the "rxrpc_s" key type
++	 * requires a payload of exactly 8 bytes.
++	 */
++	{ "asymmetric",		64 },
++	{ "cifs.idmap",		64 },
++	{ "cifs.spnego",	64 },
++	{ "pkcs7_test",		64 },
++	{ "rxrpc",		64 },
++	{ "rxrpc_s",		 8 },
++	{ "user",		64 },
+ };
+ #endif /* HAVE_LINUX_KEYCTL_H */
+ 
+ static void verify_add_key(unsigned int i)
+ {
+ #ifdef HAVE_LINUX_KEYCTL_H
+-	TEST(tst_syscall(__NR_add_key, tcases[i].type, tcases[i].desc,
+-	                 tcases[i].payload, tcases[i].plen,
+-	                 KEY_SPEC_USER_KEYRING));
++	TEST(tst_syscall(__NR_add_key, tcases[i].type, "abc:def",
++			 NULL, tcases[i].plen, KEY_SPEC_PROCESS_KEYRING));
+ 
+ 	if (TEST_RETURN != -1) {
+-		tst_res(TFAIL, "add_key() passed unexpectedly");
++		tst_res(TFAIL,
++			"add_key() with key type '%s' unexpectedly succeeded",
++			tcases[i].type);
+ 		return;
+ 	}
+ 
+-	if (TEST_ERRNO == tcases[i].exp_errno) {
+-		tst_res(TPASS | TTERRNO, "add_key() failed expectedly");
++	if (TEST_ERRNO == EFAULT) {
++		tst_res(TPASS, "received expected EFAULT with key type '%s'",
++			tcases[i].type);
+ 		return;
+ 	}
+ 
+-	tst_res(TFAIL | TTERRNO,
+-	        "add_key() failed unexpectedly, expected %s",
+-	        tst_strerrno(tcases[i].exp_errno));
++	if (TEST_ERRNO == ENODEV) {
++		tst_res(TCONF, "kernel doesn't support key type '%s'",
++			tcases[i].type);
++		return;
++	}
++
++	/*
++	 * It's possible for the "asymmetric" key type to be supported, but with
++	 * no asymmetric key parsers registered.  In that case, attempting to
++	 * add a key of type asymmetric will fail with EBADMSG.
++	 */
++	if (TEST_ERRNO == EBADMSG && !strcmp(tcases[i].type, "asymmetric")) {
++		tst_res(TCONF, "no asymmetric key parsers are registered");
++		return;
++	}
++
++	tst_res(TFAIL | TTERRNO, "unexpected error with key type '%s'",
++		tcases[i].type);
+ #else
+ 	tst_brk(TCONF, "linux/keyctl.h was missing upon compilation.");
+ #endif /* HAVE_LINUX_KEYCTL_H */
+-- 
+2.9.3
+

--- a/distribution/ltp/include/patches/20170516/0001-syscalls-memfd_create-test-memfd-flags-separately.patch
+++ b/distribution/ltp/include/patches/20170516/0001-syscalls-memfd_create-test-memfd-flags-separately.patch
@@ -1,0 +1,179 @@
+From 8024d15e3edf87803c878366aa36ae90d2dcefd1 Mon Sep 17 00:00:00 2001
+From: Jakub Racek <jracek@redhat.com>
+Date: Wed, 7 Jun 2017 13:15:53 +0200
+Subject: [PATCH] syscalls/memfd_create: test memfd flags separately
+
+Signed-off-by: Jakub Racek <jracek@redhat.com>
+---
+ .../kernel/syscalls/memfd_create/memfd_create01.c  | 12 ++++++-
+ .../kernel/syscalls/memfd_create/memfd_create02.c  | 13 +++++++-
+ .../syscalls/memfd_create/memfd_create_common.c    | 38 ++++++++++++++++++----
+ .../syscalls/memfd_create/memfd_create_common.h    | 17 ++++++++--
+ 4 files changed, 68 insertions(+), 12 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/memfd_create/memfd_create01.c b/testcases/kernel/syscalls/memfd_create/memfd_create01.c
+index 54c817b..6a84899 100644
+--- a/testcases/kernel/syscalls/memfd_create/memfd_create01.c
++++ b/testcases/kernel/syscalls/memfd_create/memfd_create01.c
+@@ -22,6 +22,7 @@
+ 
+ #define _GNU_SOURCE
+ 
++#include <errno.h>
+ #include "tst_test.h"
+ #include "memfd_create_common.h"
+ 
+@@ -259,7 +260,16 @@ static void verify_memfd_create(unsigned int n)
+ 
+ static void setup(void)
+ {
+-	ASSERT_HAVE_MEMFD_CREATE();
++	/*
++	 * For now, all tests in this file require MFD_ALLOW_SEALING flag
++	 * to be implemented, even though that flag isn't always set when
++	 * memfd is created. So don't check anything else and TCONF right away
++	 * is this flag is missing.
++	 */
++	if (!MFD_FLAGS_AVAILABLE(MFD_ALLOW_SEALING)) {
++		tst_brk(TCONF | TTERRNO,
++			"memfd_create(%u) not implemented", MFD_ALLOW_SEALING);
++	}
+ }
+ 
+ static struct tst_test test = {
+diff --git a/testcases/kernel/syscalls/memfd_create/memfd_create02.c b/testcases/kernel/syscalls/memfd_create/memfd_create02.c
+index d65e496..bc01e44 100644
+--- a/testcases/kernel/syscalls/memfd_create/memfd_create02.c
++++ b/testcases/kernel/syscalls/memfd_create/memfd_create02.c
+@@ -31,6 +31,8 @@
+ static char buf[2048];
+ static char term_buf[2048];
+ 
++static int available_flags;
++
+ static const struct tcase {
+ 	char *descr;
+ 	char *memfd_name;
+@@ -62,7 +64,8 @@ static const struct tcase {
+ 
+ static void setup(void)
+ {
+-	ASSERT_HAVE_MEMFD_CREATE();
++
++	available_flags = GET_MFD_ALL_AVAILABLE_FLAGS();
+ 
+ 	memset(buf, 0xff, sizeof(buf));
+ 
+@@ -73,8 +76,16 @@ static void setup(void)
+ static void verify_memfd_create_errno(unsigned int n)
+ {
+ 	const struct tcase *tc;
++	int needed_flags;
+ 
+ 	tc = &tcases[n];
++	needed_flags = tc->flags & FLAGS_ALL_MASK;
++
++	if ((available_flags & needed_flags) != needed_flags) {
++		tst_res(TCONF, "test '%s' skipped, flag not implemented",
++					tc->descr);
++		return;
++	}
+ 
+ 	TEST(sys_memfd_create(tc->memfd_name, tc->flags));
+ 	if (TEST_ERRNO != tc->memfd_create_exp_err)
+diff --git a/testcases/kernel/syscalls/memfd_create/memfd_create_common.c b/testcases/kernel/syscalls/memfd_create/memfd_create_common.c
+index 4cf3bd5..79fc02e 100644
+--- a/testcases/kernel/syscalls/memfd_create/memfd_create_common.c
++++ b/testcases/kernel/syscalls/memfd_create/memfd_create_common.c
+@@ -103,20 +103,44 @@ void check_ftruncate_fail(const char *filename, const int lineno,
+ 		"ftruncate(%d, %ld) failed as expected", fd, length);
+ }
+ 
+-void assert_have_memfd_create(const char *filename, const int lineno)
++int get_mfd_all_available_flags(const char *filename, const int lineno)
+ {
+-	TEST(sys_memfd_create("dummy_call", 0));
++	unsigned int i;
++	int flag;
++	int flags2test[] = FLAGS_ALL_ARRAY_INITIALIZER;
++	int flags_available = 0;
++
++	if (!MFD_FLAGS_AVAILABLE(0)) {
++		tst_brk_(filename, lineno, TCONF,
++				"memfd_create(0) not implemented");
++	}
++
++	for (i = 0; i < ARRAY_SIZE(flags2test); i++) {
++		flag = flags2test[i];
++
++		if (MFD_FLAGS_AVAILABLE(flag))
++			flags_available |= flag;
++	}
++
++	return flags_available;
++}
++
++int mfd_flags_available(const char *filename, const int lineno,
++		unsigned int flags)
++{
++	TEST(sys_memfd_create("dummy_call", flags));
+ 	if (TEST_RETURN < 0) {
+-		if (TEST_ERRNO == EINVAL) {
+-			tst_brk_(filename, lineno, TCONF | TTERRNO,
+-				"memfd_create() not implemented");
++		if (TEST_ERRNO != EINVAL) {
++			tst_brk_(filename, lineno, TBROK | TTERRNO,
++					"memfd_create() failed");
+ 		}
+ 
+-		tst_brk_(filename, lineno, TBROK | TTERRNO,
+-			"memfd_create() failed");
++		return 0;
+ 	}
+ 
+ 	SAFE_CLOSE(TEST_RETURN);
++
++	return 1;
+ }
+ 
+ int check_mfd_new(const char *filename, const int lineno,
+diff --git a/testcases/kernel/syscalls/memfd_create/memfd_create_common.h b/testcases/kernel/syscalls/memfd_create/memfd_create_common.h
+index 6329ac3..60ad895 100644
+--- a/testcases/kernel/syscalls/memfd_create/memfd_create_common.h
++++ b/testcases/kernel/syscalls/memfd_create/memfd_create_common.h
+@@ -20,10 +20,17 @@
+ #include <lapi/fcntl.h>
+ #include <lapi/memfd.h>
+ 
++/* change macros accordingly if any flags need to be added in the future */
++#define FLAGS_ALL_ARRAY_INITIALIZER {MFD_CLOEXEC, MFD_ALLOW_SEALING}
++#define FLAGS_ALL_MASK              (MFD_CLOEXEC | MFD_ALLOW_SEALING)
++
+ #define MFD_DEF_SIZE 8192
+ 
+-#define ASSERT_HAVE_MEMFD_CREATE() \
+-	assert_have_memfd_create(__FILE__, __LINE__)
++#define GET_MFD_ALL_AVAILABLE_FLAGS() \
++	get_mfd_all_available_flags(__FILE__, __LINE__)
++
++#define MFD_FLAGS_AVAILABLE(flags) \
++	mfd_flags_available(__FILE__, __LINE__, (flags))
+ 
+ #define CHECK_MFD_NEW(name, sz, flags) \
+ 	check_mfd_new(__FILE__, __LINE__, (name), (sz), (flags))
+@@ -89,7 +96,11 @@
+ #define CHECK_MFD_NON_GROWABLE_BY_WRITE(fd) \
+ 	check_mfd_non_growable_by_write(__FILE__, __LINE__, (fd))
+ 
+-void assert_have_memfd_create(const char *filename, const int lineno);
++int mfd_flags_available(const char *filename, const int lineno,
++		unsigned int flags);
++
++int get_mfd_all_available_flags(const char *filename, const int lineno);
++
+ int sys_memfd_create(const char *name, unsigned int flags);
+ 
+ int check_fallocate(const char *filename, const int lineno, int fd,
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/20170929/0001-clone08-don-t-treat-EWOULDBLOCK-as-failure.patch
+++ b/distribution/ltp/include/patches/20170929/0001-clone08-don-t-treat-EWOULDBLOCK-as-failure.patch
@@ -1,0 +1,66 @@
+From 7f7ee5eaf3b7998232cce4cae32b0bd52bba1a4d Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Fri, 20 Oct 2017 10:23:36 +0200
+Subject: [PATCH] clone08: don't treat EWOULDBLOCK as failure
+
+futex() and clone() are racing in test_clone_thread().
+If clone() changes ctid first, then futex() reports
+EWOULDBLOCK and test treats that as failure.
+
+We don't need to eliminate the race, since all we
+care about is that ctid is changed/cleared by clone().
+
+Also fix a small warning from unused variable.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Alexey Kodanev <alexey.kodanev@oracle.com>
+---
+ testcases/kernel/syscalls/clone/clone08.c | 25 +++++++++++++++++--------
+ 1 file changed, 17 insertions(+), 8 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/clone/clone08.c b/testcases/kernel/syscalls/clone/clone08.c
+index 58f9be0e2..a228b2f73 100644
+--- a/testcases/kernel/syscalls/clone/clone08.c
++++ b/testcases/kernel/syscalls/clone/clone08.c
+@@ -133,9 +133,7 @@ static int child_clone_parent(void *arg LTP_ATTRIBUTE_UNUSED)
+ 
+ static void test_clone_tid(int t)
+ {
+-	pid_t child;
+-
+-	child = clone_child(&test_cases[t]);
++	clone_child(&test_cases[t]);
+ 	tst_reap_children();
+ }
+ 
+@@ -206,11 +204,22 @@ static void test_clone_thread(int t)
+ 
+ 		clone_child(&test_cases[t]);
+ 
+-		if (syscall(SYS_futex, &ctid, FUTEX_WAIT, -1, &timeout))
+-			tst_res(TFAIL | TERRNO, "futex failed");
+-		else
+-			tst_res(TPASS, "futex exit on ctid change");
+-
++		if (syscall(SYS_futex, &ctid, FUTEX_WAIT, -1, &timeout)) {
++			/*
++			 * futex here is racing with clone() above.
++			 * Which means we can get EWOULDBLOCK if
++			 * ctid has been already changed by clone()
++			 * before we make the call. As long as ctid
++			 * changes we should not report error when
++			 * futex returns EWOULDBLOCK.
++			 */
++			if (errno != EWOULDBLOCK || ctid == -1) {
++				tst_res(TFAIL | TERRNO,
++					"futex failed, ctid: %d", ctid);
++				_exit(0);
++			}
++		}
++		tst_res(TPASS, "futex exit on ctid change, ctid: %d", ctid);
+ 		_exit(0);
+ 	}
+ 
+-- 
+2.13.6
+

--- a/distribution/ltp/include/patches/20170929/0001-kmsg01-set-restore-console-log-level.patch
+++ b/distribution/ltp/include/patches/20170929/0001-kmsg01-set-restore-console-log-level.patch
@@ -1,0 +1,69 @@
+From a2ff1c2d141d4b686ee44b709455cb1ec748f036 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Mon, 23 Oct 2017 12:49:27 +0200
+Subject: [PATCH] kmsg01: set/restore console log level
+
+commit 497564c77836 "kmsg01: lower the volume of message going to console"
+lowered message priority for the flood of messages that try to overwrite
+whole buffer. This works only for default console_loglevel. If anything
+increases console_loglevel (for example a call to console_verbose()
+via lockdep) system starts flooding also console. This causes a failure
+on systems with slower serial console, because test is unable to
+complete in 5 minutes.
+
+Before patch:
+  <timeout>
+
+After patch:
+  real	0m9.219s
+  user	0m0.289s
+  sys	0m4.027s
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/logging/kmsg/kmsg01.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/testcases/kernel/logging/kmsg/kmsg01.c b/testcases/kernel/logging/kmsg/kmsg01.c
+index 294d0a2d1..393acdcc7 100644
+--- a/testcases/kernel/logging/kmsg/kmsg01.c
++++ b/testcases/kernel/logging/kmsg/kmsg01.c
+@@ -52,7 +52,10 @@
+ #define NUM_READ_RETRY 10
+ #define NUM_OVERWRITE_MSGS 1024
+ #define READ_TIMEOUT 5
++#define PRINTK "/proc/sys/kernel/printk"
++#define CONSOLE_LOGLEVEL_QUIET   4
+ 
++static int console_loglevel = -1;
+ 
+ /*
+  * inject_msg - write message to /dev/kmsg
+@@ -571,7 +574,23 @@ static void test_kmsg(void)
+ 	test_seek();
+ }
+ 
++static void setup(void)
++{
++	if (access(PRINTK, F_OK) == 0) {
++		SAFE_FILE_SCANF(PRINTK, "%d", &console_loglevel);
++		SAFE_FILE_PRINTF(PRINTK, "%d", CONSOLE_LOGLEVEL_QUIET);
++	}
++}
++
++static void cleanup(void)
++{
++	if (console_loglevel != -1)
++		SAFE_FILE_PRINTF(PRINTK, "%d", console_loglevel);
++}
++
+ static struct tst_test test = {
++	.setup = setup,
++	.cleanup = cleanup,
+ 	.needs_root = 1,
+ 	.test_all = test_kmsg,
+ 	.min_kver = "3.5.0"
+-- 
+2.13.6
+

--- a/distribution/ltp/include/patches/20170929/0001-lib-fix-kernel-bit-detection-on-s390-platform.patch
+++ b/distribution/ltp/include/patches/20170929/0001-lib-fix-kernel-bit-detection-on-s390-platform.patch
@@ -1,0 +1,35 @@
+From 3d18c5d86942fcc1507a66ca617effc12ff97e9b Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Fri, 10 Nov 2017 16:07:20 +0800
+Subject: [PATCH] lib: fix kernel-bit detection on s390 platform
+
+This correction also fix the mmapstress03 issues on the latest kernel:
+  mmapstress03: errno = 25: really large mmap didn't fail
+  mmapstress03    0  TINFO  :  uname.machine=s390x kernel is 32bit
+  mmapstress03    1  TFAIL  :  mmapstress03.c:212: Test failed
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Acked-by: Jan Stancek <jstancek@redhat.com>
+---
+ lib/tst_kernel.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/tst_kernel.c b/lib/tst_kernel.c
+index fd648b1..42d64cb 100644
+--- a/lib/tst_kernel.c
++++ b/lib/tst_kernel.c
+@@ -34,8 +34,10 @@ int tst_kernel_bits(void)
+ 	/*
+ 	 * ARM64 (aarch64) defines 32-bit compatibility modes as
+ 	 * armv8l and armv8b (little and big endian).
++	 * s390x is 64bit but not contain 64 in the words.
+ 	 */
+-	if (!strcmp(buf.machine, "armv8l") || !strcmp(buf.machine, "armv8b"))
++	if (!strcmp(buf.machine, "armv8l") || !strcmp(buf.machine, "armv8b")
++			|| !strcmp(buf.machine, "s390x"))
+ 		kernel_bits = 64;
+ 
+ 	tst_resm(TINFO, "uname.machine=%s kernel is %ibit",
+-- 
+2.9.3
+

--- a/distribution/ltp/include/patches/20170929/0001-mm-raise-mmap-HIGH_ADDR-value-for-s390-arch.patch
+++ b/distribution/ltp/include/patches/20170929/0001-mm-raise-mmap-HIGH_ADDR-value-for-s390-arch.patch
@@ -1,0 +1,64 @@
+From 561b55b9c1752ce646f6286e30d15364713231d9 Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Fri, 10 Nov 2017 16:07:21 +0800
+Subject: [PATCH] mm: raise mmap HIGH_ADDR value for s390 arch
+
+The kernel commit 1aea9b3f92 (s390/mm: implement 5 level pages tables)
+enlarge the maximum address in the tasks address space from (1UL << 53)
+to (-PAGE_SIZE) on s390 platform.
+
+We have to increase the HIGH_ADDR in ltp testcases accordingly otherwise
+that would be failed with succeeded mmap into high region:
+
+mmap15  1  TFAIL  :  mmap15.c:77: mmap into high region succeeded unexpectedly
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Acked-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/syscalls/mmap/mmap15.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/mmap/mmap15.c b/testcases/kernel/syscalls/mmap/mmap15.c
+index 7e917bd..eff27d6 100644
+--- a/testcases/kernel/syscalls/mmap/mmap15.c
++++ b/testcases/kernel/syscalls/mmap/mmap15.c
+@@ -43,10 +43,10 @@ int TST_TOTAL = 1;
+ #ifdef __ia64__
+ # define HIGH_ADDR (void *)(0xa000000000000000UL)
+ #else
+-# define HIGH_ADDR (void *)(1L << 53)
++# define HIGH_ADDR (void *)(-page_size)
+ #endif
+ 
+-static long map_sz;
++static long page_size;
+ 
+ static void setup(void);
+ static void cleanup(void);
+@@ -70,12 +70,12 @@ int main(int ac, char **av)
+ 		fd = SAFE_OPEN(cleanup, "testfile", O_RDWR | O_CREAT, 0666);
+ 
+ 		/* Attempt to mmap into highmem addr, should get ENOMEM */
+-		addr = mmap(HIGH_ADDR, map_sz, PROT_READ,
++		addr = mmap(HIGH_ADDR, page_size, PROT_READ,
+ 			    MAP_SHARED | MAP_FIXED, fd, 0);
+ 		if (addr != MAP_FAILED) {
+ 			tst_resm(TFAIL, "mmap into high region "
+ 				 "succeeded unexpectedly");
+-			munmap(addr, map_sz);
++			munmap(addr, page_size);
+ 			close(fd);
+ 			continue;
+ 		}
+@@ -102,7 +102,7 @@ static void setup(void)
+ 
+ 	tst_tmpdir();
+ 
+-	map_sz = getpagesize();
++	page_size = getpagesize();
+ 
+ 	TEST_PAUSE;
+ }
+-- 
+2.9.3
+

--- a/distribution/ltp/include/patches/20170929/0002-kmsg01-specify-read-timeout-in-usec.patch
+++ b/distribution/ltp/include/patches/20170929/0002-kmsg01-specify-read-timeout-in-usec.patch
@@ -1,0 +1,81 @@
+From 576ad2541f0a2db21854069adba5aa206e99327e Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Mon, 23 Oct 2017 13:05:12 +0200
+Subject: [PATCH] kmsg01: specify read timeout in usec
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/logging/kmsg/kmsg01.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/testcases/kernel/logging/kmsg/kmsg01.c b/testcases/kernel/logging/kmsg/kmsg01.c
+index 393acdcc7..b81c077cb 100644
+--- a/testcases/kernel/logging/kmsg/kmsg01.c
++++ b/testcases/kernel/logging/kmsg/kmsg01.c
+@@ -51,7 +51,7 @@
+ #define NUM_READ_MSGS 3
+ #define NUM_READ_RETRY 10
+ #define NUM_OVERWRITE_MSGS 1024
+-#define READ_TIMEOUT 5
++#define READ_TIMEOUT 5000000
+ #define PRINTK "/proc/sys/kernel/printk"
+ #define CONSOLE_LOGLEVEL_QUIET   4
+ 
+@@ -148,14 +148,14 @@ static int get_msg_fields(const char *msg, unsigned long *prio,
+ /*
+  * timed_read - if possible reads from fd or times out
+  * @fd:           fd to read from
+- * @timeout_sec:  timeout in seconds
++ * @timeout_usec: timeout in useconds
+  *
+  * RETURNS:
+  *   read bytes on successful read
+  *  -1 on read() error, errno reflects read() errno
+  *  -2 on timeout
+  */
+-static int timed_read(int fd, int timeout_sec)
++static int timed_read(int fd, long timeout_usec)
+ {
+ 	int ret, tmp;
+ 	struct timeval timeout;
+@@ -163,8 +163,8 @@ static int timed_read(int fd, int timeout_sec)
+ 
+ 	FD_ZERO(&read_fds);
+ 	FD_SET(fd, &read_fds);
+-	timeout.tv_sec = timeout_sec;
+-	timeout.tv_usec = 0;
++	timeout.tv_sec = timeout_usec / 1000000;
++	timeout.tv_usec = timeout_usec % 1000000;
+ 
+ 	ret = select(fd + 1, &read_fds, 0, 0, &timeout);
+ 	switch (ret) {
+@@ -183,14 +183,14 @@ static int timed_read(int fd, int timeout_sec)
+  *                   read fails or times out. This ignores any
+  *                   EPIPE errors.
+  * @fd:           fd to read from
+- * @timeout_sec:  timeout in seconds for every read attempt
++ * @timeout_usec: timeout in useconds for every read attempt
+  *
+  * RETURNS:
+  *     0 on read reaching eof
+  *    -1 on read error, errno reflects read() errno
+  *    -2 on timeout
+  */
+-static int timed_read_kmsg(int fd, int timeout_sec)
++static int timed_read_kmsg(int fd, long timeout_usec)
+ {
+ 	int child, status, ret = 0;
+ 	int pipefd[2];
+@@ -226,7 +226,7 @@ static int timed_read_kmsg(int fd, int timeout_sec)
+ 
+ 	/* parent reads pipe until it reaches eof or until read times out */
+ 	do {
+-		TEST(timed_read(pipefd[0], timeout_sec));
++		TEST(timed_read(pipefd[0], timeout_usec));
+ 	} while (TEST_RETURN > 0);
+ 	SAFE_CLOSE(pipefd[0]);
+ 
+-- 
+2.13.6
+

--- a/distribution/ltp/include/patches/20170929/0003-kmsg01-use-lower-timeout-for-test_read_block.patch
+++ b/distribution/ltp/include/patches/20170929/0003-kmsg01-use-lower-timeout-for-test_read_block.patch
@@ -1,0 +1,50 @@
+From 87bd943a22bbd2f3aec4747dc5f03cfd9f642e82 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Mon, 23 Oct 2017 14:12:19 +0200
+Subject: [PATCH] kmsg01: use lower timeout for test_read_block()
+
+Test is currently expecting that read will block for ~5 seconds.
+This is a problem for busy systems, where there are many messages
+periodically generated. One example is ie31200_edac module,
+which periodically generates a message every second on debug
+kernels.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/logging/kmsg/kmsg01.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/testcases/kernel/logging/kmsg/kmsg01.c b/testcases/kernel/logging/kmsg/kmsg01.c
+index b81c077cb..7f077c9a3 100644
+--- a/testcases/kernel/logging/kmsg/kmsg01.c
++++ b/testcases/kernel/logging/kmsg/kmsg01.c
+@@ -51,7 +51,6 @@
+ #define NUM_READ_MSGS 3
+ #define NUM_READ_RETRY 10
+ #define NUM_OVERWRITE_MSGS 1024
+-#define READ_TIMEOUT 5000000
+ #define PRINTK "/proc/sys/kernel/printk"
+ #define CONSOLE_LOGLEVEL_QUIET   4
+ 
+@@ -252,7 +251,7 @@ static void test_read_nonblock(void)
+ 	tst_res(TINFO, "TEST: nonblock read");
+ 	fd = SAFE_OPEN("/dev/kmsg", O_RDONLY | O_NONBLOCK);
+ 
+-	TEST(timed_read_kmsg(fd, READ_TIMEOUT));
++	TEST(timed_read_kmsg(fd, 5000000));
+ 	if (TEST_RETURN == -1 && TEST_ERRNO == EAGAIN)
+ 		tst_res(TPASS, "non-block read returned EAGAIN");
+ 	else
+@@ -268,7 +267,7 @@ static void test_read_block(void)
+ 	tst_res(TINFO, "TEST: blocking read");
+ 	fd = SAFE_OPEN("/dev/kmsg", O_RDONLY);
+ 
+-	TEST(timed_read_kmsg(fd, READ_TIMEOUT));
++	TEST(timed_read_kmsg(fd, 500000));
+ 	if (TEST_RETURN == -2)
+ 		tst_res(TPASS, "read blocked");
+ 	else
+-- 
+2.13.6
+

--- a/distribution/ltp/include/patches/20180118/0001-mallocstress-extend-test-time.patch
+++ b/distribution/ltp/include/patches/20180118/0001-mallocstress-extend-test-time.patch
@@ -1,0 +1,34 @@
+From a8ecd8ae386b609d7da2d500ef8e9baec8dd7dc7 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Fri, 9 Mar 2018 10:58:01 +0100
+Subject: [PATCH 1/2] mallocstress: extend test time
+
+Arm systems with lot of memory and THP enabled are
+hitting a timeout at ~5 minute mark as reported here:
+  mallocstress poor performance with THP on arm64 system
+  https://marc.info/?l=linux-mm&m=151864950330870&w=2
+
+Some other systems are already getting close to ~5 minutes,
+so let's extend it to 10m for all.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/mem/mtest07/mallocstress.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/testcases/kernel/mem/mtest07/mallocstress.c b/testcases/kernel/mem/mtest07/mallocstress.c
+index 2e900ad..70b614b 100644
+--- a/testcases/kernel/mem/mtest07/mallocstress.c
++++ b/testcases/kernel/mem/mtest07/mallocstress.c
+@@ -243,6 +243,7 @@ static void cleanup(void)
+ }
+ 
+ static struct tst_test test = {
++	.timeout = 600,
+ 	.needs_checkpoints = 1,
+ 	.setup = setup,
+ 	.cleanup = cleanup,
+-- 
+2.9.3
+

--- a/distribution/ltp/include/patches/20180118/0001-safe_macros-make-is_fuse-return-zero-if-fs_type-is-N.patch
+++ b/distribution/ltp/include/patches/20180118/0001-safe_macros-make-is_fuse-return-zero-if-fs_type-is-N.patch
@@ -1,0 +1,39 @@
+From 67af7dbe8bdf29f9ed980d8d29feeae32a0a7a1d Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Tue, 23 Jan 2018 17:46:35 +0800
+Subject: [PATCH] safe_macros: make is_fuse() return zero if fs_type is NULL
+
+This commmit 28507e514c(safe_mount: Do not try mount() syscall for FUSE fs)
+involves FUSE fs check in safe_mount(), but we'd better guarantee the "fs_type"
+is legal to check in is_fuse() function otherwise system will kill the program.
+
+  cmdline="fanotify06"
+  contacts=""
+  analysis=exit
+  <<<test_output>>>
+  tst_test.c:980: INFO: Timeout per run is 0h 10m 00s
+  tst_test.c:1025: BROK: Test killed by SIGSEGV!
+
+Signed-off-by: Li Wang <liwang@redhat.com>
+Acked-by: Jan Stancek <jstancek@redhat.com>
+---
+ lib/safe_macros.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/safe_macros.c b/lib/safe_macros.c
+index c48e436..abdeca0 100644
+--- a/lib/safe_macros.c
++++ b/lib/safe_macros.c
+@@ -708,6 +708,9 @@ static int is_fuse(const char *fs_type)
+ {
+ 	unsigned int i;
+ 
++	if (!fs_type)
++		return 0;
++
+ 	for (i = 0; i < ARRAY_SIZE(fuse_fs_types); i++) {
+ 		if (!strcmp(fuse_fs_types[i], fs_type))
+ 			return 1;
+-- 
+2.9.3
+

--- a/distribution/ltp/include/patches/20180118/0002-times03-don-t-assume-process-initial-us-time-is-0.patch
+++ b/distribution/ltp/include/patches/20180118/0002-times03-don-t-assume-process-initial-us-time-is-0.patch
@@ -1,0 +1,52 @@
+From ed01f6a05c77f65cb5d1089474c9a0e2129c581a Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Fri, 9 Mar 2018 08:25:51 +0100
+Subject: [PATCH 2/2] times03: don't assume process initial [us]time is 0
+
+times() runs immediately after fork(), but syscall alone
+seems to be enough for some systems to already account ticks.
+
+For example on arm64 with 4.14:
+  tst_test.c:980: INFO: Timeout per run is 0h 05m 00s
+  times03.c:102: PASS: buf1.tms_utime = 0
+  times03.c:105: FAIL: buf1.tms_stime = 1
+  ...
+
+This patch replaces zero check with a comparison against a small
+enough number < 5 (which should be between 5ms and 50ms depending
+on CONFIG_HZ).
+
+Suggested-by: Cyril Hrubis <chrubis@suse.cz>
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/kernel/syscalls/times/times03.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/times/times03.c b/testcases/kernel/syscalls/times/times03.c
+index 78d72d2..7911c03 100644
+--- a/testcases/kernel/syscalls/times/times03.c
++++ b/testcases/kernel/syscalls/times/times03.c
+@@ -96,15 +96,15 @@ static void verify_times(void)
+ 	if (times(&buf1) == -1)
+ 		tst_brk(TBROK | TERRNO, "times()");
+ 
+-	if (buf1.tms_utime != 0)
++	if (buf1.tms_utime > 5)
+ 		tst_res(TFAIL, "buf1.tms_utime = %li", buf1.tms_utime);
+ 	else
+-		tst_res(TPASS, "buf1.tms_utime = 0");
++		tst_res(TPASS, "buf1.tms_utime <= 5");
+ 
+-	if (buf1.tms_stime != 0)
++	if (buf1.tms_stime > 5)
+ 		tst_res(TFAIL, "buf1.tms_stime = %li", buf1.tms_stime);
+ 	else
+-		tst_res(TPASS, "buf1.tms_stime = 0");
++		tst_res(TPASS, "buf1.tms_stime <= 5");
+ 
+ 	generate_utime();
+ 	generate_stime();
+-- 
+2.9.3
+

--- a/distribution/ltp/include/patches/20180515/0001-cve-2017-5669-shmat-for-0-or-PAGESIZE-with-RND-flag-.patch
+++ b/distribution/ltp/include/patches/20180515/0001-cve-2017-5669-shmat-for-0-or-PAGESIZE-with-RND-flag-.patch
@@ -1,0 +1,93 @@
+From b767b73ef027ba8d35f297c7d3659265ac80425b Mon Sep 17 00:00:00 2001
+From: Rafael David Tinoco <rafael.tinoco@canonical.com>
+Date: Wed, 30 May 2018 09:14:34 -0300
+Subject: [PATCH] cve-2017-5669: shmat() for 0 (or <PAGESIZE with RND flag) has
+ to fail with REMAPs
+
+Fixes: https://github.com/linux-test-project/ltp/issues/319
+
+According to upstream thread (https://lkml.org/lkml/2018/5/28/2056),
+cve-2017-5669 needs to address the "new" way of handling nil addresses
+for shmat() when used with MAP_FIXED or SHM_REMAP flags.
+
+- mapping nil-page is OK on lower addresses with MAP_FIXED (or else X11 is broken)
+- mapping nil-page is NOT OK with SHM_REMAP on lower addresses
+
+Addresses Davidlohr Bueso's comments/changes:
+
+commit 8f89c007b6de
+Author: Davidlohr Bueso <dave@stgolabs.net>
+Date:   Fri May 25 14:47:30 2018 -0700
+
+    ipc/shm: fix shmat() nil address after round-down when remapping
+
+commit a73ab244f0da
+Author: Davidlohr Bueso <dave@stgolabs.net>
+Date:   Fri May 25 14:47:27 2018 -0700
+
+    Revert "ipc/shm: Fix shmat mmap nil-page protection"
+
+For previously test, and now broken, made based on:
+
+commit 95e91b831f87
+Author: Davidlohr Bueso <dave@stgolabs.net>
+Date:   Mon Feb 27 14:28:24 2017 -0800
+
+    ipc/shm: Fix shmat mmap nil-page protection
+
+Signed-off-by: Rafael David Tinoco <rafael.tinoco@linaro.org>
+Tested-by: Naresh Kamboju <naresh.kamboju@linaro.org>
+Reviewed-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/cve/cve-2017-5669.c | 20 +++++++++++++++++++-
+ 1 file changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/testcases/cve/cve-2017-5669.c b/testcases/cve/cve-2017-5669.c
+index 1ca5983..0834626 100644
+--- a/testcases/cve/cve-2017-5669.c
++++ b/testcases/cve/cve-2017-5669.c
+@@ -28,7 +28,20 @@
+  * is just to see if we get an access error or some other unexpected behaviour.
+  *
+  * See commit 95e91b831f (ipc/shm: Fix shmat mmap nil-page protection)
++ *
++ * The commit above disallowed SHM_RND maps to zero (and rounded) entirely and
++ * that broke userland for cases like Xorg. New behavior disallows REMAPs to
++ * lower addresses (0<=PAGESIZE).
++ *
++ * See commit a73ab244f0da (Revert "ipc/shm: Fix shmat mmap nil-page protect...)
++ * See commit 8f89c007b6de (ipc/shm: fix shmat() nil address after round-dow...)
++ * See https://github.com/linux-test-project/ltp/issues/319
++ *
++ * This test needs root permissions or else security_mmap_addr(), from
++ * get_unmapped_area(), will cause permission errors when trying to mmap lower
++ * addresses.
+  */
++
+ #include <sys/types.h>
+ #include <sys/ipc.h>
+ #include <sys/shm.h>
+@@ -60,7 +73,11 @@ static void cleanup(void)
+ static void run(void)
+ {
+ 	tst_res(TINFO, "Attempting to attach shared memory to null page");
+-	shm_addr = shmat(shm_id, ((void *)1), SHM_RND);
++	/*
++	 * shmat() for 0 (or < PAGESIZE with RND flag) has to fail with REMAPs
++	 * https://github.com/linux-test-project/ltp/issues/319
++	 */
++	shm_addr = shmat(shm_id, ((void *)1), SHM_RND | SHM_REMAP);
+ 	if (shm_addr == (void *)-1) {
+ 		shm_addr = NULL;
+ 		if (errno == EINVAL) {
+@@ -89,6 +106,7 @@ static void run(void)
+ }
+ 
+ static struct tst_test test = {
++	.needs_root = 1,
+ 	.setup = setup,
+ 	.cleanup = cleanup,
+ 	.test_all = run,
+-- 
+2.9.5
+

--- a/distribution/ltp/include/patches/20180515/0001-cve-meltdown-read-saved_command_line.patch
+++ b/distribution/ltp/include/patches/20180515/0001-cve-meltdown-read-saved_command_line.patch
@@ -1,0 +1,153 @@
+From 4db15cd7922a3880cd63b3a6aed77b85eecb9e47 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Wed, 20 Jun 2018 13:51:58 +0200
+Subject: [PATCH] cve/meltdown: read *saved_command_line
+
+After commit 8c06c7740d19 ("x86/pti: Leave kernel text global for !PCID"),
+kernel can now map all of kernel text into the user page tables.
+So, read of "linux_proc_banner" can succeed and report a false positive.
+
+This patch changes the test to read value of "saved_command_line"
+pointer and then also memory pointed to by it. And compares result
+(first 32 bytes) to /proc/cmdline. saved_command_line string is
+allocated dynamically and falls outside of (_text, _end) area:
+  crash> p/x _text
+  $2 = 0xffffffff81000000 <startup_64>
+  crash> p/x _end
+  $3 = 0xffffffff82411000
+  crash> p/x &saved_command_line
+  $4 = 0xffffffff81cf3008
+  crash> p/x saved_command_line
+  $5 = 0xffff88007ff55100
+so test should work on kernels with and without the patch.
+
+saved_command_line is allocated dynamically since 2.6.21:
+  30d7e0d466b3 ("[PATCH] Dynamic kernel command-line: common")
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Reviewed-by: Li Wang <liwang@redhat.com>
+Reviewed-by: Petr Vorel <pvorel@suse.cz>
+Acked-by: Cyril Hrubis <chrubis@suse.cz>
+---
+ testcases/cve/meltdown.c | 64 ++++++++++++++++++++++++++++++++++++------------
+ 1 file changed, 48 insertions(+), 16 deletions(-)
+
+diff --git a/testcases/cve/meltdown.c b/testcases/cve/meltdown.c
+index dce84a0c3..a53ea9b8e 100644
+--- a/testcases/cve/meltdown.c
++++ b/testcases/cve/meltdown.c
+@@ -189,7 +189,7 @@ readbit(int fd, unsigned long addr, char bit)
+ 	for (i = 0; i < CYCLES; i++) {
+ 		ret = pread(fd, buf, sizeof(buf), 0);
+ 		if (ret < 0)
+-			tst_res(TBROK | TERRNO, "can't read /proc/version");
++			tst_res(TBROK | TERRNO, "can't read fd");
+ 
+ 		clflush_target();
+ 
+@@ -298,17 +298,17 @@ find_kernel_symbol(const char *name)
+ 	return addr;
+ }
+ 
+-unsigned long linux_proc_banner_addr;
+-int banner_fd;
++static unsigned long saved_cmdline_addr;
++static int spec_fd;
+ 
+ static void setup(void)
+ {
+ 	set_cache_hit_threshold();
+ 
+-	linux_proc_banner_addr = find_kernel_symbol("linux_proc_banner");
+-	tst_res(TINFO, "linux_proc_banner is at %lx", linux_proc_banner_addr);
++	saved_cmdline_addr = find_kernel_symbol("saved_command_line");
++	tst_res(TINFO, "&saved_command_line == 0x%lx", saved_cmdline_addr);
+ 
+-	banner_fd = SAFE_OPEN("/proc/version", O_RDONLY);
++	spec_fd = SAFE_OPEN("/proc/cmdline", O_RDONLY);
+ 
+ 	memset(target_array, 1, sizeof(target_array));
+ 
+@@ -316,37 +316,69 @@ static void setup(void)
+ 		tst_res(TBROK | TERRNO, "set_signal");
+ }
+ 
++#define READ_SIZE 32
++
+ static void run(void)
+ {
+-	unsigned int i, score, ret;
+-	static char expected[] = "%s version %s";
+-	static char read[32];
+-	unsigned long addr = linux_proc_banner_addr;
+-	unsigned long size = sizeof(expected) - 1;
+-
++	unsigned int i, score = 0, ret;
++	unsigned long addr;
++	unsigned long size;
++	char read[READ_SIZE] = { 0 };
++	char expected[READ_SIZE] = { 0 };
++	int expected_len;
++
++	expected_len = pread(spec_fd, expected, sizeof(expected), 0);
++	if (expected_len < 0)
++		tst_res(TBROK | TERRNO, "can't read test fd");
++
++	/* read address of saved_cmdline_addr */
++	addr = saved_cmdline_addr;
++	size = sizeof(addr);
+ 	for (i = 0; i < size; i++) {
+-		ret = readbyte(banner_fd, addr);
++		ret = readbyte(spec_fd, addr);
+ 
+ 		read[i] = ret;
+-		tst_res(TINFO, "read %lx = 0x%x %c", addr, ret,
++		tst_res(TINFO, "read %lx = 0x%02x %c", addr, ret,
+ 			isprint(ret) ? ret : ' ');
+ 
+ 		addr++;
+ 	}
+ 
+-	for (score = 0, i = 0; i < size; i++)
++	/* read value pointed to by saved_cmdline_addr */
++	memcpy(&addr, read, sizeof(addr));
++	memset(read, 0, sizeof(read));
++	tst_res(TINFO, "save_command_line: 0x%lx", addr);
++	size = expected_len;
++
++	if (!addr)
++		goto done;
++
++	for (i = 0; i < size; i++) {
++		ret = readbyte(spec_fd, addr);
++
++		read[i] = ret;
++		tst_res(TINFO, "read %lx = 0x%02x %c | expected 0x%02x |"
++			" match: %d", addr, ret, isprint(ret) ? ret : ' ',
++			expected[i], read[i] == expected[i]);
++
++		addr++;
++	}
++
++	for (i = 0; i < size; i++)
+ 		if (expected[i] == read[i])
+ 			score++;
+ 
++done:
+ 	if (score > size / 2)
+ 		tst_res(TFAIL, "I was able to read your kernel memory!!!");
+ 	else
+ 		tst_res(TPASS, "I was not able to read your kernel memory");
++	tst_res(TINFO, "score(matched/all): %u / %lu", score, size);
+ }
+ 
+ static void cleanup(void)
+ {
+-	SAFE_CLOSE(banner_fd);
++	SAFE_CLOSE(spec_fd);
+ }
+ 
+ static struct tst_test test = {
+-- 
+2.14.4
+

--- a/distribution/ltp/include/patches/20180515/0001-open_posix-add-LTP_ATTRIBUTE-macros-to-supress-warni.patch
+++ b/distribution/ltp/include/patches/20180515/0001-open_posix-add-LTP_ATTRIBUTE-macros-to-supress-warni.patch
@@ -1,0 +1,26 @@
+From cc4a63bfc4c90aa31f9b373424bba325d8091259 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Tue, 19 Jun 2018 13:00:54 +0200
+Subject: [PATCH] open_posix: add LTP_ATTRIBUTE* macros to supress warnings
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Signed-off-by: Ping Fang <pifang@redhat.com>
+---
+ testcases/open_posix_testsuite/include/posixtest.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/testcases/open_posix_testsuite/include/posixtest.h b/testcases/open_posix_testsuite/include/posixtest.h
+index 8e704b6ff..dd1a9b291 100644
+--- a/testcases/open_posix_testsuite/include/posixtest.h
++++ b/testcases/open_posix_testsuite/include/posixtest.h
+@@ -43,3 +43,7 @@
+ #ifndef ARRAY_SIZE
+ #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+ #endif
++
++#define LTP_ATTRIBUTE_NORETURN		__attribute__((noreturn))
++#define LTP_ATTRIBUTE_UNUSED		__attribute__((unused))
++#define LTP_ATTRIBUTE_UNUSED_RESULT	__attribute__((warn_unused_result))
+-- 
+2.14.4
+

--- a/distribution/ltp/include/patches/20180515/0001-pthread_cancel_3-1-rewrite.patch
+++ b/distribution/ltp/include/patches/20180515/0001-pthread_cancel_3-1-rewrite.patch
@@ -1,0 +1,239 @@
+From c30700bad85e37ee63a474360bb4eac25b662fa3 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 31 May 2018 14:22:30 +0200
+Subject: [PATCH] pthread_cancel_3-1: rewrite
+
+This test sets priorities, measures time, tries to synchronize
+threads with integers and sleeps for seconds. And there appears
+to be race somewhere that makes it rarely fail.
+
+The premise tested is that action triggered by pthread_cancel
+runs asynchronously. This rewrite takes simpler approach:
+
+Thread sleeps until it can observe variable set by parent
+_after_ pthread_cancel() or after it hits specified timeout.
+If timeout is hit, then presumably cleanup_func() didn't
+run in parallel with main thread and test fails.
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+Reviewed-by: Li Wang <liwang@redhat.com>
+Signed-off-by: Ping Fang <pifang@redhat.com>
+---
+ .../conformance/interfaces/pthread_cancel/3-1.c    | 165 ++++++---------------
+ 1 file changed, 48 insertions(+), 117 deletions(-)
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cancel/3-1.c b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cancel/3-1.c
+index 40469d6f3..ad2d20642 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cancel/3-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cancel/3-1.c
+@@ -1,159 +1,90 @@
+ /*
+- * Copyright (c) 2004, QUALCOMM Inc. All rights reserved.
+- * Created by:  abisain REMOVE-THIS AT qualcomm DOT com
++ * Copyright (c) 2018, Linux Test Project
+  * This file is licensed under the GPL license.  For the full content
+  * of this license, see the COPYING file at the top level of this
+  * source tree.
+-
+- * Test pthread_cancel
+- * When the cancelation is acted on, the cancelation cleanup handlers for
+- * 'thread' shall be called "asynchronously"
+  *
+- * STEPS:
+- * 1. Change main thread to a real-time thread with a high priority
+- * 1. Create a lower priority thread
+- * 2. In the thread function, push a cleanup function onto the stack
+- * 3. Cancel the thread from main and get timestamp, then block.
+- * 4. The cleanup function should be automatically
+- *    executed, else the test will fail.
++ * Cancellation steps happen asynchronously with respect to
++ * the pthread_cancel(). The return status of pthread_cancel()
++ * merely informs the caller whether the cancellation request
++ * was successfully queued.
+  */
+ 
+ #include <pthread.h>
++#include <semaphore.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <errno.h>
+ #include <unistd.h>
+ #include "posixtest.h"
+-#include <time.h>
+-
+-#define TEST "3-1"
+-#define FUNCTION "pthread_cancel"
+-#define ERROR_PREFIX "unexpected error: " FUNCTION " " TEST ": "
++#include "safe_helpers.h"
+ 
+-#define FIFOPOLICY SCHED_FIFO
+-#define MAIN_PRIORITY 30
+-#define TIMEOUT_IN_SECS 10
++#define TIMEOUT_MS 5000
++#define SLEEP_MS 1
+ 
+-/* Manual semaphore */
+-int sem;
++static volatile int after_cancel;
++static volatile int thread_sleep_time;
++static sem_t sem;
+ 
+-/* Made global so that the cleanup function
+- * can manipulate the value as well.
+- */
+-int cleanup_flag;
+-struct timespec main_time, cleanup_time;
+-
+-/* A cleanup function that sets the cleanup_flag to 1, meaning that the
+- * cleanup function was reached.
+- */
+-void a_cleanup_func()
++static void cleanup_func(LTP_ATTRIBUTE_UNUSED void *unused)
+ {
+-	clock_gettime(CLOCK_REALTIME, &cleanup_time);
+-	cleanup_flag = 1;
+-	sem = 0;
+-	return;
++	do {
++		usleep(SLEEP_MS*1000);
++		thread_sleep_time += SLEEP_MS;
++	} while (after_cancel == 0 && thread_sleep_time < TIMEOUT_MS);
+ }
+ 
+-/* A thread function called at the creation of the thread. It will push
+- * the cleanup function onto it's stack, then go into a continuous 'while'
+- * loop, never reaching the cleanup_pop function.  So the only way the cleanup
+- * function can be called is when the thread is canceled and all the cleanup
+- * functions are supposed to be popped.
+- */
+-void *a_thread_func()
++static void *thread_func(LTP_ATTRIBUTE_UNUSED void *unused)
+ {
+-	int rc = 0;
++	int waited_for_cancel_ms = 0;
+ 
+-	/* To enable thread immediate cancelation, since the default
+-	 * is PTHREAD_CANCEL_DEFERRED.
+-	 */
+-	rc = pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setcanceltype\n");
+-		exit(PTS_UNRESOLVED);
+-	}
+-	pthread_cleanup_push(a_cleanup_func, NULL);
++	SAFE_PFUNC(pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL));
++	pthread_cleanup_push(cleanup_func, NULL);
+ 
+-	sem = 1;
+-	while (sem == 1)
+-		sleep(1);
+-	sleep(5);
+-	sem = 0;
++	SAFE_FUNC(sem_post(&sem));
++	while (waited_for_cancel_ms < TIMEOUT_MS) {
++		usleep(SLEEP_MS*1000);
++		waited_for_cancel_ms += SLEEP_MS;
++	}
+ 
+-	/* Should never be reached, but is required to be in the code
+-	 * since pthread_cleanup_push is in the code.  Else a compile error
+-	 * will result.
+-	 */
++	/* shouldn't be reached */
++	printf("Error: cancel never arrived\n");
+ 	pthread_cleanup_pop(0);
+-	pthread_exit(0);
++	exit(PTS_FAIL);
+ 	return NULL;
+ }
+ 
+ int main(void)
+ {
+-	pthread_t new_th;
+-	int i;
+-	double diff;
+-	struct sched_param param;
+-	int rc = 0;
+-
+-	/* Initializing the cleanup flag. */
+-	cleanup_flag = 0;
+-	sem = 0;
+-	param.sched_priority = MAIN_PRIORITY;
+-
+-	/* Increase priority of main, so the new thread doesn't get to run */
+-	rc = pthread_setschedparam(pthread_self(), FIFOPOLICY, &param);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_setschedparam\n");
+-		exit(PTS_UNRESOLVED);
+-	}
++	pthread_t th;
+ 
+-	/* Create a new thread. */
+-	rc = pthread_create(&new_th, NULL, a_thread_func, NULL);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_create\n");
+-		return PTS_UNRESOLVED;
+-	}
++	SAFE_FUNC(sem_init(&sem, 0, 0));
++	SAFE_PFUNC(pthread_create(&th, NULL, thread_func, NULL));
+ 
+-	/* Make sure thread is created and executed before we cancel it. */
+-	while (sem == 0)
+-		sleep(1);
++	/* wait for thread to start */
++	SAFE_FUNC(sem_wait(&sem));
++	SAFE_PFUNC(pthread_cancel(th));
+ 
+-	rc = pthread_cancel(new_th);
+-	if (rc != 0) {
+-		printf(ERROR_PREFIX "pthread_cancel\n");
+-		exit(PTS_FAIL);
+-	}
++	/*
++	 * if cancel action would run synchronously then
++	 * thread will sleep for too long, because it
++	 * would never see after_cancel == 1
++	 */
++	after_cancel = 1;
+ 
+-	/* Get the time after canceling the thread */
+-	clock_gettime(CLOCK_REALTIME, &main_time);
+-	i = 0;
+-	while (sem == 1) {
+-		sleep(1);
+-		if (i == TIMEOUT_IN_SECS) {
+-			printf(ERROR_PREFIX "Cleanup handler was not called\n");
+-			exit(PTS_FAIL);
+-		}
+-		i++;
+-	}
++	SAFE_PFUNC(pthread_join(th, NULL));
+ 
+-	/* If the cleanup function was not reached by calling the
+-	 * pthread_cancel function, then the test fails.
+-	 */
+-	if (cleanup_flag != 1) {
+-		printf(ERROR_PREFIX "Cleanup handler was not called\n");
++	if (thread_sleep_time >= TIMEOUT_MS) {
++		printf("Error: cleanup_func hit timeout\n");
+ 		exit(PTS_FAIL);
+ 	}
+ 
+-	diff = cleanup_time.tv_sec - main_time.tv_sec;
+-	diff +=
+-	    (double)(cleanup_time.tv_nsec - main_time.tv_nsec) / 1000000000.0;
+-	if (diff < 0) {
+-		printf(ERROR_PREFIX
+-		       "Cleanup function was called before main continued\n");
++	if (thread_sleep_time == 0) {
++		printf("Error: cleanup_func never called\n");
+ 		exit(PTS_FAIL);
+ 	}
++
++	printf("Thread cancelled after %d ms.\n", thread_sleep_time);
+ 	printf("Test PASSED\n");
+ 	exit(PTS_PASS);
+ }
+-- 
+2.14.4
+

--- a/distribution/ltp/include/patches/INTERNAL/cgroup-debug-check-cgroups.patch
+++ b/distribution/ltp/include/patches/INTERNAL/cgroup-debug-check-cgroups.patch
@@ -1,0 +1,71 @@
+From 784f90fe59469fe02f555573349d613143ee45d8 Mon Sep 17 00:00:00 2001
+From: Jan Stancek <jstancek@redhat.com>
+Date: Thu, 14 Apr 2011 10:07:49 +0200
+Subject: [PATCH] check cgroups (and cleanup)
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ .../kernel/controllers/cgroup/check_cgroups.sh     |   51 ++++++++++++++++++++
+ 1 files changed, 51 insertions(+), 0 deletions(-)
+ create mode 100644 testcases/kernel/controllers/cgroup/check_cgroups.sh
+
+diff --git a/testcases/kernel/controllers/cgroup/check_cgroups.sh b/testcases/kernel/controllers/cgroup/check_cgroups.sh
+new file mode 100644
+index 0000000..c6d1414
+--- /dev/null
++++ b/testcases/kernel/controllers/cgroup/check_cgroups.sh
+@@ -0,0 +1,51 @@
++checkcg()
++{
++    echo "Checking cgroups $1"
++    rm -rf /tmp/check
++    mkdir /tmp/check
++
++    echo "Checking whole"
++    mount -t cgroup none /tmp/check
++    if [ $? -ne 0 ]; then
++        echo "HERE: Failed to mount $s"
++    else
++        groups=`find /tmp/check -type d | wc -l`
++        if [ $groups -gt 1 ]; then
++            echo "CRITICAL: Problem with whole, found some dirs"
++            find /tmp/check -type d
++            echo "Cleaning up:"
++            find /tmp/check -type d -exec rmdir {} \;
++            find /tmp/check -type d -exec rmdir {} \;
++            find /tmp/check -type d -exec rmdir {} \;
++            echo "After cleanup:"
++            find /tmp/check -type d
++        fi
++    fi
++    umount /tmp/check
++
++    subsys=`cat /proc/cgroups | grep -v ^# | awk '{print $1}'`
++    for s in $subsys; do
++        echo "Checking $s"
++        mount -t cgroup -o $s none /tmp/check
++        if [ $? -ne 0 ]; then
++            echo "HERE: Failed to mount $s"
++        else
++            groups=`find /tmp/check -type d | wc -l`
++            if [ $groups -gt 1 ]; then
++                echo "CRITICAL: Problem with $s, found some dirs"
++                find /tmp/check -type d
++                echo "All files:"
++                find /tmp/check
++                echo "Cleaning up:"
++                find /tmp/check -type d -exec rmdir {} \;
++                find /tmp/check -type d -exec rmdir {} \;
++                find /tmp/check -type d -exec rmdir {} \;
++                echo "After cleanup:"
++                find /tmp/check -type d
++            fi
++            umount /tmp/check
++        fi
++    done
++    echo ""
++}
++
+-- 
+1.7.1
+

--- a/distribution/ltp/include/patches/INTERNAL/disable-testcases.patch
+++ b/distribution/ltp/include/patches/INTERNAL/disable-testcases.patch
@@ -1,0 +1,23 @@
+diff --git a/runtest/crashme b/runtest/crashme
+index a4c5b41..4726c21 100644
+--- a/runtest/crashme
++++ b/runtest/crashme
+@@ -7,7 +7,7 @@ f00f f00f
+ crash01 crash01
+ # Generate random code and execute it. Read f00f comment,
+ # this test lockup SunOS,WindowsNT,etc. in seconds..
+-crash02 crash02
++#crash02 crash02
+ # Generate random syscalls and execute them, less probability
+ # to hose your system, but still.
+ mem01 mem01 -r
+diff --git a/runtest/mm b/runtest/mm
+index 2dd66f0..79db143 100644
+--- a/runtest/mm
++++ b/runtest/mm
+@@ -99,4 +99,4 @@ overcommit_memory overcommit_memory -R 200
+ 
+ max_map_count max_map_count -i 10
+ 
+-min_free_kbytes min_free_kbytes
++#min_free_kbytes min_free_kbytes

--- a/distribution/ltp/include/patches/INTERNAL/ltp-pan-ltp-testname-stamps-in-dmesg-and-console.patch
+++ b/distribution/ltp/include/patches/INTERNAL/ltp-pan-ltp-testname-stamps-in-dmesg-and-console.patch
@@ -1,0 +1,30 @@
+From 906c0687dc963eb8a2a01bad38e75af807273692 Mon Sep 17 00:00:00 2001
+From: Li Wang <liwang@redhat.com>
+Date: Wed, 12 Aug 2015 17:49:30 +0800
+Subject: [PATCH] ltp-pan: ltp testname stamps in dmesg and console
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ pan/ltp-pan.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/pan/ltp-pan.c b/pan/ltp-pan.c
+index cee71aa..79dc3fa 100644
+--- a/pan/ltp-pan.c
++++ b/pan/ltp-pan.c
+@@ -1360,6 +1360,12 @@ static void write_test_start(struct tag_pgrp *running)
+ 		     running->cmd->cmdline, "", "exit", "<<<test_output>>>");
+ 	}
+ 	fflush(stdout);
++
++	FILE *f = fopen("/dev/kmsg", "w");
++	if (f) {
++		fprintf(f, "ltptest %s start\n", running->cmd->name);
++		fclose(f);
++	}
+ }
+ 
+ static void
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/INTERNAL/readahead02-use-per-device-readahead-limit-in-RHEL7.patch
+++ b/distribution/ltp/include/patches/INTERNAL/readahead02-use-per-device-readahead-limit-in-RHEL7.patch
@@ -1,0 +1,55 @@
+From 773c0b3867b0b7b6dd6e3bc96e9bec7a5f697e29 Mon Sep 17 00:00:00 2001
+Message-Id: <773c0b3867b0b7b6dd6e3bc96e9bec7a5f697e29.1458566225.git.jstancek@redhat.com>
+From: Jan Stancek <jstancek@redhat.com>
+Date: Mon, 21 Mar 2016 14:13:40 +0100
+Subject: [PATCH] readhead02: use per-device readahead limit in RHEL7
+
+Since following RHEL7 commit:
+  commit 14f0e6d631f98be270f7b8d38d0b967f68df8262
+  Author: Eric Sandeen <sandeen@redhat.com>
+  Date:   Wed Nov 25 21:06:09 2015 -0500
+    [mm] use only per-device readahead limit
+
+also RHEL7 respects per-device readahead limit. This has been
+backported from upstream 4.4, but there isn't a good way to
+detect presence of the patch. Therefore our ltp needs a RHEL
+only patch to adjust kernel version check.
+
+To make things simpler, we use MIN(bdi max, 2M). This way we don't
+need to match kernel version exactly, since this should work for
+all RHEL7 kernels (not just the ones with the patch).
+
+Signed-off-by: Jan Stancek <jstancek@redhat.com>
+---
+ testcases/kernel/syscalls/readahead/readahead02.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/readahead/readahead02.c b/testcases/kernel/syscalls/readahead/readahead02.c
+index 7dc308c03e5d..3935a3c8f9e5 100644
+--- a/testcases/kernel/syscalls/readahead/readahead02.c
++++ b/testcases/kernel/syscalls/readahead/readahead02.c
+@@ -194,9 +194,11 @@ static long get_device_readahead(const char *fname)
+ 		tst_brkm(TBROK | TERRNO, cleanup, "stat");
+ 	snprintf(buf, sizeof(buf), "/sys/dev/block/%d:%d/queue/read_ahead_kb",
+ 		 major(st.st_dev), minor(st.st_dev));
++	if (access(buf, F_OK) != 0)
++		return 2 * 1024 * 1024;
+ 	SAFE_FILE_SCANF(cleanup, buf, "%ld", &ra_kb);
+ 
+-	return ra_kb * 1024;
++	return MIN(2 * 1024 * 1024, ra_kb * 1024);
+ }
+ 
+ /* read_testfile - mmap testfile and read every page.
+@@ -224,7 +226,7 @@ static void read_testfile(int do_readahead, const char *fname, size_t fsize,
+ 	long readahead_size;
+ 
+ 	/* use bdi limit for 4.4 and older, otherwise default to 2M */
+-	if ((tst_kvercmp(4, 4, 0)) >= 0)
++	if ((tst_kvercmp(3, 10, 0)) >= 0)
+ 		readahead_size = get_device_readahead(fname);
+ 	else
+ 		readahead_size = 2 * 1024 * 1024;
+-- 
+1.8.3.1
+

--- a/distribution/ltp/include/patches/INTERNAL/rhel-fs-quota_remount-solve-SELinux-issue.patch
+++ b/distribution/ltp/include/patches/INTERNAL/rhel-fs-quota_remount-solve-SELinux-issue.patch
@@ -1,0 +1,14 @@
+diff --git a/testcases/kernel/fs/quota_remount/quota_remount_test01.sh b/testcases/kernel/fs/quota_remount/quota_remount_test01.sh
+index f8b4848..d413ecf 100755
+--- a/testcases/kernel/fs/quota_remount/quota_remount_test01.sh
++++ b/testcases/kernel/fs/quota_remount/quota_remount_test01.sh
+@@ -83,6 +83,9 @@ mkdir $MNTDIR || die 2 "Could not create the mountpoint"
+ mount -t ext3 -o loop,usrquota,grpquota $IMAGE $MNTDIR || die 2 "Could not mount the filesystem"
+ tst_resm TINFO "Successfully mounted the File System"
+ 
++# added by Caspar Zhang
++# see RHBZ#703871 for more information
++chcon --reference=/var $MNTDIR
+ quotacheck -cug $MNTDIR || die 2 "Could not create quota files"
+ tst_resm TINFO "Successfully Created Quota Files"
+ 

--- a/distribution/ltp/include/patches/INTERNAL/rhel-scrashme-remove-f00f-test-on-system-with-NX-bit.patch
+++ b/distribution/ltp/include/patches/INTERNAL/rhel-scrashme-remove-f00f-test-on-system-with-NX-bit.patch
@@ -1,0 +1,30 @@
+From 15726e12ba9725f4a6d36a8cbb159bc5a4c7d093 Mon Sep 17 00:00:00 2001
+From: Caspar Zhang <czhang@redhat.com>
+Date: Thu, 3 Mar 2011 17:35:39 +0800
+Subject: [PATCH 10/10] scrashme: remove f00f test on system with NX bit
+
+On systems with the NX bit set it fails. sigkill is not returned as
+expected.
+
+Signed-off-by: Caspar Zhang <czhang@redhat.com>
+---
+ runtest/crashme |    4 +++-
+ 1 files changed, 3 insertions(+), 1 deletions(-)
+
+diff --git a/runtest/crashme b/runtest/crashme
+index 432b660..c9a1523 100644
+--- a/runtest/crashme
++++ b/runtest/crashme
+@@ -1,6 +1,8 @@
+ #DESCRIPTION:Utility to crash your machine
+ # Before running these: BACKUP YOUR SYSTEM!  you've been warned!
+-f00f f00f
++## Removed by Jeff Burke: On systems with the NX bit set it fails.
++## sigkill is not returned as expected.
++#f00f f00f
+ # This is a simple test for handling of the pentium f00f bug.
+ # It is an example of a catistrophic test case.  If the system
+ # doesn't correctly handle this test, it will likely lockup.
+-- 
+1.7.4.1
+

--- a/distribution/ltp/include/patches/INTERNAL/rhel-scrashme-remove-fork12-test.patch
+++ b/distribution/ltp/include/patches/INTERNAL/rhel-scrashme-remove-fork12-test.patch
@@ -1,0 +1,25 @@
+fork12 is a fork bomb test. Not very realistic for running as user root
+in automated environment.
+
+Signed-off-by: Caspar Zhang <czhang@redhat.com>
+---
+ runtest/crashme |    4 +++-
+ 1 files changed, 3 insertions(+), 1 deletions(-)
+
+diff --git a/runtest/crashme b/runtest/crashme
+index a4c5b41..432b660 100644
+--- a/runtest/crashme
++++ b/runtest/crashme
+@@ -13,6 +13,8 @@ crash02 crash02
+ mem01 mem01 -r
+ # Memory eater. Loves to be run in parallel with other programs.
+ # May panic on buggy systems if the OOM killer was not fast enough :-)
+-fork12 fork12
++## Removed by Jeff Burke: This is a fork bomb test. Not very realistic
++## for running as user root in automated environment.
++#fork12 fork12
+ # Fork as many children as possible.  On systems with lots of memory
+ # and kernels prior to 2.4.19, this can hang the system by using up all pids
+-- 
+1.7.4.1
+

--- a/distribution/ltp/include/patches/INTERNAL/rhel345-sched-remove-cfs-sched-hackbench.patch
+++ b/distribution/ltp/include/patches/INTERNAL/rhel345-sched-remove-cfs-sched-hackbench.patch
@@ -1,0 +1,27 @@
+Since RHEL[345] doesn't use cfs-scheduler, remove hackbench test in
+these releases.
+
+Signed-off-by: Caspar Zhang <czhang@redhat.com>
+---
+ runtest/sched |    5 +++--
+ 1 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/runtest/sched b/runtest/sched
+index 16877a3..fdeea71 100644
+--- a/runtest/sched
++++ b/runtest/sched
+@@ -6,8 +6,9 @@ pth_str03 pth_str03
+ time-schedule01		time-schedule
+ trace_sched01		trace_sched -c 1
+ 
+-hackbench01 hackbench 50 process 1000
+-hackbench02 hackbench 20 thread 1000
++# Remove by Jeff Burke. RHEL[345] do not use cfq-scheduler
++#hackbench01 hackbench 50 process 1000
++#hackbench02 hackbench 20 thread 1000
+ 
+ sched_cli_serv run_sched_cliserv.sh
+ # Run this stress test for 2 minutes
+-- 
+1.7.4.1
+

--- a/distribution/ltp/include/patches/INTERNAL/rhel6-commands-cron-ensure-syslog-enabled.patch
+++ b/distribution/ltp/include/patches/INTERNAL/rhel6-commands-cron-ensure-syslog-enabled.patch
@@ -1,0 +1,63 @@
+Ensure the syslog service enabled before executing any cron tests, else
+the tests would fail in RHEL6. This patch would be never sent to
+upstream.
+
+Signed-off-by: Caspar Zhang <czhang@redhat.com>
+---
+ testcases/commands/cron/cron_tests.sh |   34 +++++++++++++++++++++++++++++++++
+ 1 files changed, 34 insertions(+), 0 deletions(-)
+
+diff --git a/testcases/commands/cron/cron_tests.sh b/testcases/commands/cron/cron_tests.sh
+index a627ddb..dff0085 100644
+--- a/testcases/commands/cron/cron_tests.sh
++++ b/testcases/commands/cron/cron_tests.sh
+@@ -57,12 +57,46 @@ else
+     LTPBIN=$LTPROOT/testcases/bin
+ fi
+ 
++cleanup()
++{
++	export TCID=cleanup
++	$LTPBIN/tst_resm TCONF "restore service to initial status"
++	if [ $IS_RSYSLOG_RUNNING -eq 0 ];
++	then
++		service rsyslog stop
++	fi
++}
++
+ # Set return code RC variable to 0, it will be set with a non-zero return code
+ # in case of error. Set TFAILCNT to 0, increment if there occures a failure.
+ 
+ LOCTMP=${PWD}/tmp
+ TFAILCNT=0
+ RC=0
++IS_RSYSLOG_RUNNING=0
++
++# Setup the syslog service to record cron log.
++trap 'trap "" EXIT; cleanup' EXIT
++
++export TCID=setup
++$LTPBIN/tst_resm TCONF "make sure corresponding syslog service running first"
++if [ -f /var/run/syslogd.pid ] && 
++	[ "`cat /var/run/syslogd.pid`" = "`pidof rsyslogd`" ];
++then
++	IS_RSYSLOG_RUNNING=1
++	service rsyslog restart
++	RC=$?
++else
++	IS_RSYSLOG_RUNNING=0
++	service rsyslog start
++	RC=$?
++fi
++
++if [ $RC -ne 0 ];
++then
++	$LTPBIN/tst_resm TFAIL "start service failed, exiting."
++	exit $RC
++fi
+ 
+ # Test #1
+ # Test if crontab <filename> installs the crontab file and cron schedules the 
+-- 
+1.7.4.1
+

--- a/distribution/ltp/include/patches/INTERNAL/skip-firmware-tests.patch
+++ b/distribution/ltp/include/patches/INTERNAL/skip-firmware-tests.patch
@@ -1,0 +1,25 @@
+From 98f87bd26b7c3288643e35a46286188793507e23 Mon Sep 17 00:00:00 2001
+From: Madper Xie <cxie@redhat.com>
+Date: Thu, 13 Feb 2014 14:06:58 +0800
+Subject: [PATCH] Skip firmware tests.
+
+Skip them before fixing.
+---
+ testcases/kernel/Makefile | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/testcases/kernel/Makefile b/testcases/kernel/Makefile
+index 6bffe79..cf91ddb 100644
+--- a/testcases/kernel/Makefile
++++ b/testcases/kernel/Makefile
+@@ -39,7 +39,6 @@ SUBDIRS			+= connectors \
+ 			   containers \
+ 			   controllers \
+ 			   device-drivers \
+-			   firmware \
+ 			   fs \
+ 			   hotplug \
+ 			   io \
+-- 
+1.8.5.4
+

--- a/distribution/ltp/include/patches/PATCH_STATUS.txt
+++ b/distribution/ltp/include/patches/PATCH_STATUS.txt
@@ -1,0 +1,63 @@
+STATUS OF THE PATCHES
+=====================
+
+PATCH_STATUS.txt
+
+# --------------------------ltp-redhat----------------------------------
+ltp-pan-ltp-testname-stamps-in-dmesg-and-console.patch		INTERNAL [0]
+rhel6-commands-ar01-a-strange-dot.patch				INTERNAL [1]
+rhel-scrashme-remove-fork12-test.patch				INTERNAL
+rhel-syscalls-swapon03-fix-failed-swapon.patch			INTERNAL [2]
+cgroup-debug-check-cgroups.patch				INTERNAL [0]
+
+rhel345-sched-remove-cfs-sched-hackbench.patch			INTERNAL [3]
+skip-firmware-tests.patch					INTERNAL [3]
+rhel6-commands-cron-ensure-syslog-enabled.patch			INTERNAL [3]
+rhel-scrashme-remove-f00f-test-on-system-with-nx-bit.patch	INTERNAL [3]
+
+# --------------------------ltp-20150903--------------------------------
+disable-testcases.patch						INTERNAL
+rhel-fs-quota_remount-solve-SELinux-issue.patch			INTERNAL [1]
+lib-mem.c-handle-mlock-returning-EAGAIN.patch			UPSTREAM
+mem-hugetlb-Find-an-empty-region-to-use-in-hugemmap0.patch	UPSTREAM
+mtest01-sigchld.patch						UPSTREAM
+
+# --------------------------ltp-20160126--------------------------------
+hugemmap02.c-don-t-skip-cleanup-in-the-loop.patch		UPSTREAM
+open_posix-add-SAFE_PFUNC-macro.patch				UPSTREAM
+open_posix-condvar-schedule-remove-duplicit-setsched.patch	UPSTREAM
+open_posix-condvar-schedule-remove-signal-handlers.patch	UPSTREAM
+open_posix-condvar-schedule-remove-useless-waiting.patch 	UPSTREAM
+open_posix-condvar-schedule-use-SAFE_PFUNC.patch 		UPSTREAM
+syscalls-readahead02-use-bdi-max-readahead-limit.patch		UPSTREAM
+readahead02-use-per-device-readahead-limit-in-RHEL7.patch	INTERNAL [2]
+mm-ksm-extend-max_page_sharing-before-ksm-testing.patch		UPSTREAM
+
+# --------------------------ltp-20160510--------------------------------
+creat05-don-t-assume-number-of-opened-fds.patch			UPSTREAM
+mem-oom-fork-may-fail-before-test.patch				UPSTREAM
+handle-EOPNOTSUPP-if-hugepages_supported.patch			UPSTREAM
+mem-lib-skip-oom-KSM-for-lite-1-single-TESTMEM-MB-al.patch	UPSTREAM
+fanotify06-create-a-mount-for-test.patch			UPSTREAM
+lib-add-SAFE_-FILE_LINES_SCANF.patch				INTERNAL
+syscalls-madvise06-Convert-to-new-test-API.patch		UPSTREAM
+zram01-extend-the-zram3-disksize-to-40MB.patch			UPSTREAM
+madvise06-make-bug-detection-more-reliable.patch		UPSTREAM
+swapping01-replace-mem_free-by-mem_available.patch		UPSTREAM
+
+# --------------------------ltp-20160920--------------------------------
+lib-Add-optional-minimal-size-for-test-device.patch 		UPSTREAM
+utimensat-fix-immutable-file-retcodes-for-4.8.0-and-.patch	UPSTREAM
+move_pages04-fix-zero-page-status-code-for-kernels-4.patch	UPSTREAM
+lib-add-tst_res_hexd-for-newlib.patch				UPSTREAM
+syscalls-new-test-writev07.patch				UPSTREAM
+writev-remove-writev03-and-writev04.patch			UPSTREAM
+writev01-rewrite-and-drop-partially-valid-iovec-test.patch	UPSTREAM
+kernel-zram-Fix-testcase-for-kernels-v4.7.patch			UPSTREAM
+
+
+# Notes:
+[0] used for debugging
+[1] the failure is related to SELinux, patch is temporary and dirty hack.
+[2] it depends on kernel config options, so patch for internal use only
+[3] patch for specific hardware/release

--- a/distribution/ltp/include/runtest.sh
+++ b/distribution/ltp/include/runtest.sh
@@ -1,0 +1,345 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /kernel/distribution/ltp/include
+#   Description: Linux Test Project - include part
+#   Author: Caspar Zhang <czhang@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2011 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Source the common test script helpers
+. /usr/bin/rhts_environment.sh
+
+# Set unique log file.
+OUTPUTDIR=/mnt/testarea
+if ! [ -d $OUTPUTDIR ]; then
+    echo "Creating $OUTPUTDIR"
+    mkdir -p $OUTPUTDIR
+fi
+LTPDIR=$OUTPUTDIR/ltp
+OPTS=""
+
+# Helper functions
+
+# control where to log debug messages to:
+# devnull = 1 : log to /dev/null
+# devnull = 0 : log to file specified in ${DEBUGLOG}
+devnull=0
+
+# Create debug log.
+DEBUGLOG=`mktemp -p /mnt/testarea -t DeBug.XXXXXX`
+
+# locking to avoid races
+lck=$OUTPUTDIR/$(basename $0).lck
+
+if [ -z ${ARCH} ]; then
+    ARCH=$(uname -i)
+fi
+
+if grep -q "release 4" /etc/redhat-release; then
+    RHEL4=1
+fi
+
+# by jstancek
+check_cpu_cgroup ()
+{
+    # Move us to root cpu cgroup
+    # see: Bug 773259 - tests don't run in root cpu cgroup with systemd
+
+    if [ -e /proc/self/cgroup ]; then
+        grep -i "cpu[,:]" /proc/self/cgroup | grep -q ":/$"
+        ret=$?
+    else
+        echo "Couldn't find /proc/self/cgroup." | tee -a $OUTPUTFILE
+        ret=1
+    fi
+
+    if [ $ret -eq 0 ]; then
+        echo "Running in root cpu cgroup" | tee -a $OUTPUTFILE
+    else
+        echo "cat /proc/self/cgroup" | tee -a $OUTPUTFILE
+        cat /proc/self/cgroup | tee -a $OUTPUTFILE
+        cpu_cgroup_mntpoint=$(mount | grep "type cgroup (.*cpu[,)]" | awk '{print $3}')
+        if [ -e "$cpu_cgroup_mntpoint/tasks" ]; then
+            echo "Found root cpu cgroup tasks at: $cpu_cgroup_mntpoint/tasks" | tee -a $OUTPUTFILE
+            echo $$ > $cpu_cgroup_mntpoint/tasks
+            ret=$?
+            if [ $ret -eq 0 ]; then
+                echo "Succesfully moved (pid: $$) to root cpu cgroup." | tee -a $OUTPUTFILE
+            else
+                echo "Failed to move (pid: $$), ret code: $ret" | tee -a $OUTPUTFILE
+            fi
+        fi
+
+        if [ $ret -ne 0 ]; then
+            echo "Couldn't verify that we run in root cpu cgroup." | tee -a $OUTPUTFILE
+            echo "Note that some tests (on RHEL7) may fail, see Bug 773259." | tee -a $OUTPUTFILE
+        fi
+    fi
+}
+check_cpu_cgroup
+
+# Log a message to the ${DEBUGLOG} or to /dev/null.
+DeBug ()
+{
+    local msg="$1"
+    local timestamp=$(date +%Y%m%d-%H%M%S)
+    if [ "$devnull" = "0" ]; then
+        lockfile -r 1 $lck
+        if [ "$?" = "0" ]; then
+            echo -n "${timestamp}: " >>$DEBUGLOG 2>&1
+            echo "${msg}" >>$DEBUGLOG 2>&1
+            rm -f $lck >/dev/null 2>&1
+        fi
+    else
+        echo "${msg}" >/dev/null 2>&1
+    fi
+}
+
+DebugInfo ()
+{
+    DeBug "******* Requested Information $1 *******"
+    DeBug "** IPCS Information **"
+    /usr/bin/ipcs -a >> $DEBUGLOG
+    DeBug "** msgmni Information **"
+    cat /proc/sys/kernel/msgmni >> $DEBUGLOG
+    DeBug "******* End Requested Information $1 *******"
+
+    # Just for easy reading
+    echo >> $DEBUGLOG
+    if [ "$1" = "After" ] || [ "$1" = "AfterIPCRMCleanUp" ]; then
+        echo >> $DEBUGLOG
+    fi
+
+}
+
+RprtRslt ()
+{
+    TEST=$1
+    result=$2
+
+    # File the results in the database
+    if [ "$result" = "PASS" ]; then
+        # I want to see the succeeded running log as well
+        SubmitLog "$OUTPUTDIR/$TEST.run.log"
+        report_result $TEST $result
+    else
+        SubmitLog "$OUTPUTDIR/$TEST.run.log"
+        score=$(cat $OUTPUTDIR/$RUNTEST.log | grep "Total Failures:" |cut -d ' ' -f 3)
+        report_result $TEST $result $score
+    fi
+}
+
+SubmitLog ()
+{
+    LOG=$1
+
+    if [ -z "$TESTPATH" ]; then
+        echo "Running in developer mode"
+    else
+        rhts_submit_log -S $RESULT_SERVER -T $TESTID -l $LOG
+    fi
+}
+
+CleanUp ()
+{
+    LOGFILE=$1
+
+    if [ -e $OUTPUTDIR/$LOGFILE.run.log ]; then
+        rm -f $OUTPUTDIR/$LOGFILE.run.log
+    fi
+
+    if [ -e $OUTPUTDIR/$LOGFILE.log ]; then
+        rm -f $OUTPUTDIR/$LOGFILE.log
+    fi
+}
+
+IPCRMCleanup ()
+{
+    # Clean up msgid
+    DeBug "******* Start msgmni cleanup $1 *******"
+    for i in `ipcs -q | cut -f2 -d' '`; do
+        ipcrm -q $i
+    done
+    DeBug "******* End msgmni cleanup $1 *******"
+    echo >> $DEBUGLOG
+}
+
+ChkTime ()
+{
+    local timestamp=$(date '+%F %T')
+    logger -p local0.notice -t TEST.INFO: "$timestamp -> $1"
+}
+
+TimeSyncNTP ()
+{
+    local timestamp=$(date '+%F %T')
+    logger -p local0.notice -t TEST.INFO: \
+        "$timestamp -> Sync time with clock.redhat.com"
+
+    if [ "$RHEL4" ]; then
+        # Avoid AVC denial in RHEL 4.
+        # Required policy modification,
+        # allow ntpd_t initrc_tmp_t:file append;
+        runcon -u root -r system_r -t initrc_t -- \
+            ntpdate clock.redhat.com
+    else
+        ntpdate clock.redhat.com
+    fi
+}
+
+EnableNTP ()
+{
+    local timestamp=$(date '+%F %T')
+    logger -p local0.notice -t TEST.INFO: "$timestamp -> Enable NTP"
+    service ntpd start
+}
+
+DisableNTP ()
+{
+    local timestamp=$(date '+%F %T')
+    logger -p local0.notice -t TEST.INFO: "$timestamp -> Disable NTP"
+    service ntpd stop
+}
+
+EnableKsmd ()
+{
+    local timestamp=$(date '+%F %T')
+    logger -p local0.notice -t TEST.INFO: "$timestamp -> Enable ksmd and ksmtuned"
+    service ksm start
+    service ksmtuned start
+}
+
+DisableKsmd ()
+{
+    local timestamp=$(date '+%F %T')
+    logger -p local0.notice -t TEST.INFO: "$timestamp -> Disable ksmd and ksmtuned"
+    service ksm stop
+    service ksmtuned stop
+}
+
+# OOM is sporadically killing more than just expected process
+ProtectHarnessFromOOM ()
+{
+    for pid in $(pgrep beah) $(pgrep rhts) $(pgrep ltp) $(pgrep dhclient) $(pgrep NetworkManager); do
+        echo -16 > /proc/$pid/oom_adj
+    done
+
+    # make sure children of this process are not protected
+    # as those include also OOM tests
+    echo 0 > /proc/self/oom_adj
+}
+
+# Modify the $RUNTEST.log for eassier identifying KnownIssue case
+LogDeceiver ()
+{
+    if ! [ -f ${LTPDIR}/KNOWNISSUE ]; then
+        return
+    fi
+
+    for k in $(cat ${LTPDIR}/KNOWNISSUE | grep -v '^#'); do
+        sed -i '/'$k'/ s/FAIL/KNOW/' $OUTPUTDIR/$RUNTEST.log
+    done
+}
+
+RunTest ()
+{
+    RUNTEST=$1
+    OPTIONS=$2 # pass other options here, like "-b /dev/sda5 -B xfs"
+
+    ProtectHarnessFromOOM
+
+    # disable AVC check only in CGROUP tests
+    if echo $RUNTEST | grep -q CGROUP; then
+        export AVC_ERROR='+no_avc_check'
+    fi
+
+    ChkTime $RUNTEST
+
+    # Default result to Fail
+    export result_r="FAIL"
+
+    # Sync the time with the time server. Tests may change the time
+    TimeSyncNTP
+
+    if [ -n "$FILTERTESTS" ]; then
+        FILTERTESTS="$(echo $FILTERTESTS | sed 's/\w\+/-e &/g')"
+        time -p ${LTPDIR}/runltp -p -d $OUTPUTDIR -l $OUTPUTDIR/$RUNTEST.log \
+            -o $OUTPUTDIR/$RUNTEST.run.log $OPTIONS -s "$FILTERTESTS"
+    else
+        DebugInfo Before
+        DeBug "Command Line:"
+        DeBug "${LTPDIR}/runltp -p -d $OUTPUTDIR -l $OUTPUTDIR/$RUNTEST.log \
+            -o $OUTPUTDIR/$RUNTEST.run.log -f $RUNTEST $OPTIONS"
+        time -p ${LTPDIR}/runltp -p -d $OUTPUTDIR -l $OUTPUTDIR/$RUNTEST.log \
+            -o $OUTPUTDIR/$RUNTEST.run.log -f $RUNTEST $OPTIONS
+    fi
+
+    DebugInfo After
+    if [ $RUNTEST = "ipc" ]; then
+        IPCRMCleanup
+        DebugInfo AfterIPCRMCleanup
+    fi
+
+    LogDeceiver
+
+    if ! [ -e $OUTPUTDIR/$RUNTEST.log ] || grep -q FAIL $OUTPUTDIR/$RUNTEST.log; then
+        echo "$RUNTEST Failed: " | tee -a $OUTPUTFILE
+        result_r="FAIL"
+    else
+        echo "$RUNTEST Passed: " | tee -a $OUTPUTFILE
+        result_r="PASS"
+    fi
+
+    cat $OUTPUTDIR/$RUNTEST.log >> $OUTPUTFILE
+    echo Test End Time: `date` >> $OUTPUTFILE
+
+    # If REPORT_FAILED_RESULT set to "yes", report every failed test to beaker
+    # so that it's easier to see which tests failed.
+    if [ "$REPORT_FAILED_RESULT" == "yes" -a "$result_r" == "FAIL" ]; then
+        while read test res ret; do
+            if [ "$res" != "FAIL" ]; then
+                continue
+            fi
+            RprtRslt $RUNTEST/$test $res $ret
+        done < $OUTPUTDIR/$RUNTEST.log
+    fi
+    RprtRslt $RUNTEST $result_r
+
+    # Restore AVC check
+    if echo $RUNTEST | grep -q CGROUP; then
+        export AVC_ERROR=''
+    fi
+}
+
+RunFiltTest ()
+{
+    if [ -n "$FILTERTESTS" ]; then
+        rm -f $OUTPUTDIR/filtered_runtest.log
+        rm -f $OUTPUTDIR/filtered_runtest.run.log
+
+        RunTest filtered_runtest "$OPTS"
+        return 0
+    fi
+
+    return 1
+}

--- a/distribution/ltp/lite/Makefile
+++ b/distribution/ltp/lite/Makefile
@@ -1,0 +1,143 @@
+include /usr/share/rhts/lib/rhts-make.include
+ifeq (,$(wildcard ../include/ltp-make.include))
+include /mnt/tests/kernel/distribution/ltp/include/ltp-make.include
+else
+include ../include/ltp-make.include
+endif
+
+# The toplevel namespace within which the test lives.
+TOPLEVEL_NAMESPACE=/kernel
+
+# The name of the package under test.
+PACKAGE_NAME=distribution
+
+# The name of test case.
+TEST_CASE=ltp/lite
+
+# The version of the test rpm that gets created / submitted.
+# export TESTVERSION=1.0
+# The TESTVERSION is declared in the include file
+# /mnt/tests/kernel/distribution/ltp/include/ltp-make.include
+
+export TEST=$(TOPLEVEL_NAMESPACE)/$(PACKAGE_NAME)/$(TEST_CASE)
+
+.PHONY: build clean run patch-inc-tolerant
+
+PATCHDIR = .
+ifeq ($(wildcard patches),patches)
+    PATCHDIR = patches
+endif
+PATCHES=$(PATCHDIR)
+
+# All files you want in your rpm.
+FILES=	$(METADATA) runtest.sh Makefile PURPOSE \
+	RHELKT1LITE.* \
+	grab_corefiles.sh grab_corefiles_excluded_bins \
+	is_baremetal.sh timeout.my \
+	$(PATCHES)
+
+patch-inc-tolerant:
+	-make --ignore-errors patch-inc > patchinc.log 2>&1
+	-cat patchinc.log
+
+patch: patch-inc-tolerant patch-lite
+
+patch-lite:
+	@echo "============ Patch ltp-lite test suite. ============"
+ifeq ($(TESTVERSION),20120822)
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/proc01.c $(TARGET)/testcases/kernel/fs/proc/
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/clone_platform.h $(TARGET)/testcases/kernel/syscalls/clone/
+	cp -vrf $(PATCHDIR)/$(TESTVERSION)/readahead $(TARGET)/testcases/kernel/syscalls/
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/send01.c $(TARGET)/testcases/kernel/syscalls/send/
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/sendto01.c $(TARGET)/testcases/kernel/syscalls/sendto/
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/sendmsg01.c $(TARGET)/testcases/kernel/syscalls/sendmsg/
+else ifeq ($(TESTVERSION),20130109)
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/waitid02.c $(TARGET)/testcases/kernel/syscalls/waitid
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/clone02.c $(TARGET)/testcases/kernel/syscalls/clone
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/clone07.c $(TARGET)/testcases/kernel/syscalls/clone
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/proc01.c $(TARGET)/testcases/kernel/fs/proc
+else ifeq ($(TESTVERSION),20130904)
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/proc01.c $(TARGET)/testcases/kernel/fs/proc
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/kernel_Makefile $(TARGET)/testcases/kernel/Makefile
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/sendmsg01.c $(TARGET)/testcases/kernel/syscalls/sendmsg/
+else ifeq ($(TESTVERSION),20140115)
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/readahead02.c $(TARGET)/testcases/kernel/syscalls/readahead/
+else ifeq ($(TESTVERSION),20150119)
+	cp -vf RHELKT1LITE.20150119 RHELKT1LITE
+	cp -vf $(PATCHDIR)/$(TESTVERSION)/proc01.c $(TARGET)/testcases/kernel/fs/proc/
+else ifeq ($(TESTVERSION),20150420)
+	cp -vf $(PATCHDIR)/20150420/proc01.c $(TARGET)/testcases/kernel/fs/proc/
+	cp -vf RHELKT1LITE.20150420 RHELKT1LITE
+else ifeq ($(TESTVERSION),20160126)
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/20150903/proc01_ignore_bus_usb.patch
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/oom_hang_workaround.patch
+	cp -vf RHELKT1LITE.20150903 RHELKT1LITE
+else ifeq ($(TESTVERSION),20160510)
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/20150903/proc01_ignore_bus_usb.patch
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/oom_hang_workaround.patch
+	cp -vf RHELKT1LITE.20160510 RHELKT1LITE
+else ifeq ($(TESTVERSION),20160920)
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/20150903/proc01_ignore_bus_usb.patch
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/oom_hang_workaround.patch
+	cp -vf RHELKT1LITE.20160920 RHELKT1LITE
+else ifeq ($(TESTVERSION),20170116)
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/20150903/proc01_ignore_bus_usb.patch
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/oom_hang_workaround.patch
+	cp -vf RHELKT1LITE.20170116 RHELKT1LITE
+else ifeq ($(TESTVERSION),20170516)
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/20150903/proc01_ignore_bus_usb.patch
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/oom_hang_workaround.patch
+	cp -vf RHELKT1LITE.20170516 RHELKT1LITE
+else ifeq ($(TESTVERSION),20170929)
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/20150903/proc01_ignore_bus_usb.patch
+	patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/oom_hang_workaround2.patch
+	if ! ./is_baremetal.sh; then patch -d $(TARGET) -p1 --merge < $(PATCHDIR)/ltp-include-relax-timer-thresholds-for-non-baremetal.patch; fi
+	cp -vf RHELKT1LITE.20170929 RHELKT1LITE
+else ifeq ($(TESTVERSION),2018018)
+	patch -d $(TARGET) -p1 < $(PATCHDIR)/20150903/proc01_ignore_bus_usb.patch
+	patch -d $(TARGET) -p1 < $(PATCHDIR)/oom_hang_workaround2.patch
+	if ! ./is_baremetal.sh; then patch -d $(TARGET) -p1 < $(PATCHDIR)/ltp-include-relax-timer-thresholds-for-non-baremetal.patch; fi
+	# RHEL5 gcc has trouble with this test
+	if grep -q "release 5" /etc/redhat-release; then rm -f $(TARGET)/testcases/cve/cve-2016-7117.c; fi
+	# RHEL5 doesn't have timeout
+	if grep -q "release 5" /etc/redhat-release; then cp -f timeout.my /usr/bin/timeout; fi
+	cp -vf RHELKT1LITE.20180118 RHELKT1LITE
+else
+	patch -d $(TARGET) -p1 < $(PATCHDIR)/20150903/proc01_ignore_bus_usb.patch
+	if ! ./is_baremetal.sh; then patch -d $(TARGET) -p1 < $(PATCHDIR)/ltp-include-relax-timer-thresholds-for-non-baremetal.patch; fi
+	# RHEL5 gcc has trouble with this test
+	if grep -q "release 5" /etc/redhat-release; then rm -f $(TARGET)/testcases/cve/cve-2016-7117.c; fi
+	# RHEL5 doesn't have timeout
+	if grep -q "release 5" /etc/redhat-release; then cp -f timeout.my /usr/bin/timeout; fi
+	cp -vf RHELKT1LITE.20180515 RHELKT1LITE
+endif
+
+build: $(TARGET) build-all
+	chmod +x ./runtest.sh
+	chmod +x ./grab_corefiles.sh
+
+patchonly-generic: $(TARGET) patch-inc-tolerant
+
+patchonly: $(TARGET) patch
+
+patch-and-build: $(TARGET) patch build
+
+run: $(TARGET) patch build
+	@echo "============ Run Tests ============"
+	LANG=C ./runtest.sh
+
+$(METADATA):
+	touch $(METADATA)
+	@echo "Name:            $(TEST)" >$(METADATA)
+	@echo "Description:     Latest LTP test KernelTier1" >>$(METADATA)
+	@echo "Path:            $(TEST_DIR)" >>$(METADATA)
+	@echo "TestTime:        180m" >>$(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >>$(METADATA)
+	@echo "License:         GPLv3" >>$(METADATA)
+	@echo "RhtsRequires:    kernel-kernel-distribution-ltp-include" >> $(METADATA)
+	@echo "Requires:        automake autoconf procmail flex bison rsyslog sysklogd util-linux-ng rpm-build" >> $(METADATA)
+	@echo "Requires:        gcc wget ntpdate kernel-headers redhat-lsb bc numactl" >> $(METADATA)
+	@echo "Requires:        kernel-devel libaio-devel libcap-devel numactl-devel libcgroup strace hexdump virt-what" >> $(METADATA)
+	@echo "Owner:           Kernel General Test Team <kernel-general-test-team@redhat.com>" >>$(METADATA)
+	@echo "Releases:        RHEL6 RHEL7 RedHatEnterpriseLinux7 RedHatEnterpriseLinuxPegas7 RedHatEnterpriseLinuxAlternateArchitectures7 RedHatEnterpriseLinux8 Fedora25 Fedora26 Fedorarawhide" >>$(METADATA)
+	@echo "Type:            KernelTier0 KernelTier1" >>$(METADATA)

--- a/distribution/ltp/lite/PURPOSE
+++ b/distribution/ltp/lite/PURPOSE
@@ -1,0 +1,5 @@
+This script can be used to run a subset the tests in the LTP test suite,
+this script is typically used as a quick test to check an install base.
+
+For more details:
+https://github.com/linux-test-project/ltp

--- a/distribution/ltp/lite/RHELKT1LITE.20180515
+++ b/distribution/ltp/lite/RHELKT1LITE.20180515
@@ -1,0 +1,1652 @@
+#logging
+kmsg01 kmsg01
+
+#Math library tests - CPU tests
+abs01 abs01
+
+atof01 atof01
+
+float_bessel cd $LTPROOT/testcases/bin; float_bessel -v
+float_exp_log cd $LTPROOT/testcases/bin; float_exp_log -v
+float_iperb cd $LTPROOT/testcases/bin; float_iperb -v
+float_power cd $LTPROOT/testcases/bin; float_power -v
+float_trigo cd $LTPROOT/testcases/bin; float_trigo -v
+
+fptest01 fptest01
+fptest02 fptest02
+
+nextafter01 nextafter01
+
+#fsx filesystem stress tests
+fsx-linux export TCbin=$LTPROOT/testcases/bin;fsxtest02 10000
+
+#Interprocess communication stress
+# These tests use tests/pipeio to put pipes (named or unnamed) through a workout
+#
+pipeio_1 pipeio -T pipeio_1 -c 5 -s 4090 -i 100 -b -f x80
+# spawns 5 children to write 100 chunks of 4090 bytes to a named pipe 
+# using blocking I/O
+#pipeio_2 pipeio -T pipeio_2 -c 5 -s 4090 -i 100 -f x80
+# spawns 5 children to write 100 chunks of 4090 bytes to a named pipe 
+# using non-blocking I/O
+# This test hits EAGAIN, which pipeio doesn't handle at the moment
+pipeio_3 pipeio -T pipeio_3 -c 5 -s 4090 -i 100 -u -b -f x80
+# spawns 5 children to write 100 chunks of 4090 bytes to an unnamed pipe 
+# using blocking I/O
+pipeio_4 pipeio -T pipeio_4 -c 5 -s 4090 -i 100 -u -f x80
+# spawns 5 children to write 100 chunks of 4090 bytes to an unnamed pipe 
+# using non-blocking I/O
+pipeio_5 pipeio -T pipeio_5 -c 5 -s 5000 -i 10 -b -f x80
+# spawns 5 children to write 10 chunks of 5000 bytes to a named pipe 
+# using blocking I/O
+pipeio_6 pipeio -T pipeio_6 -c 5 -s 5000 -i 10 -b -u -f x80
+# spawns 5 children to write 10 chunks of 5000 bytes to an unnamed pipe 
+# using blocking I/O
+#pipeio_7 pipeio -T pipeio_7 -c 5 -s 5000 -i 10 -f x80
+# spawns 5 children to write 10 chunks of 5000 bytes to a named pipe 
+# using non-blocking I/O
+# This test hits EAGAIN, which pipeio doesn't handle at the moment
+pipeio_8 pipeio -T pipeio_8 -c 5 -s 5000 -i 10 -u -f x80
+# spawns 5 children to write 10 chunks of 5000 bytes to an unnamed pipe 
+# using non-blocking I/O
+
+sem01 sem01
+sem02 sem02
+
+#Kernel system calls
+abort01 abort01
+
+accept01 accept01
+accept4_01 accept4_01
+
+access01 access01
+access02 access02
+access03 access03
+access04 access04
+
+acct01 acct01
+
+add_key01 add_key01
+add_key02 add_key02
+
+adjtimex01 adjtimex01
+adjtimex02 adjtimex02
+
+alarm02 alarm02
+alarm03 alarm03
+alarm05 alarm05
+alarm06 alarm06
+alarm07 alarm07
+
+asyncio02 asyncio02
+
+bind01 bind01
+bind02 bind02
+
+bdflush01 bdflush01
+
+brk01 brk01
+
+capget01 capget01
+capget02 capget02
+
+capset01 capset01
+capset02 capset02
+
+cacheflush01 cacheflush01
+
+chdir01 chdir01
+chdir01A symlink01 -T chdir01
+chdir02 chdir02
+chdir03 chdir03
+chdir04 chdir04
+
+chmod01 chmod01
+chmod01A symlink01 -T chmod01
+chmod02 chmod02
+chmod03 chmod03
+chmod04 chmod04
+chmod05 chmod05
+chmod06 chmod06
+chmod07 chmod07
+
+chown01 chown01
+chown01_16 chown01_16
+chown02 chown02
+chown02_16 chown02_16
+chown03 chown03
+chown03_16 chown03_16
+chown04 chown04
+chown04_16 chown04_16
+chown05 chown05
+chown05_16 chown05_16
+
+chroot01 chroot01
+chroot02 chroot02
+chroot03 chroot03
+chroot04 chroot04
+
+clock_getres01 clock_getres01
+clock_nanosleep01 clock_nanosleep01
+clock_nanosleep02 clock_nanosleep02
+clock_nanosleep2_01 clock_nanosleep2_01
+
+clone01 clone01
+clone02 clone02
+clone03 clone03
+clone04 clone04
+clone05 clone05
+clone06 clone06
+clone07 clone07
+clone08 clone08
+clone09 clone09
+
+close01 close01
+close02 close02
+close08 close08
+
+confstr01 confstr01
+
+connect01 connect01
+
+creat01 creat01
+creat03 creat03
+creat04 creat04
+creat05 creat05
+creat06 creat06
+creat07 creat07
+creat08 creat08
+
+dup01 dup01
+dup02 dup02
+dup03 dup03
+dup04 dup04
+dup05 dup05
+dup06 dup06
+dup07 dup07
+
+dup201 dup201
+dup202 dup202
+dup203 dup203
+dup204 dup204
+dup205 dup205
+
+dup3_01 dup3_01
+dup3_02 dup3_02
+
+epoll_create1_01 epoll_create1_01
+epoll01 epoll-ltp
+epoll_ctl01 epoll_ctl01
+epoll_ctl02 epoll_ctl02
+epoll_wait01 epoll_wait01
+#epoll_wait02 epoll_wait02 --> sporadically wakes up early, needs to be investigated
+epoll_wait03 epoll_wait03
+epoll_pwait01 epoll_pwait01
+
+eventfd01 eventfd01
+
+eventfd2_01 eventfd2_01
+eventfd2_02 eventfd2_02
+eventfd2_03 eventfd2_03
+
+execl01 execl01
+execle01 execle01
+execlp01 execlp01
+
+execv01 execv01
+execve01 execve01
+execve02 execve02
+execve03 execve03
+execve04 execve04
+execve05 execve05 20 $LTPROOT/testcases/bin/execve05 $LTPROOT/testcases/bin/execve05 4
+execvp01 execvp01
+
+exit01 exit01
+exit02 exit02
+
+exit_group01 exit_group01
+
+faccessat01 faccessat01
+
+fallocate01 fallocate01
+fallocate02 fallocate02
+fallocate03 fallocate03
+fallocate04 fallocate04
+
+posix_fadvise01                      posix_fadvise01
+posix_fadvise01_64                posix_fadvise01_64
+posix_fadvise02                      posix_fadvise02
+posix_fadvise02_64                posix_fadvise02_64
+posix_fadvise03                      posix_fadvise03
+posix_fadvise03_64                posix_fadvise03_64
+posix_fadvise04                      posix_fadvise04
+posix_fadvise04_64                posix_fadvise04_64
+
+fchdir01 fchdir01
+fchdir02 fchdir02
+fchdir03 fchdir03
+
+fchmod01 fchmod01
+fchmod02 fchmod02
+fchmod03 fchmod03
+fchmod04 fchmod04
+fchmod05 fchmod05
+fchmod06 fchmod06
+fchmod07 fchmod07
+
+fchmodat01 fchmodat01
+
+fchown01 fchown01
+fchown01_16 fchown01_16
+fchown02 fchown02
+fchown02_16 fchown02_16
+fchown03 fchown03
+fchown03_16 fchown03_16
+fchown04 fchown04
+fchown04_16 fchown04_16
+fchown05 fchown05
+fchown05_16 fchown05_16
+
+fchownat01 fchownat01
+fchownat02 fchownat02
+
+fcntl01 fcntl01
+fcntl01_64 fcntl01_64
+fcntl02 fcntl02
+fcntl02_64 fcntl02_64
+fcntl03 fcntl03
+fcntl03_64 fcntl03_64
+fcntl04 fcntl04
+fcntl04_64 fcntl04_64
+fcntl05 fcntl05
+fcntl05_64 fcntl05_64
+fcntl06 fcntl06
+fcntl06_64 fcntl06_64
+fcntl07 fcntl07
+fcntl07_64 fcntl07_64
+fcntl08 fcntl08
+fcntl08_64 fcntl08_64
+fcntl09 fcntl09
+fcntl09_64 fcntl09_64
+fcntl10 fcntl10
+fcntl10_64 fcntl10_64
+fcntl11 fcntl11
+fcntl11_64 fcntl11_64
+fcntl12 fcntl12
+fcntl12_64 fcntl12_64
+fcntl13 fcntl13
+fcntl13_64 fcntl13_64
+fcntl14 fcntl14
+fcntl14_64 fcntl14_64
+fcntl15 fcntl15
+fcntl15_64 fcntl15_64
+fcntl16 fcntl16
+fcntl16_64 fcntl16_64
+fcntl17 fcntl17
+fcntl17_64 fcntl17_64
+fcntl18 fcntl18
+fcntl18_64 fcntl18_64
+fcntl19 fcntl19
+fcntl19_64 fcntl19_64
+fcntl20 fcntl20
+fcntl20_64 fcntl20_64
+fcntl21 fcntl21
+fcntl21_64 fcntl21_64
+fcntl22 fcntl22
+fcntl22_64 fcntl22_64
+fcntl23 fcntl23
+fcntl23_64 fcntl23_64
+fcntl24 fcntl24
+fcntl24_64 fcntl24_64
+fcntl25 fcntl25
+fcntl25_64 fcntl25_64
+fcntl26 fcntl26
+fcntl26_64 fcntl26_64
+fcntl27 fcntl27
+fcntl27_64 fcntl27_64
+fcntl28 fcntl28
+fcntl28_64 fcntl28_64
+fcntl29 fcntl29
+fcntl29_64 fcntl29_64
+fcntl30 fcntl30
+fcntl30_64 fcntl30_64
+fcntl31 fcntl31
+fcntl31_64 fcntl31_64
+fcntl32 fcntl32
+fcntl32_64 fcntl32_64
+fcntl33 fcntl33
+fcntl33_64 fcntl33_64
+fcntl34 fcntl34
+fcntl34_64 fcntl34_64
+fcntl35 fcntl35
+fcntl35_64 fcntl35_64
+fcntl36 fcntl36
+fcntl36_64 fcntl36_64
+
+fdatasync01 fdatasync01
+fdatasync02 fdatasync02
+
+flistxattr01 flistxattr01
+flistxattr02 flistxattr02
+flistxattr03 flistxattr03
+
+flock01 flock01
+flock02 flock02
+flock03 flock03
+flock04 flock04
+flock05 flock05
+flock06 flock06
+
+fmtmsg01 fmtmsg01
+
+fork01 fork01
+fork02 fork02
+fork03 fork03
+fork04 fork04
+fork05 fork05
+fork06 fork06
+fork07 fork07
+fork08 fork08
+fork09 fork09
+fork10 fork10
+fork11 fork11
+fork13 fork13 -i 10000
+fork14 fork14
+
+fpathconf01 fpathconf01
+
+fstat01 fstat01
+fstat01_64 fstat01_64
+fstat02 fstat02
+fstat02_64 fstat02_64
+fstat03 fstat03
+fstat03_64 fstat03_64
+fstat05 fstat05
+fstat05_64 fstat05_64
+
+fstatat01 fstatat01
+
+fstatfs01 fstatfs01
+fstatfs01_64 fstatfs01_64
+fstatfs02 fstatfs02
+fstatfs02_64 fstatfs02_64
+
+fsync01 fsync01
+fsync02 fsync02
+fsync03 fsync03
+
+ftruncate01 ftruncate01
+ftruncate01_64 ftruncate01_64
+ftruncate02 ftruncate02
+ftruncate02_64 ftruncate02_64
+ftruncate03 ftruncate03
+ftruncate03_64 ftruncate03_64
+ftruncate04 ftruncate04
+ftruncate04_64 ftruncate04_64
+
+futimesat01 futimesat01
+
+getcontext01 getcontext01
+
+getcpu01 getcpu01
+
+getcwd01 getcwd01
+getcwd02 getcwd02
+getcwd03 getcwd03
+getcwd04 getcwd04
+
+getdents01 getdents01
+getdents02 getdents02
+
+getdents01_64 getdents01 -l
+getdents02_64 getdents02 -l
+
+getdomainname01 getdomainname01
+
+getdtablesize01 getdtablesize01
+
+getegid01 getegid01
+getegid01_16 getegid01_16
+getegid02 getegid02
+getegid02_16 getegid02_16
+
+geteuid01 geteuid01
+geteuid01_16 geteuid01_16
+geteuid02 geteuid02
+geteuid02_16 geteuid02_16
+
+getgid01 getgid01
+getgid01_16 getgid01_16
+getgid03 getgid03
+getgid03_16 getgid03_16
+
+getgroups01 getgroups01
+getgroups01_16 getgroups01_16
+getgroups03 getgroups03
+getgroups03_16 getgroups03_16
+
+gethostbyname_r01 gethostbyname_r01
+
+gethostid01 gethostid01
+
+gethostname01 gethostname01
+
+getitimer01 getitimer01
+getitimer02 getitimer02
+getitimer03 getitimer03
+
+getpagesize01 getpagesize01
+
+getpeername01 getpeername01
+
+getpgid01 getpgid01
+getpgid02 getpgid02
+
+getpgrp01 getpgrp01
+
+getpid01 getpid01
+getpid02 getpid02
+
+getppid01 getppid01
+getppid02 getppid02
+
+getpriority01 getpriority01
+getpriority02 getpriority02
+
+getrandom01 getrandom01
+getrandom02 getrandom02
+getrandom03 getrandom03
+getrandom04 getrandom04
+
+getresgid01 getresgid01
+getresgid02 getresgid02
+getresgid03 getresgid03
+
+getresuid01 getresuid01
+getresuid02 getresuid02
+getresuid03 getresuid03
+
+getrlimit01 getrlimit01
+getrlimit02 getrlimit02
+
+get_mempolicy01 get_mempolicy01
+get_robust_list01 get_robust_list01
+
+getrusage01 getrusage01
+getrusage02 getrusage02
+getrusage03 getrusage03
+#TODO: getrusage04 sporadicly fails
+getrusage04 sh -c "getrusage04 || true"
+
+getsid01 getsid01
+getsid02 getsid02
+
+getsockname01 getsockname01
+
+getsockopt01 getsockopt01
+getsockopt02 getsockopt02
+
+gettid01 gettid01
+
+gettimeofday01 gettimeofday01
+gettimeofday02 gettimeofday02
+
+getuid01 getuid01
+getuid01_16 getuid01_16
+getuid03 getuid03
+getuid03_16 getuid03_16
+
+getxattr01 getxattr01
+getxattr02 getxattr02
+getxattr03 getxattr03
+getxattr04 getxattr04
+
+ioctl01_02   test_ioctl
+ioctl03      ioctl03
+ioctl04      ioctl04
+ioctl05      ioctl05
+ioctl06      ioctl06
+
+inotify_init1_01 inotify_init1_01
+inotify_init1_02 inotify_init1_02
+
+inotify01 inotify01
+inotify02 inotify02
+inotify03 inotify03
+inotify04 inotify04
+inotify05 inotify05
+inotify06 inotify06
+
+fanotify01 fanotify01
+fanotify02 fanotify02
+fanotify03 fanotify03
+fanotify04 fanotify04
+fanotify05 fanotify05
+fanotify06 fanotify06
+fanotify07 fanotify07
+fanotify08 fanotify08
+
+ioperm01 ioperm01
+ioperm02 ioperm02
+
+iopl01 iopl01
+iopl02 iopl02
+
+io_cancel01 io_cancel01
+io_destroy01 io_destroy01
+io_getevents01 io_getevents01
+io_setup01 io_setup01
+io_submit01 io_submit01
+
+keyctl01 keyctl01
+keyctl02 keyctl02
+keyctl03 keyctl03
+keyctl04 keyctl04
+keyctl05 keyctl05
+
+kcmp01 kcmp01
+kcmp02 kcmp02
+kcmp03 kcmp03
+
+kill01 kill01
+kill02 kill02
+kill03 kill03
+kill04 kill04
+kill05 kill05
+kill06 kill06
+kill07 kill07
+kill08 kill08
+kill09 kill09
+kill10 kill10
+kill11 kill11
+kill12 kill12
+
+lchown01 lchown01
+lchown01_16 lchown01_16
+lchown02 lchown02
+lchown02_16 lchown02_16
+lchown03 lchown03
+lchown03_16 lchown03_16
+
+lgetxattr01 lgetxattr01
+lgetxattr02 lgetxattr02
+
+link01 symlink01 -T link01
+link02 link02
+link03 link03
+link04 link04
+link05 link05
+link06 link06
+link07 link07
+link08 link08
+
+linkat01 linkat01
+linkat02 linkat02
+
+listen01 listen01
+
+listxattr01 listxattr01
+listxattr02 listxattr02
+listxattr03 listxattr03
+
+llistxattr01 llistxattr01
+llistxattr02 llistxattr02
+llistxattr03 llistxattr03
+
+llseek01 llseek01
+llseek02 llseek02
+llseek03 llseek03
+
+lseek01 lseek01
+lseek02 lseek02
+lseek07 lseek07
+lseek11 lseek11
+
+lstat01A symlink01 -T lstat01
+lstat01A_64 symlink01 -T lstat01_64
+lstat01 lstat01
+lstat01_64 lstat01_64
+lstat02 lstat02
+lstat02_64 lstat02_64
+lstat03 lstat03
+lstat03_64 lstat03_64
+
+mallopt01 mallopt01
+
+mbind01 mbind01
+
+memset01 memset01
+memcmp01 memcmp01
+memcpy01 memcpy01
+
+migrate_pages01 migrate_pages01
+migrate_pages02 migrate_pages02
+
+mlockall01 mlockall01
+mlockall02 mlockall02
+mlockall03 mlockall03
+
+mkdir02 mkdir02
+mkdir03 mkdir03
+mkdir04 mkdir04
+mkdir05 mkdir05
+mkdir05A symlink01 -T mkdir05
+mkdir09 mkdir09
+
+mkdirat01 mkdirat01
+mkdirat02 mkdirat02
+
+mknod01 mknod01
+mknod02 mknod02
+mknod03 mknod03
+mknod04 mknod04
+mknod05 mknod05
+mknod06 mknod06
+mknod07 mknod07
+mknod08 mknod08
+mknod09 mknod09
+
+mknodat01 mknodat01
+mknodat02 mknodat02
+
+mlock01 mlock01
+mlock02 mlock02
+mlock03 mlock03 -i 20
+mlock04 mlock04
+
+qmm01 mmap001 -m 1
+mmap01 mmap01
+mmap02 mmap02
+mmap03 mmap03
+mmap04 mmap04
+mmap05 mmap05
+mmap06 mmap06
+mmap07 mmap07
+mmap08 mmap08
+mmap09 mmap09
+mmap12 mmap12
+mmap13 mmap13
+mmap14 mmap14
+#TODO: mmap11 mmap11 -i 30000, test is masked in upstream LTP
+mmap15 mmap15
+mmap16 mmap16
+
+modify_ldt01 modify_ldt01
+modify_ldt02 modify_ldt02
+modify_ldt03 modify_ldt03
+
+mount01 mount01
+mount02 mount02
+mount03 mount03
+mount04 mount04
+mount05 mount05
+mount06 mount06
+
+move_pages01 move_pages.sh 01
+move_pages02 move_pages.sh 02
+move_pages03 cd $LTPROOT/testcases/bin && chown root move_pages03 && chmod 04755 move_pages03 && move_pages.sh 03
+move_pages04 move_pages.sh 04
+move_pages05 move_pages.sh 05
+move_pages06 move_pages.sh 06
+move_pages07 move_pages.sh 07
+#TODO: move_pages0[89] makes sense only kernel < 2.6.29
+#TODO: move_pages08 move_pages.sh 08
+#TODO: move_pages09 move_pages.sh 09
+move_pages10 move_pages.sh 10
+move_pages11 cd $LTPROOT/testcases/bin && chown root move_pages11 && chmod 04755 move_pages11 && move_pages.sh 11
+move_pages12 move_pages12
+
+mprotect01 mprotect01
+mprotect02 mprotect02
+mprotect03 mprotect03
+mprotect04 mprotect04
+
+mq_notify01 mq_notify01
+mq_notify02 mq_notify02
+mq_open01 mq_open01
+mq_timedreceive01 mq_timedreceive01
+mq_timedsend01 mq_timedsend01
+mq_unlink01 mq_unlink01
+
+mremap01 mremap01
+mremap02 mremap02
+mremap03 mremap03
+mremap04 mremap04
+mremap05 mremap05
+
+msgctl01 msgctl01
+msgctl02 msgctl02
+msgctl03 msgctl03
+msgctl04 msgctl04
+msgctl05 msgctl05
+msgctl06 msgctl06
+msgctl07 msgctl07
+msgctl08 msgctl08
+msgctl09 msgctl09
+#TODO: msgctl10 msgctl10 -> keeps triggerring OOM until there are no more processes to kill
+#TODO: msgctl11 msgctl11 -> too many pids
+msgctl12 msgctl12
+msgctl13 msgctl13
+
+msgget01 msgget01
+msgget02 msgget02
+msgget03 msgget03
+
+msgrcv01 msgrcv01
+msgrcv02 msgrcv02
+msgrcv03 msgrcv03
+msgrcv04 msgrcv04
+msgrcv05 msgrcv05
+msgrcv06 msgrcv06
+msgrcv07 msgrcv07
+msgrcv08 msgrcv08
+
+msgsnd01 msgsnd01
+msgsnd02 msgsnd02
+msgsnd05 msgsnd05
+msgsnd06 msgsnd06
+
+msync01 msync01
+msync02 msync02
+msync03 msync03
+msync04 msync04
+
+munlock01 munlock01
+munlock02 munlock02
+
+munlockall01 munlockall01
+munlockall02 munlockall02
+
+munmap01 munmap01
+munmap02 munmap02
+munmap03 munmap03
+
+nanosleep01 nanosleep01
+nanosleep02 nanosleep02
+nanosleep03 nanosleep03
+nanosleep04 nanosleep04
+
+nftw01 nftw01
+nftw6401 nftw6401
+
+nice01 nice01
+nice02 nice02
+nice03 nice03
+nice04 nice04
+
+open01 open01
+open01A symlink01 -T open01
+open02 open02
+open03 open03
+open04 open04
+open05 open05
+open06 open06
+open07 open07
+open08 open08
+open09 open09
+open10 open10
+open11 open11
+open12 open12
+open13 open13
+open14 open14
+
+openat01 openat01
+openat02 openat02
+openat03 openat03
+
+mincore01 mincore01
+mincore02 mincore02
+
+madvise01 madvise01
+madvise02 madvise02
+madvise05 madvise05
+madvise06 madvise06
+madvise07 madvise07
+madvise08 madvise08
+madvise09 madvise09
+
+newuname01 newuname01
+
+pathconf01 pathconf01
+
+pause01 pause01
+pause02 pause02
+pause03 pause03
+
+personality01 personality01
+personality02 personality02
+
+pipe01 pipe01
+pipe02 pipe02
+pipe03 pipe03
+pipe04 pipe04
+pipe05 pipe05
+pipe06 pipe06
+pipe07 pipe07
+pipe08 pipe08
+pipe09 pipe09
+pipe10 pipe10
+pipe11 pipe11
+
+pipe2_01 pipe2_01
+pipe2_02 pipe2_02
+
+poll01 poll01
+poll02 poll02
+
+ppoll01 ppoll01
+
+prctl01 prctl01
+prctl02 prctl02
+
+pread01 pread01
+pread01_64 pread01_64
+pread02 pread02
+pread02_64 pread02_64
+pread03 pread03
+pread03_64 pread03_64
+
+preadv01 preadv01
+preadv01_64 preadv01_64
+preadv02 preadv02
+preadv02_64 preadv02_64
+
+profil01 profil01
+
+process_vm_readv01 process_vm01 -r
+process_vm_readv02 process_vm_readv02
+process_vm_readv03 process_vm_readv03
+process_vm_writev01 process_vm01 -w
+process_vm_writev02 process_vm_writev02
+
+prot_hsymlinks prot_hsymlinks
+dirtyc0w dirtyc0w
+
+#pselect01 pselect01
+#pselect01_64 pselect01_64
+pselect01 sh -c "pselect01 || true"
+pselect01_64 sh -c "pselect01_64 || true"
+
+pselect02 pselect02
+pselect02_64 pselect02_64
+pselect03 pselect03
+pselect03_64 pselect03_64
+
+ptrace01 ptrace01
+ptrace02 ptrace02
+ptrace03 ptrace03
+ptrace04 ptrace04
+ptrace05 ptrace05
+
+pwrite01 pwrite01
+pwrite02 pwrite02
+pwrite04 pwrite04
+
+pwrite01_64 pwrite01_64
+pwrite02_64 pwrite02_64
+pwrite04_64 pwrite04_64
+
+pwritev01 pwritev01
+pwritev01_64 pwritev01_64
+pwritev02 pwritev02
+pwritev02_64 pwritev02_64
+
+quotactl01 quotactl01
+quotactl02 quotactl02
+quotactl03 quotactl03
+
+read01 read01
+read02 read02
+read03 read03
+read04 read04
+
+readahead01 readahead01
+readahead02 readahead02
+
+readdir01 readdir01
+readdir02 readdir02
+readdir21 readdir21
+
+readlink01A symlink01 -T readlink01
+readlink01 readlink01
+readlink03 readlink03
+
+readlinkat01 readlinkat01
+readlinkat02 readlinkat02
+
+readv01 readv01
+readv02 readv02
+readv03 readv03
+
+reboot01 reboot01
+reboot02 reboot02
+
+recv01 recv01
+
+recvfrom01 recvfrom01
+
+recvmsg01 recvmsg01
+recvmsg02 recvmsg02
+recvmsg03 recvmsg03
+
+remap_file_pages01 remap_file_pages01
+remap_file_pages02 remap_file_pages02
+
+removexattr01 removexattr01
+removexattr02 removexattr02
+
+rename01 rename01
+rename01A symlink01 -T rename01
+rename02 rename02
+rename03 rename03
+rename04 rename04
+rename05 rename05
+rename06 rename06
+rename07 rename07
+rename08 rename08
+rename09 rename09
+rename10 rename10
+rename11 rename11
+rename12 rename12
+rename13 rename13
+rename14 rename14
+
+renameat01 renameat01
+
+renameat201 renameat201
+renameat202 renameat202 -i 10
+
+request_key01 request_key01
+request_key02 request_key02
+cve-2017-6951 cve-2017-6951
+
+rmdir01 rmdir01
+rmdir02 rmdir02
+rmdir03 rmdir03
+rmdir03A symlink01 -T rmdir03
+
+rt_sigaction01 rt_sigaction01
+rt_sigaction02 rt_sigaction02
+rt_sigaction03 rt_sigaction03
+rt_sigprocmask01 rt_sigprocmask01
+rt_sigprocmask02 rt_sigprocmask02
+rt_sigqueueinfo01 rt_sigqueueinfo01
+rt_sigsuspend01 rt_sigsuspend01
+
+sbrk01 sbrk01
+sbrk02 sbrk02
+sbrk03 sbrk03
+
+sched_get_priority_max01 sched_get_priority_max01
+sched_get_priority_max02 sched_get_priority_max02
+
+sched_get_priority_min01 sched_get_priority_min01
+sched_get_priority_min02 sched_get_priority_min02
+
+sched_getparam01 sched_getparam01
+sched_getparam02 sched_getparam02
+sched_getparam03 sched_getparam03
+
+sched_rr_get_interval01 sched_rr_get_interval01
+sched_rr_get_interval02 sched_rr_get_interval02
+sched_rr_get_interval03 sched_rr_get_interval03
+
+sched_setparam01 sched_setparam01
+sched_setparam02 sched_setparam02
+sched_setparam03 sched_setparam03
+sched_setparam04 sched_setparam04
+sched_setparam05 sched_setparam05
+
+sched_getscheduler01 sched_getscheduler01
+sched_getscheduler02 sched_getscheduler02
+
+sched_setscheduler01 sched_setscheduler01
+sched_setscheduler02 sched_setscheduler02
+sched_setscheduler03 sched_setscheduler03
+
+sched_yield01 sched_yield01
+
+sched_setaffinity01 sched_setaffinity01
+sched_getaffinity01 sched_getaffinity01
+
+sched_setattr01 sched_setattr01
+sched_getattr01 sched_getattr01
+sched_getattr02 sched_getattr02
+
+select01 select01
+select02 select02
+select03 select03
+select04 select04
+
+semctl01 semctl01
+semctl02 semctl02
+semctl03 semctl03
+semctl04 semctl04
+semctl05 semctl05
+semctl06 semctl06
+semctl07 semctl07
+
+semget01 semget01
+semget02 semget02
+semget03 semget03
+semget05 semget05
+semget06 semget06
+
+semop01 semop01
+semop02 semop02
+semop03 semop03
+semop04 semop04
+semop05 semop05
+
+send01 send01
+
+sendfile02 sendfile02
+sendfile02_64 sendfile02_64
+sendfile03 sendfile03
+sendfile03_64 sendfile03_64
+sendfile04 sendfile04
+sendfile04_64 sendfile04_64
+sendfile05 sendfile05
+sendfile05_64 sendfile05_64
+sendfile06 sendfile06
+sendfile06_64 sendfile06_64
+sendfile07 sendfile07
+sendfile07_64 sendfile07_64
+sendfile08 sendfile08
+sendfile08_64 sendfile08_64
+sendfile09 sendfile09
+sendfile09_64 sendfile09_64
+
+sendmsg01 sendmsg01
+sendmsg02 sendmsg02
+
+sendto01 sendto01
+sendto02 sendto02
+
+setdomainname01 setdomainname01
+setdomainname02 setdomainname02
+setdomainname03 setdomainname03
+
+setfsgid01 setfsgid01
+setfsgid01_16 setfsgid01_16
+setfsgid02 setfsgid02
+setfsgid02_16 setfsgid02_16
+setfsgid03 setfsgid03
+setfsgid03_16 setfsgid03_16
+
+setfsuid01 setfsuid01
+setfsuid01_16 setfsuid01_16
+setfsuid02 setfsuid02
+setfsuid02_16 setfsuid02_16
+setfsuid03 setfsuid03
+setfsuid03_16 setfsuid03_16
+setfsuid04 setfsuid04
+setfsuid04_16 setfsuid04_16
+
+setgid01 setgid01
+setgid01_16 setgid01_16
+setgid02 setgid02
+setgid02_16 setgid02_16
+setgid03 setgid03
+setgid03_16 setgid03_16
+
+setegid01 setegid01
+setegid02 setegid02
+
+sgetmask01 sgetmask01
+
+setgroups01 setgroups01
+setgroups01_16 setgroups01_16
+setgroups02 setgroups02
+setgroups02_16 setgroups02_16
+setgroups03 setgroups03
+setgroups03_16 setgroups03_16
+setgroups04 setgroups04
+setgroups04_16 setgroups04_16
+
+sethostname01 sethostname01
+sethostname02 sethostname02
+sethostname03 sethostname03
+
+setitimer01 setitimer01
+setitimer02 setitimer02
+setitimer03 setitimer03
+
+setns01 setns01
+setns02 setns02
+
+setpgid01 setpgid01
+setpgid02 setpgid02
+setpgid03 setpgid03
+
+setpgrp01 setpgrp01
+setpgrp02 setpgrp02
+
+setpriority01 setpriority01
+setpriority02 setpriority02
+
+setregid01 setregid01
+setregid01_16 setregid01_16
+setregid02 setregid02
+setregid02_16 setregid02_16
+setregid03 setregid03
+setregid03_16 setregid03_16
+setregid04 setregid04
+setregid04_16 setregid04_16
+
+setresgid01 setresgid01
+setresgid01_16 setresgid01_16
+setresgid02 setresgid02
+setresgid02_16 setresgid02_16
+setresgid03 setresgid03
+setresgid03_16 setresgid03_16
+setresgid04 setresgid04
+setresgid04_16 setresgid04_16
+
+setresuid01 setresuid01
+setresuid01_16 setresuid01_16
+setresuid02 setresuid02
+setresuid02_16 setresuid02_16
+setresuid03 setresuid03
+setresuid03_16 setresuid03_16
+setresuid04 setresuid04
+setresuid04_16 setresuid04_16
+setresuid05 setresuid05
+setresuid05_16 setresuid05_16
+
+setreuid01 setreuid01
+setreuid01_16 setreuid01_16
+setreuid02 setreuid02
+setreuid02_16 setreuid02_16
+setreuid03 setreuid03
+setreuid03_16 setreuid03_16
+setreuid04 setreuid04
+setreuid04_16 setreuid04_16
+setreuid05 setreuid05
+setreuid05_16 setreuid05_16
+setreuid06 setreuid06
+setreuid06_16 setreuid06_16
+setreuid07 setreuid07
+setreuid07_16 setreuid07_16
+
+setrlimit01 setrlimit01
+setrlimit02 setrlimit02
+setrlimit03 setrlimit03
+
+set_robust_list01 set_robust_list01
+set_thread_area01 set_thread_area01
+set_tid_address01 set_tid_address01
+
+setsid01 setsid01
+
+setsockopt01 setsockopt01
+cve-2016-4997 cve-2016-4997
+
+settimeofday01 settimeofday01
+settimeofday02 settimeofday02
+
+setuid01 setuid01
+setuid01_16 setuid01_16
+setuid03 setuid03
+setuid03_16 setuid03_16
+setuid04 setuid04
+setuid04_16 setuid04_16
+
+setxattr01 setxattr01
+setxattr02 setxattr02
+setxattr03 setxattr03
+
+shmat01 shmat01
+shmat02 shmat02
+cve-2017-5669 cve-2017-5669
+
+shmctl01 shmctl01
+shmctl02 shmctl02
+shmctl03 shmctl03
+shmctl04 shmctl04
+
+shmdt01 shmdt01
+shmdt02 shmdt02
+
+shmget01 shmget01
+shmget02 shmget02
+shmget03 shmget03
+shmget04 shmget04
+shmget05 shmget05
+
+sigaction01 sigaction01
+sigaction02 sigaction02
+
+sigaltstack01 sigaltstack01
+sigaltstack02 sigaltstack02
+
+sighold02 sighold02
+
+signal01 signal01
+signal02 signal02
+signal03 signal03
+signal04 signal04
+signal05 signal05
+signal06 signal06
+
+signalfd01 signalfd01
+
+signalfd4_01 signalfd4_01
+signalfd4_02 signalfd4_02
+
+sigpending02 sigpending02
+
+sigprocmask01 sigprocmask01
+
+sigrelse01 sigrelse01
+
+sigsuspend01 sigsuspend01
+
+socket01 socket01
+socket02 socket02
+
+socketcall01 socketcall01
+socketcall02 socketcall02
+socketcall03 socketcall03
+socketcall04 socketcall04
+
+socketpair01 socketpair01
+socketpair02 socketpair02
+
+sockioctl01 sockioctl01
+
+splice01 splice01
+splice02 seq 1 20000 | splice02
+splice03 splice03
+splice04 splice04
+splice05 splice05
+
+tee01 tee01
+tee02 tee02
+
+ssetmask01 ssetmask01
+
+stat01 stat01
+stat01_64 stat01_64
+stat02 stat02
+stat02_64 stat02_64
+stat03 stat03
+stat03_64 stat03_64
+stat04 symlink01 -T stat04
+stat04_64 symlink01 -T stat04_64
+stat05 stat05
+stat05_64 stat05_64
+stat06 stat06
+stat06_64 stat06_64
+
+statfs01 statfs01
+statfs01_64 statfs01_64
+statfs02 statfs02
+statfs02_64 statfs02_64
+statfs03 statfs03
+statfs03_64 statfs03_64
+
+statvfs01 statvfs01
+statvfs02 statvfs02
+
+stime01 stime01
+stime02 stime02
+
+string01 string01
+
+swapoff01 swapoff01
+swapoff02 swapoff02
+
+swapon01 swapon01
+swapon02 swapon02
+swapon03 swapon03
+
+#Exclusive syscall() for POWER6 machines only
+switch01 endian_switch01
+
+symlink01 symlink01
+symlink02 symlink02
+symlink03 symlink03
+symlink04 symlink04
+symlink05 symlink05
+
+symlinkat01 symlinkat01
+
+sync01 sync01
+sync02 sync02
+
+sync_file_range01 sync_file_range01
+
+syscall01 syscall01
+
+sysconf01 sysconf01
+
+sysctl01 sysctl01
+sysctl03 sysctl03
+#TODO: undocumented behavior of EPERM/EACCES
+sysctl04 sysctl04
+
+sysfs01 sysfs01
+sysfs02 sysfs02
+sysfs03 sysfs03
+sysfs04 sysfs04
+sysfs05 sysfs05
+sysfs06 sysfs06
+
+sysinfo01 sysinfo01
+sysinfo02 sysinfo02
+
+syslog01 syslog01
+syslog02 syslog02
+syslog03 syslog03
+syslog04 syslog04
+syslog05 syslog05
+syslog06 syslog06
+syslog07 syslog07
+syslog08 syslog08
+syslog09 syslog09
+syslog10 syslog10
+syslog11 syslog11
+syslog12 syslog12
+
+
+time01 time01
+time02 time02
+
+times01 times01
+times03 times03
+
+timerfd01 timerfd01
+timerfd02 timerfd02
+timerfd03 timerfd03
+timerfd_create01 timerfd_create01
+timerfd_gettime01 timerfd_gettime01
+timerfd_settime01 timerfd_settime01
+
+timer_getoverrun01 timer_getoverrun01
+timer_gettime01 timer_gettime01
+
+tkill01 tkill01
+tkill02 tkill02
+
+truncate01 truncate01
+truncate01_64 truncate01_64
+truncate02 truncate02
+truncate02_64 truncate02_64
+truncate03 truncate03
+truncate03_64 truncate03_64
+
+umask01 umask01
+
+uname01 uname01
+uname02 uname02
+uname03 uname03
+cve-2012-0957 cve-2012-0957
+
+unlink01 symlink01 -T unlink01
+unlink05 unlink05
+unlink07 unlink07
+unlink08 unlink08
+
+unlinkat01 unlinkat01
+
+unshare01 unshare01
+unshare02 unshare02
+
+ustat01 ustat01
+ustat02 ustat02
+
+utime01 utime01
+utime01A symlink01 -T utime01
+utime02 utime02
+utime03 utime03
+utime04 utime04
+utime05 utime05
+utime06 utime06
+
+utimes01 utimes01
+
+utimensat01 utimensat_tests.sh
+
+vfork01 vfork01
+vfork02 vfork02
+
+vhangup01 vhangup01
+vhangup02 vhangup02
+
+vmsplice01 vmsplice01
+vmsplice02 vmsplice02
+
+wait01 wait01
+wait02 wait02
+
+wait401 wait401
+wait402 wait402
+
+waitpid01 waitpid01
+waitpid02 waitpid02
+waitpid03 waitpid03
+waitpid04 waitpid04
+waitpid05 waitpid05
+waitpid06 waitpid06
+waitpid07 waitpid07
+waitpid08 waitpid08
+waitpid09 waitpid09
+waitpid10 waitpid10
+waitpid11 waitpid11
+waitpid12 waitpid12
+waitpid13 waitpid13
+
+waitid01 waitid01
+waitid02 waitid02
+
+write01 write01
+write03 write03
+write04 write04
+write05 write05
+
+writev01 writev01
+writev02 writev02
+writev05 writev05
+writev06 writev06
+writev07 writev07
+
+#TODO: perf_event_open01 perf_event_open01 -> takes too long on power7
+#TODO: perf_event_open02 perf_event_open02
+
+futex_wait01 futex_wait01
+futex_wait02 futex_wait02
+futex_wait03 futex_wait03
+futex_wait04 futex_wait04
+futex_wait05 futex_wait05
+futex_wake01 futex_wake01
+futex_wake02 futex_wake02
+futex_wake03 futex_wake03
+futex_wake04 futex_wake04
+futex_wait_bitset01 futex_wait_bitset01
+futex_wait_bitset02 futex_wait_bitset02
+
+memfd_create01 memfd_create01
+memfd_create02 memfd_create02
+
+#Memory Mgmt tests
+mm01 mmap001 -m 10000
+# 40 Mb mmap() test.
+# Creates a 10000 page mmap, touches all of the map, sync's it, and
+# munmap()s it.
+mm02 mmap001
+# simple mmap() test.
+#mm03 mmap001 -i 0 -I 1 -m 100
+# repetitive mmapping test.
+# Creates a one page map repetitively for one minute.
+
+mtest01 mtest01 -p80
+mtest01w mtest01 -p80 -w
+
+mtest05 mmstress
+
+mtest06 mmap1 -x 0.05
+
+#TODO: mem01 mem01 -> sometimes fails to allocate memory or hits OOM
+mem02 mem02
+
+page01 page01
+page02 page02
+
+data_space data_space
+stack_space stack_space
+
+shmt02 shmt02
+shmt03 shmt03
+shmt04 shmt04
+shmt05 shmt05
+shmt06 shmt06
+shmt07 shmt07
+shmt08 shmt08
+shmt09 shmt09
+shmt10 shmt10
+
+mallocstress01  mallocstress
+
+mmapstress01 mmapstress01 -p 20 -t 0.2
+mmapstress02 mmapstress02
+mmapstress03 mmapstress03
+mmapstress04 mmapstress04
+mmapstress05 mmapstress05
+mmapstress06 mmapstress06 20
+mmapstress07 TMPFILE=`mktemp /tmp/example.XXXXXXXXXXXX`; mmapstress07 $TMPFILE
+mmapstress08 mmapstress08
+mmapstress09 mmapstress09 -p 20 -t 0.2
+mmapstress10 mmapstress10 -p 20 -t 0.2
+
+vma01 vma01
+vma02 vma02
+vma03 vma03
+vma04 vma04
+vma05 vma05.sh
+
+#Scheduler Stress Tests
+pth_str01 pth_str01
+pth_str02 pth_str02 -n1000
+pth_str03 pth_str03
+
+#Native POSIX Thread Library (NPTL) Tests
+nptl01 nptl01
+
+#Terminal type stress
+pty01 pty01
+ptem01 ptem01
+hangup01 hangup01
+
+#Misc
+dynamic_debug01                dynamic_debug01.sh
+gdb01 gdb01.sh
+
+#Filesystem stress tests
+gf01 growfiles -W gf01 -b -e 1 -u -i 0 -L 20 -w -C 1 -l -I r -T 10 glseek20 glseek20.2
+gf02 growfiles -W gf02 -b -e 1 -L 10 -i 100 -I p -S 2 -u -f gf03_
+gf03 growfiles -W gf03 -b -e 1 -g 1 -i 1 -S 150 -u -f gf05_
+gf06 growfiles -W gf06 -b -e 1 -u -r 1-5000 -R 0--1 -i 0 -L 30 -C 1 g_rand10 g_rand10.2
+gf07 growfiles -W gf07 -b -e 1 -u -r 1-5000 -R 0--2 -i 0 -L 30 -C 1 -I p g_rand13 g_rand13.2
+gf10 growfiles -W gf10 -b -e 1 -u -r 1-5000 -i 0 -L 30 -C 1 -I l g_lio14 g_lio14.2
+gf11 growfiles -W gf11 -b -e 1 -u -r 1-5000 -i 0 -L 30 -C 1 -I L g_lio15 g_lio15.2
+gf12 mkfifo gffifo17; growfiles -b -W gf12 -e 1 -u -i 0 -L 30 gffifo17
+gf13 mkfifo gffifo18; growfiles -b -W gf13 -e 1 -u -i 0 -L 30 -I r -r 1-4096 gffifo18
+gf14 growfiles -W gf14 -b -e 1 -u -i 0 -L 20 -w -l -C 1 -T 10 glseek19 glseek19.2
+gf15 growfiles -W gf15 -b -e 1 -u -r 1-49600 -I r -u -i 0 -L 120 -B 1073741824 Lgfile1
+gf17 growfiles -W gf17 -b -e 1 -i 0 -L 120 -u -g 5000 -T 101 -t 499998 -l -C 10 -c 1000 -S 10 -B 1073741824 -f Lgf03_
+gf18 growfiles -W gf18 -b -e 1 -i 0 -L 120 -w -u -r 10-5000 -I r -l -S 2 -B 1073741824 -f Lgf04_
+gf19 growfiles -W gf19 -b -e 1 -g 5000 -i 500 -t 49900 -T10 -c9 -I p -o O_RDWR,O_CREAT,O_TRUNC -u -f gf08i_
+gf20 growfiles -W gf20 -D 0 -b -i 0 -L 60 -u -B 1000b -e 1 -r 1-256000:512 -R 512-256000 -T 4 gfbigio-$$
+gf23 growfiles -W gf23 -D 0 -b -i 0 -L 60 -u -B 1000b -e 1 -r 512-64000:1024 -R 1-384000 -T 4 gf-inf-$$
+gf24 growfiles -W gf24 -D 0 -b -i 0 -L 60 -u -B 1000b -e 1 -g 20480 gf-jbld-$$
+gf25 growfiles -W gf25 -D 0 -b -i 0 -L 60 -u -B 1000b -e 1 -r 1024000-2048000:2048 -R 4095-2048000 -T 1 gf-large-gs-$$
+gf26 growfiles -W gf26 -D 0 -b -i 0 -L 60 -u -B 1000b -e 1 -r 128-32768:128 -R 512-64000 -T 4 gfsmallio-$$
+gf27 growfiles -W gf27 -b -D 0 -w -g 8b -C 1 -b -i 1000 -u gfsparse-1-$$
+gf30 growfiles -W gf30 -D 0 -b -i 0 -L 60 -u -B 1000b -e 1 -o O_RDWR,O_CREAT,O_SYNC -g 20480 -T 10 -t 20480 gf-sync-$$
+rwtest01 export LTPROOT; rwtest -N rwtest01 -c -q -i 60s  -f sync 10%25000:rw-sync-$$
+rwtest02 export LTPROOT; rwtest -N rwtest02 -c -q -i 60s  -f buffered 10%25000:rw-buffered-$$
+rwtest03 export LTPROOT; rwtest -N rwtest03 -c -q -i 60s -n 2  -f buffered -s mmread,mmwrite -m random -Dv 10%25000:mm-buff-$$
+rwtest04 export LTPROOT; rwtest -N rwtest04 -c -q -i 60s -n 2  -f sync -s mmread,mmwrite -m random -Dv 10%25000:mm-sync-$$
+rwtest05 export LTPROOT; rwtest -N rwtest05 -c -q -i 50 -T 64b 500b:/tmp/rwtest01%f
+
+#aio/dio tests
+# setup scratch space
+SETUP01 dd if=/dev/urandom of=$BIG_FILE bs=4096 count=4096
+
+#ltp-aio-stress
+# added -s 128M, guests have limited disk space
+AIOSETUP01  dd if=$BIG_FILE of=$SCRATCH_MNT/aiodio/junkfile bs=8192 conv=block,sync
+
+ADS1000 aio-stress -I500  -o2 -S -r4         -s 128M $SCRATCH_MNT/aiodio/file1
+ADS1005 aio-stress -I500  -o3 -S -r4         -s 128M $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/file2
+ADS1008 aio-stress -I500  -o3 -S -r32   -t4  -s 128M $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/file2 $SCRATCH_MNT/aiodio/file3 $SCRATCH_MNT/aiodio/file4
+ADS1014 aio-stress -I500  -o2 -O -r8         -s 128M $SCRATCH_MNT/aiodio/file1    $SCRATCH_MNT/aiodio/file2
+ADS1020 aio-stress -I500  -o3 -O -r16   -t2  -s 128M $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/file2
+ADS1027 aio-stress -I500  -o0 -S -r8         -s 128M $SCRATCH_MNT/aiodio/file2
+ADS1031 aio-stress -I500  -o1 -S -r4    -t2  -s 128M $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/file2
+ADS1040 aio-stress -I500  -o1 -O -r8    -t2  -s 128M $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/file2
+
+#ltp-aiodio.part1
+AIOSETUP01  dd if=$BIG_FILE of=$SCRATCH_MNT/aiodio/junkfile bs=8192 conv=block,sync
+AIOSETUP02  dd if=$BIG_FILE of=$SCRATCH_MNT/aiodio/fff      bs=4096 conv=block,sync
+AIOSETUP03  dd if=$BIG_FILE of=$SCRATCH_MNT/aiodio/ff1      bs=2048 conv=block,sync
+AIOSETUP04  dd if=$BIG_FILE of=$SCRATCH_MNT/aiodio/ff2      bs=1024 conv=block,sync
+AIOSETUP05  dd if=$BIG_FILE of=$SCRATCH_MNT/aiodio/ff3      bs=512  conv=block,sync
+
+# we have to align buffers for O_DIRECT
+AD056 time aiocp -a $BUF_ALIGN -b 4k -n 16 -f DIRECT            $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/ff2
+AD057 time aiocp               -b 4k -n 16 -f SYNC              $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/ff2
+AD058 time aiocp -a $BUF_ALIGN -b 4k -n 16 -f DIRECT -f SYNC    $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/ff2
+AD130 time aiocp -a $BUF_ALIGN -b 64k -n 1 -f DIRECT            $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/ff2
+AD131 time aiocp               -b 64k -n 1 -f SYNC              $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/ff2
+AD132 time aiocp -a $BUF_ALIGN -b 64k -n 1 -f DIRECT -f SYNC    $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/ff2
+AD193 time aiocp -a $BUF_ALIGN -b 512k -n 1 -f DIRECT           $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/ff2
+AD194 time aiocp               -b 512k -n 1 -f SYNC             $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/ff2
+AD195 time aiocp -a $BUF_ALIGN -b 512k -n 1 -f DIRECT -f SYNC   $SCRATCH_MNT/aiodio/junkfile $SCRATCH_MNT/aiodio/ff2
+AD301 time aiocp -a $BUF_ALIGN -b 128k -n 32 -f CREAT -f DIRECT $SCRATCH_MNT/aiodio/fff $SCRATCH_MNT/aiodio/junkdir/fff
+AD302 time aiocp -a $BUF_ALIGN -b 128k -n 32 -f CREAT -f DIRECT $SCRATCH_MNT/aiodio/ff1 $SCRATCH_MNT/aiodio/junkdir/ff1
+AD303 time aiocp -a $BUF_ALIGN -b 128k -n 32 -f CREAT -f DIRECT $SCRATCH_MNT/aiodio/ff2 $SCRATCH_MNT/aiodio/junkdir/ff2
+AD304 time aiocp -a $BUF_ALIGN -b 128k -n 32 -f CREAT -f DIRECT $SCRATCH_MNT/aiodio/ff3 $SCRATCH_MNT/aiodio/junkdir/ff3
+
+#ltp-aiodio.part2
+ADSP005 aiodio_sparse -i 2 -a 4k -w 4k -s 8k -n 2
+ADSP006 aiodio_sparse -i 2 -a 4k -w 4k -s 8k -n 2
+ADSP007 aiodio_sparse -i 4 -a 8k -w 8k -s 32k -n 2
+ADSP008 aiodio_sparse -i 4 -a 8k -w 16k -s 64k -n 2
+ADSP009 aiodio_sparse -i 4 -a 8k -w 32k -s 128k -n 2
+ADSP010 aiodio_sparse -i 4 -a 8k -w 64k -s 256k -n 2
+ADSP011 aiodio_sparse -i 4 -a 8k -w 128k -s 512k -n 2
+ADSP012 aiodio_sparse -i 4 -a 8k -w 256k -s 1024k -n 2
+ADSP013 aiodio_sparse -i 4 -a 8k -w 512k -s 2048k -n 2
+ADSP014 aiodio_sparse -i 4 -a 8k -w 1024k -s 4096k -n 2
+ADSP015 aiodio_sparse -i 4 -a 8k -w 2048k -s 8192k -n 2
+ADSP016 aiodio_sparse -i 4 -a 8k -w 4096k -s 16384k -n 2
+ADSP017 aiodio_sparse -i 4 -a 8k -w 8192k -s 32768k -n 2
+ADSP018 aiodio_sparse -i 4 -a 8k -w 16384k -s 65536k -n 2
+ADSP045 dio_sparse  -a 4k -w 4k -s 2k -n 2
+ADSP046 dio_sparse  -a 4k -w 4k -s 4k -n 2
+ADSP047 dio_sparse  -a 8k -w 16k -s 16k -n 2
+ADSP048 dio_sparse  -a 8k -w 32k -s 32k -n 2
+ADSP049 dio_sparse  -a 8k -w 64k -s 64k -n 2
+ADSP050 dio_sparse  -a 8k -w 128k -s 128k -n 2
+ADSP051 dio_sparse  -a 8k -w 256k -s 256k -n 2
+ADSP052 dio_sparse  -a 8k -w 512k -s 512k -n 2
+ADSP053 dio_sparse  -a 8k -w 1024k -s 1024k -n 2
+ADSP054 dio_sparse  -a 8k -w 2048k -s 2048k -n 2
+ADSP055 dio_sparse  -a 8k -w 4096k -s 4096k -n 2
+ADSP056 dio_sparse  -a 8k -w 8192k -s 8192k -n 2
+
+#ltp-aiodio.part3
+# lower number of ops for KT1
+AIOSETUP01  dd if=$BIG_FILE of=$SCRATCH_MNT/aiodio/junkfile bs=8192 conv=block,sync
+FSX032 fsx-linux -d  -l 500000 -r 4096 -t 4096 -w 4096 -N 1000 $SCRATCH_MNT/aiodio/junkfile
+FSX042 fsx-linux -N 1000 -o 4096                               $SCRATCH_MNT/aiodio/junkfile
+
+#proc
+proc01 proc01 -m 128
+
+#oom
+#meminfo cat /proc/meminfo
+#oom01 oom01
+#oom02 oom02

--- a/distribution/ltp/lite/grab_corefiles.sh
+++ b/distribution/ltp/lite/grab_corefiles.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+. /usr/bin/rhts-environment.sh
+
+bin_core_list=""
+
+for core_abs in $(ls -1 /mnt/testarea/ltp/cores/core.*); do
+    echo "Found corefile: $core_abs"
+    bin=`file $core_abs | awk -F \' '{print $2}'`
+    echo "from binary: $bin"
+    bin=$(echo $bin | awk '{print $1}')
+    if [ -e "/mnt/testarea/ltp/testcases/bin/$bin" ]; then
+        grep "$bin" grab_corefiles_excluded_bins > /dev/null
+        if [ $? -ne 0 ]; then
+            bin_core_list="$bin_core_list $core_abs /mnt/testarea/ltp/testcases/bin/$bin"
+        else
+            echo "$bin is excluded"
+        fi
+    else
+        bin_core_list="$bin_core_list $core_abs"
+    fi
+done
+
+echo "List of files to pack: $bin_core_list"
+if [ -n "$bin_core_list" ]; then
+    tar cfvz binaries_and_corefiles.tar.gz $bin_core_list
+    rhts_submit_log -l binaries_and_corefiles.tar.gz
+    report_result unexpected_corefile_found WARN 1
+else
+    echo "No cores to submit"
+fi

--- a/distribution/ltp/lite/grab_corefiles_excluded_bins
+++ b/distribution/ltp/lite/grab_corefiles_excluded_bins
@@ -1,0 +1,7 @@
+abort01
+kill11
+madvise07
+mmap16
+waitpid05
+clock_getres01
+endian_switch01

--- a/distribution/ltp/lite/is_baremetal.sh
+++ b/distribution/ltp/lite/is_baremetal.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -x
+
+# system with shared resources
+# any s390x system
+(uname -m | grep s390) && exit 1
+
+# any guest system, e.g. ppc64 guests
+(hostname | grep guest) && exit 1
+
+# any ppc lpar
+(uname -m | grep ppc) && (hostname | grep "\-lp") && exit 1
+
+if command -v virt-what; then
+	hv=$(virt-what)
+	[ "$hv" != "" ] && exit 1
+fi
+
+exit 0

--- a/distribution/ltp/lite/metadata
+++ b/distribution/ltp/lite/metadata
@@ -1,0 +1,14 @@
+[General]
+name=/kernel/distribution/ltp/lite
+owner=Kernel General Test Team <kernel-general-test-team@redhat.com>
+description=Latest LTP test KernelTier1
+license=GPLv3
+confidential=no
+destructive=no
+
+[restraint]
+entry_point=make run
+max_time=180m
+dependencies=automake;autoconf;procmail;flex;bison;rsyslog;util-linux;rpm-build;gcc;wget;ntpdate;kernel-headers;redhat-lsb;bc;kernel-devel;libaio-devel;libcap-devel;libcgroup;strace
+softDependencies=numactl;numactl-devel
+repoRequires=distribution/ltp/include

--- a/distribution/ltp/lite/patches/20120822/clone_platform.h
+++ b/distribution/ltp/lite/patches/20120822/clone_platform.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2003 Silicon Graphics, Inc.  All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+/* Common platform specific defines for the clone system call tests */
+
+//#define CHILD_STACK_SIZE 8192
+#define CHILD_STACK_SIZE (128*1024)

--- a/distribution/ltp/lite/patches/20120822/proc01.c
+++ b/distribution/ltp/lite/patches/20120822/proc01.c
@@ -1,0 +1,482 @@
+/*
+ * proc01.c - Tests Linux /proc file reading.
+ *
+ * Copyright (C) 2001 Stephane Fillod <f4cfe@free.fr>
+ * Copyright (c) 2008, 2009  Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Further, this software is distributed without any warranty that it is
+ * free of the rightful claim of any third person regarding infringement
+ * or the like.  Any license provided herein, whether implied or
+ * otherwise, applies only to this software file.  Patent licenses, if
+ * any, provided herein do not apply to combinations of this program with
+ * other software, or any other product whatsoever.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc., 59
+ * Temple Place - Suite 330, Boston MA 02111-1307, USA.
+ *
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <fnmatch.h>
+
+#ifdef HAVE_LIBSELINUX_DEVEL
+#include <selinux/selinux.h>
+#endif
+
+#include "test.h"
+#include "usctest.h"
+
+#define MAX_BUFF_SIZE 65536
+#define MAX_FUNC_NAME 256
+
+char *TCID = "proc01";
+int TST_TOTAL = 1;
+
+static int	 opt_verbose = 0;
+static int	 opt_procpath = 0;
+static char	*opt_procpathstr;
+static int	 opt_buffsize = 0;
+static int	 opt_maxmbytes = 0;
+static char	*opt_maxmbytesstr;
+static int	 opt_readirq = 0;
+static char	*opt_buffsizestr;
+
+static char	*procpath = "/proc";
+static char	 selfpath[] = "/proc/self";
+size_t		 buffsize = 1024;
+long long	 maxbytes = 0;
+
+unsigned long long total_read = 0;
+unsigned int total_obj = 0;
+
+struct mapping {
+	char func[MAX_FUNC_NAME];
+	char file[PATH_MAX];
+	int err;
+};
+
+typedef struct mapping Mapping;
+
+/* Those are known failures for 2.6.18 baremetal kernel and Xen dom0
+   kernel on i686, x86_64, ia64, ppc64 and s390x. In addition, It looks
+   like if SELinux is disabled, the test may still fail on some other
+   entries. */
+const Mapping known_issues[] = {
+    {"open", "/proc/acpi/event", EBUSY},
+    {"open", "/proc/sal/cpe/data", EBUSY},
+    {"open", "/proc/sal/cmc/data", EBUSY},
+    {"open", "/proc/sal/init/data", EBUSY},
+    {"open", "/proc/sal/mca/data", EBUSY},
+    {"read", "/proc/kmsg", EAGAIN},
+    {"read", "/proc/sal/cpe/event", EAGAIN},
+    {"read", "/proc/sal/cmc/event", EAGAIN},
+    {"read", "/proc/sal/init/event", EAGAIN},
+    {"read", "/proc/sal/mca/event", EAGAIN},
+    {"read", "/proc/xen/privcmd", EINVAL},
+    {"read", "/proc/self/mem", EIO},
+    {"read", "/proc/self/task/[0-9]*/mem", EIO},
+    {"read", "/proc/self/attr/*", EINVAL},
+    {"read", "/proc/self/task/[0-9]*/attr/*", EINVAL},
+    {"read", "/proc/self/ns/*", EINVAL},
+    {"read", "/proc/self/task/[0-9]*/ns/*", EINVAL},
+    {"read", "/proc/ppc64/rtas/error_log", EINVAL},
+    {"read", "/proc/powerpc/rtas/error_log", EINVAL},
+    {"read", "/proc/fs/nfsd/unlock_filesystem", EINVAL},
+    {"read", "/proc/fs/nfsd/unlock_ip", EINVAL},
+    {"read", "/proc/fs/nfsd/filehandle", EINVAL},
+    {"read", "/proc/fs/nfsd/.getfs", EINVAL},
+    {"read", "/proc/fs/nfsd/.getfd", EINVAL},
+    {"", "", 0}
+};
+
+/*
+ * If a particular LSM is enabled, it is expected that some entries can
+ * be read successfully. Otherwise, those entries will retrun some
+ * failures listed above. Here to add any LSM specific entries.
+ */
+
+/*
+ * Test macro to indicate that SELinux libraries and headers are
+ * installed.
+ */
+#ifdef HAVE_LIBSELINUX_DEVEL
+const char lsm_should_work[][PATH_MAX] = {
+    "/proc/self/attr/*",
+    "/proc/self/task/[0-9]*/attr/*",
+    ""
+};
+/* Place holder for none of LSM is detected. */
+#else
+const char lsm_should_work[][PATH_MAX] = {
+    ""
+};
+#endif
+
+/* Known files that does not honor O_NONBLOCK, so they will hang
+   the test while being read. */
+const char error_nonblock[][PATH_MAX] = {
+    "/proc/xen/xenbus",
+    ""
+};
+
+/*
+ * Verify expected failures, and then let the test to continue.
+ *
+ * Return 0 when a problem errno is found.
+ * Return 1 when a known issue is found.
+ *
+ */
+int found_errno(const char *syscall, const char *obj, int tmperr)
+{
+	int i;
+
+	/* Should not see any error for certain entries if a LSM is enabled. */
+#ifdef HAVE_LIBSELINUX_DEVEL
+	if (is_selinux_enabled()) {
+		for (i = 0; lsm_should_work[i][0] != '\0'; i++) {
+			if (!strcmp(obj, lsm_should_work[i]) ||
+			    !fnmatch(lsm_should_work[i], obj, FNM_PATHNAME)) {
+				return 0;
+			}
+		}
+	}
+#endif
+	for (i = 0; known_issues[i].err != 0; i++) {
+		if (tmperr == known_issues[i].err &&
+		    (!strcmp(obj, known_issues[i].file) ||
+		     !fnmatch(known_issues[i].file, obj, FNM_PATHNAME)) &&
+		    !strcmp(syscall, known_issues[i].func)) {
+			/* Using strcmp / fnmatch could have messed up the
+			 * errno value. */
+			errno = tmperr;
+			tst_resm(TINFO | TERRNO, "%s: known issue", obj);
+			return 1;
+		}
+	}
+	return 0;
+}
+
+void cleanup()
+{
+	/*
+	 * remove the tmp directory and exit
+	 */
+	TEST_CLEANUP;
+	tst_rmdir();
+
+}
+
+void setup()
+{
+	/*
+	 * setup a default signal hander and a
+	 * temporary working directory.
+	 */
+	tst_sig(FORK, DEF_HANDLER, cleanup);
+	TEST_PAUSE;
+	tst_tmpdir();
+}
+
+void help()
+{
+	printf("  -b x    read byte count\n");
+	printf("  -m x    max megabytes to read from single file\n");
+	printf("  -q      read .../irq/... entries\n");
+	printf("  -r x    proc pathname\n");
+	printf("  -v      verbose mode\n");
+}
+
+/*
+ * add the -m option whose parameter is the
+ * pages that should be mapped.
+ */
+option_t options[] = {
+	{ "b:", &opt_buffsize,	&opt_buffsizestr},
+	{ "m:", &opt_maxmbytes,	&opt_maxmbytesstr},
+	{ "q",	&opt_readirq,	NULL },
+	{ "r:", &opt_procpath,	&opt_procpathstr},
+	{ "v",  &opt_verbose,	NULL },
+	{ NULL, NULL,		NULL }
+};
+
+/*
+ * NB: this function is recursive
+ * returns 0 if no error encountered, otherwise number of errors (objs)
+ *
+ * REM: Funny enough, while developing this function (actually replacing
+ *	streamed fopen by standard open), I hit a real /proc bug.
+ *	On a 2.2.13-SuSE kernel, "cat /proc/tty/driver/serial" would fail
+ *	with EFAULT, while "cat /proc/tty/driver/serial > somefile" wouldn't.
+ *	Okay, this might be due to a slight serial misconfiguration, but still.
+ *	Analysis with strace showed up the difference was on the count size
+ *	of read (1024 bytes vs 4096 bytes). So I tested further..
+ *	read count of 512 bytes adds /proc/tty/drivers to the list
+ *	of broken proc files, while 64 bytes reads removes
+ *	/proc/tty/driver/serial from the list. Interesting, isn't it?
+ *	Now, there's a -b option to this test, so you can try your luck. --SF
+ *
+ * It's more fun to run this test it as root, as all the files will be accessible!
+ * (however, be careful, there might be some bufferoverflow holes..)
+ * reading proc files might be also a good kernel latency killer.
+ */
+long readproc(const char *obj)
+{
+	DIR *dir = NULL;	/* pointer to a directory */
+	struct dirent *dir_ent;	/* pointer to directory entries */
+	char dirobj[PATH_MAX];	/* object inside directory to modify */
+	struct stat statbuf;	/* used to hold stat information */
+	int fd, tmperr, i;
+	ssize_t nread;
+	static char buf[MAX_BUFF_SIZE];	/* static kills reentrancy, but we don't care about the contents */
+	unsigned long long file_total_read = 0;
+
+	/* Determine the file type */
+	if (lstat(obj, &statbuf) < 0) {
+
+		/* permission denied is not considered as error */
+		if (errno != EACCES) {
+			tst_resm(TFAIL | TERRNO, "%s: lstat", obj);
+			return 1;
+		}
+		return 0;
+
+	}
+
+	/* Prevent loops, but read /proc/self. */
+	if (S_ISLNK(statbuf.st_mode) && strcmp(obj, selfpath))
+		return 0;
+
+	total_obj++;
+
+	/* Take appropriate action, depending on the file type */
+	if (S_ISDIR(statbuf.st_mode) || !strcmp(obj, selfpath)) {
+
+		/* object is a directory */
+
+		/*
+		 * Skip over the /proc/irq directory, unless the user
+		 * requested that we read the directory because it could
+		 * map to a broken driver which effectively `hangs' the
+		 * test.
+		 */
+		if (!opt_readirq && !strcmp("/proc/irq", obj)) {
+			return 0;
+		/* Open the directory to get access to what is in it */
+		} else if ((dir = opendir(obj)) == NULL) {
+			if (errno != EACCES) {
+				tst_resm(TFAIL | TERRNO, "%s: opendir",
+					obj);
+				return 1;
+			}
+			return 0;
+		} else {
+
+			long ret_val = 0;
+
+			/* Loop through the entries in the directory */
+			for (dir_ent = (struct dirent *)readdir(dir);
+			     dir_ent != NULL;
+			     dir_ent = (struct dirent *)readdir(dir)) {
+
+				/* Ignore ".", "..", "kcore", and
+				 * "/proc/<pid>" (unless this is our
+				 * starting point as directed by the
+				 * user).
+				 */
+				if (strcmp(dir_ent->d_name, ".") &&
+				     strcmp(dir_ent->d_name, "..") &&
+				     strcmp(dir_ent->d_name, "kcore") &&
+				     (fnmatch("[0-9]*", dir_ent->d_name,
+					      FNM_PATHNAME) ||
+				      strcmp(obj, procpath))) {
+
+					if (opt_verbose) {
+						fprintf(stderr, "%s\n",
+							dir_ent->d_name);
+					}
+
+					/* Recursively call this routine to test the
+					 * current entry */
+					snprintf(dirobj, PATH_MAX,
+						"%s/%s", obj,
+						 dir_ent->d_name);
+					ret_val += readproc(dirobj);
+
+				}
+
+			}
+
+			/* Close the directory */
+			if (dir)
+				(void) closedir(dir);
+
+			return ret_val;
+
+		}
+
+	} else {		/* if it's not a dir, read it! */
+
+		if (!S_ISREG(statbuf.st_mode))
+			return 0;
+
+#ifdef DEBUG
+		fprintf(stderr, "%s", obj);
+#endif
+
+		/* is O_NONBLOCK enough to escape from FIFO's ? */
+		if ((fd = open(obj, O_RDONLY | O_NONBLOCK)) < 0) {
+
+			tmperr = errno;
+
+			if (!found_errno("open", obj, tmperr)) {
+
+				errno = tmperr;
+
+				if (errno != EACCES) {
+					tst_resm(TFAIL | TERRNO,
+						"%s: open failed", obj);
+					return 1;
+				}
+
+			}
+			return 0;
+
+		}
+
+        	/* Skip write-only files. */
+	        if ((statbuf.st_mode & S_IRUSR) == 0 &&
+		    (statbuf.st_mode & S_IWUSR) != 0) {
+			tst_resm(TINFO, "%s: is write-only.", obj);
+			return 0;
+		}
+
+		/* Skip files does not honor O_NONBLOCK. */
+		for (i = 0; error_nonblock[i][0] != '\0'; i++) {
+			if (!strcmp(obj, error_nonblock[i])) {
+				tst_resm(TWARN,	"%s: does not honor "
+						"O_NONBLOCK", obj);
+				return 0;
+			}
+		}
+
+		file_total_read = 0;
+		do {
+
+			nread = read(fd, buf, buffsize);
+
+			if (nread < 0) {
+
+                		tmperr = errno;
+				(void) close(fd);
+
+				/* ignore no perm (not root) and no
+				 * process (terminated) errors */
+				if (!found_errno("read", obj,
+						tmperr)) {
+
+					errno = tmperr;
+
+					if (errno != EACCES &&
+					    errno != ESRCH) {
+						tst_resm(TFAIL | TERRNO,
+							"read failed: "
+							"%s", obj);
+						return 1;
+					}
+					return 0;
+
+                		}
+
+			}
+
+			if (opt_verbose) {
+#ifdef DEBUG
+				fprintf(stderr, "%ld", nread);
+#endif
+				fprintf(stderr, ".");
+			}
+
+			file_total_read += nread;
+			if ((maxbytes > 0) && (file_total_read > maxbytes))
+				break;
+
+		} while (0 < nread);
+		total_read += file_total_read;
+
+		if (opt_verbose)
+			fprintf(stderr, "\n");
+
+		if (0 <= fd)
+			(void) close(fd);
+
+	}
+
+	/* It's better to assume success by default rather than failure. */
+	return 0;
+
+}
+
+int main(int argc, char *argv[])
+{
+	char *msg;
+	int lc;
+
+	if ((msg = parse_opts(argc, argv, options, help)) != NULL)
+		tst_brkm(TBROK, cleanup, "OPTION PARSING ERROR - %s", msg);
+
+	if (opt_buffsize) {
+		size_t bs;
+		bs = atoi(opt_buffsizestr);
+		if (bs <= MAX_BUFF_SIZE)
+			buffsize = bs;
+		else
+			tst_brkm(TBROK, cleanup,
+				 "Invalid arg for -b (max: %u): %s",
+				 MAX_BUFF_SIZE, opt_buffsizestr);
+	}
+	if (opt_maxmbytes)
+		maxbytes = atoi(opt_maxmbytesstr) * 1024 * 1024;
+
+	if (opt_procpath)
+		procpath = opt_procpathstr;
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		Tst_count = 0;
+
+		TEST(readproc(procpath));
+
+		if (TEST_RETURN != 0) {
+			tst_resm(TFAIL, "readproc() failed with %ld errors.",
+				 TEST_RETURN);
+		} else {
+			tst_resm(TPASS, "readproc() completed successfully, "
+				 "total read: %llu bytes, %u objs", total_read,
+				 total_obj);
+		}
+	}
+
+	cleanup();
+	tst_exit();
+}

--- a/distribution/ltp/lite/patches/20120822/readahead/Makefile
+++ b/distribution/ltp/lite/patches/20120822/readahead/Makefile
@@ -1,0 +1,22 @@
+#
+#  Copyright (C) 2012 Linux Test Project, Inc.
+#
+#  This program is free software;  you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY;  without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+#  the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program;  if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+top_srcdir		?= ../../../..
+
+include $(top_srcdir)/include/mk/testcases.mk
+include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/distribution/ltp/lite/patches/20120822/readahead/readahead01.c
+++ b/distribution/ltp/lite/patches/20120822/readahead/readahead01.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2012 Linux Test Project, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of version 2 of the GNU General Public
+ * License as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Further, this software is distributed without any warranty that it
+ * is free of the rightful claim of any third person regarding
+ * infringement or the like.  Any license provided herein, whether
+ * implied or otherwise, applies only to this software file.  Patent
+ * licenses, if any, provided herein do not apply to combinations of
+ * this program with other software, or any other product whatsoever.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/*
+ * errno tests for readahead() syscall
+ */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/socket.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "config.h"
+#include "test.h"
+#include "usctest.h"
+#include "safe_macros.h"
+#include "linux_syscall_numbers.h"
+
+char *TCID = "readahead01";
+int  TST_TOTAL = 1;
+
+#if defined(__NR_readahead)
+static void setup(char *argv[]);
+static void cleanup(void);
+
+static int check_ret(long expected_ret)
+{
+	if (expected_ret == TEST_RETURN) {
+		tst_resm(TPASS, "expected ret success - "
+			"returned value = %ld", TEST_RETURN);
+		return 0;
+	}
+	else
+		tst_resm(TFAIL, "unexpected failure - "
+			"returned value = %ld, expected: %ld",
+			TEST_RETURN, expected_ret);
+	return 1;
+}
+
+static int check_errno(long expected_errno)
+{
+	if (TEST_ERRNO == expected_errno) {
+		tst_resm(TPASS|TTERRNO, "expected failure");
+		return 0;
+	}
+	else if (TEST_ERRNO == 0)
+		tst_resm(TFAIL, "call succeeded unexpectedly");
+	else
+		tst_resm(TFAIL|TTERRNO, "unexpected failure - "
+			"expected = %ld : %s, actual",
+			expected_errno, strerror(expected_errno));
+	return 1;
+}
+
+static void test_bad_fd()
+{
+	char tempname[PATH_MAX] = "readahead01_XXXXXX";
+	int fd;
+
+	tst_resm(TINFO, "test_bad_fd -1");
+	TEST(syscall(__NR_readahead, -1, 0, getpagesize()));
+	check_ret(-1);
+	check_errno(EBADF);
+
+	tst_resm(TINFO, "test_bad_fd O_WRONLY");
+	fd = mkstemp(tempname);
+	if (fd == -1)
+		tst_resm(TBROK|TERRNO, "mkstemp failed");
+	close(fd);
+	fd = open(tempname, O_WRONLY);
+	if (fd == -1)
+		tst_resm(TBROK|TERRNO, "Failed to open testfile");
+	TEST(syscall(__NR_readahead, fd, 0, getpagesize()));
+	check_ret(-1);
+	check_errno(EBADF);
+	close(fd);
+	unlink(tempname);
+}
+
+static void test_invalid_fd()
+{
+	int fd[2];
+
+	tst_resm(TINFO, "test_invalid_fd pipe");
+	if (pipe(fd) < 0)
+		tst_resm(TFAIL|TERRNO, "Failed to create pipe");
+	TEST(syscall(__NR_readahead, fd[0], 0, getpagesize()));
+	check_ret(-1);
+	check_errno(EINVAL);
+	close(fd[0]);
+	close(fd[1]);
+
+	tst_resm(TINFO, "test_invalid_fd socket");
+	fd[0] = socket(AF_INET, SOCK_STREAM, 0);
+	TEST(syscall(__NR_readahead, fd[0], 0, getpagesize()));
+	check_ret(-1);
+	check_errno(EINVAL);
+	close(fd[0]);
+}
+
+int main(int argc, char *argv[])
+{
+	int lc;
+
+	setup(argv);
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		Tst_count = 0;
+		test_bad_fd();
+		test_invalid_fd();
+	}
+	cleanup();
+	tst_exit();
+}
+
+static void setup(char *argv[])
+{
+	tst_require_root(NULL);
+	tst_tmpdir();
+
+	/* check if readahead syscall is supported */
+	syscall(__NR_readahead, 0, 0, 0);
+
+	TEST_PAUSE;
+}
+
+static void cleanup(void)
+{
+	TEST_CLEANUP;
+	tst_rmdir();
+}
+
+#else /* __NR_readahead */
+int main(void)
+{
+	tst_brkm(TCONF, NULL, "System doesn't support __NR_readahead");
+}
+#endif
+

--- a/distribution/ltp/lite/patches/20120822/readahead/readahead02.c
+++ b/distribution/ltp/lite/patches/20120822/readahead/readahead02.c
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) 2012 Linux Test Project, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of version 2 of the GNU General Public
+ * License as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Further, this software is distributed without any warranty that it
+ * is free of the rightful claim of any third person regarding
+ * infringement or the like.  Any license provided herein, whether
+ * implied or otherwise, applies only to this software file.  Patent
+ * licenses, if any, provided herein do not apply to combinations of
+ * this program with other software, or any other product whatsoever.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/*
+ * functional test for readahead() syscall
+ *
+ * This test is measuring effects of readahead syscall.
+ * It mmaps/reads a test file with and without prior call to readahead.
+ *
+ */
+#define _GNU_SOURCE
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "config.h"
+#include "test.h"
+#include "usctest.h"
+#include "safe_macros.h"
+#include "linux_syscall_numbers.h"
+
+char *TCID = "readahead02";
+int  TST_TOTAL = 1;
+
+#if defined(__NR_readahead)
+static char testfile[] = "testfile";
+static long testfile_size = 64*1024*1024;
+static int opt_fsize;
+static char *opt_fsizestr;
+static int pagesize;
+
+option_t options[] = {
+	{ "s:", &opt_fsize, &opt_fsizestr},
+	{ NULL, NULL, NULL }
+};
+
+static void setup(char *argv[]);
+static void cleanup(void);
+
+void help()
+{
+	printf("  -s x    testfile size (default 64MB)\n");
+}
+
+static int check_ret(long expected_ret)
+{
+	if (expected_ret == TEST_RETURN) {
+		tst_resm(TPASS, "expected ret success - "
+			"returned value = %ld", TEST_RETURN);
+		return 0;
+	}
+	else
+		tst_resm(TFAIL, "unexpected failure - "
+			"returned value = %ld, expected: %ld",
+			TEST_RETURN, expected_ret);
+	return 1;
+}
+
+static int has_proc_io()
+{
+	char fname[128];
+	struct stat buf;
+	int ret;
+
+	sprintf(fname, "/proc/%u/io", getpid());
+	ret = stat(fname, &buf);
+	if (ret == -1) {
+		if (errno == ENOENT)
+			return 0;
+		else
+			tst_brkm(TBROK|TERRNO, cleanup, "stat failed");
+	}
+	return 1;
+}
+
+static void drop_caches()
+{
+	int ret;
+	char *drop_caches = "/proc/sys/vm/drop_caches";
+	FILE *f;
+
+	f = fopen(drop_caches, "w");
+	if (f) {
+		ret = fprintf(f, "1");
+		fclose(f);
+		if (ret < 1)
+			tst_brkm(TBROK, cleanup, "Failed to drop caches");
+	} else
+		tst_brkm(TBROK, cleanup, "Failed to open: %s", drop_caches);
+}
+
+static long get_bytes_read()
+{
+	FILE *f;
+	long bytes_read = -1;
+	int ret;
+	char fname[128];
+	char *line = NULL;
+	size_t linelen;
+
+	sprintf(fname, "/proc/%u/io", getpid());
+	f = fopen(fname, "r");
+	if (f) {
+		do {
+			ret = getline(&line, &linelen, f);
+			if (sscanf(line, "read_bytes: %ld", &bytes_read) == 1)
+				break;
+		} while (ret != -1);
+		fclose(f);
+	}
+	return bytes_read;
+}
+
+static void create_testfile()
+{
+	FILE *f;
+	char *tmp;
+	int i;
+
+	tst_resm(TINFO, "creating test file of size: %ld", testfile_size);
+	tmp = SAFE_MALLOC(cleanup, pagesize);
+
+	/* round to page size */
+	testfile_size = testfile_size & ~((long)pagesize - 1);
+
+	f = fopen(testfile, "w");
+	if (!f)
+		tst_brkm(TBROK|TERRNO, cleanup, "Failed to create %s",
+			testfile);
+
+	for (i = 0; i < testfile_size; i += pagesize)
+		if (fwrite(tmp, pagesize, 1, f) < 1)
+			tst_brkm(TBROK, cleanup, "Failed to create %s",
+				testfile);
+	fflush(f);
+	fsync(fileno(f));
+	fclose(f);
+	free(tmp);
+}
+
+/* read_testfile - mmap testfile and read every page.
+ * This functions measures how many I/O and time it takes to fully
+ * read contents of test file.
+ *
+ * @do_readahead: call readahead prior to reading file content?
+ * @fname: name of file to test
+ * @fsize: how many bytes to read/mmap
+ * @read_bytes: returns difference of bytes read, parsed from /proc/<pid>/io
+ * @usec: returns how many microsecond it took to go over fsize bytes
+ */
+static void read_testfile(int do_readahead, char *fname, int fsize,
+	long *read_bytes, long *usec)
+{
+	int fd, i;
+	long read_bytes_start;
+	unsigned char *p, tmp;
+	unsigned long time_start_usec, time_end_usec;
+	off_t offset;
+	struct timeval now;
+
+	fd = open(fname, O_RDONLY);
+	if (fd < 0)
+		tst_brkm(TBROK|TERRNO, cleanup, "Failed to open %s",
+			fname);
+
+	if (do_readahead) {
+		TEST(syscall(__NR_readahead, fd, (off64_t)0, (size_t)fsize));
+		check_ret(0);
+
+		/* offset of file shouldn't change after readahead */
+		offset = lseek(fd, 0, SEEK_CUR);
+		if (offset == (off_t) -1)
+			tst_brkm(TBROK|TERRNO, cleanup, "lseek failed");
+		if (offset == 0)
+			tst_resm(TPASS, "offset is still at 0 as expected");
+		else
+			tst_resm(TFAIL, "offset has changed to: %lu", offset);
+	}
+
+	if (gettimeofday(&now, NULL) == -1)
+		tst_brkm(TBROK|TERRNO, cleanup, "gettimeofday failed");
+	time_start_usec = now.tv_sec * 1000000 + now.tv_usec;
+	read_bytes_start = get_bytes_read();
+
+	p = mmap(NULL, fsize, PROT_READ, MAP_SHARED|MAP_POPULATE, fd, 0);
+	if (p == MAP_FAILED)
+		tst_brkm(TBROK|TERRNO, cleanup, "mmap failed");
+	/* 
+         * for old kernels, where MAP_POPULATE does not work, touch each page
+         */
+        tmp = 0;
+	for (i = 0; i < fsize; i += pagesize)
+		tmp = tmp ^ p[i];
+        /* prevent gcc from optimizing out loop above */
+	if (tmp != 0)
+		tst_brkm(TBROK, NULL, "This line should not be reached");
+
+        if (munmap(p, fsize) == -1)
+		tst_brkm(TBROK|TERRNO, cleanup, "munmap failed");
+
+	*read_bytes = get_bytes_read() - read_bytes_start;
+	if (gettimeofday(&now, NULL) == -1)
+		tst_brkm(TBROK|TERRNO, cleanup, "gettimeofday failed");
+	time_end_usec = now.tv_sec * 1000000 + now.tv_usec;
+	*usec = time_end_usec - time_start_usec;
+
+	if (close(fd) == -1)
+		tst_brkm(TBROK|TERRNO, cleanup, "close failed");
+}
+
+static void test_readahead()
+{
+	long read_bytes, read_bytes_ra;
+	long usec, usec_ra;
+
+	tst_resm(TINFO, "read_testfile(0)");
+	drop_caches();
+	read_testfile(0, testfile, testfile_size, &read_bytes, &usec);
+
+	tst_resm(TINFO, "read_testfile(1)");
+	drop_caches();
+	read_testfile(1, testfile, testfile_size, &read_bytes_ra, &usec_ra);
+
+	tst_resm(TINFO, "read_testfile(0) took: %ld usec", usec);
+	tst_resm(TINFO, "read_testfile(1) took: %ld usec", usec_ra);
+	if (has_proc_io()) {
+		tst_resm(TINFO, "read_testfile(0) read: %ld bytes",
+				read_bytes);
+		tst_resm(TINFO, "read_testfile(1) read: %ld bytes",
+				read_bytes_ra);
+		/* 
+		 * read_bytes_ra should be very close to 0,
+		 * but this can not be guaranteed as it depends
+		 * on available RAM.
+		 */
+		if (read_bytes_ra < read_bytes)
+			tst_resm(TPASS, "readahead saved us some I/O");
+		else
+			tst_resm(TFAIL, "readahead failed to save any I/O");
+	} else
+		tst_resm(TCONF, "Your system doesn't have /proc/pid/io,"
+			" unable to determine read bytes during test");
+
+}
+
+int main(int argc, char *argv[])
+{
+	char *msg;
+	int lc;
+
+	if ((msg = parse_opts(argc, argv, options, help)) != NULL)
+		tst_brkm(TBROK, NULL, "OPTION PARSING ERROR - %s", msg);
+
+	if (opt_fsize)
+		testfile_size = atoi(opt_fsizestr);
+
+	setup(argv);
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		Tst_count = 0;
+		test_readahead();
+	}
+	cleanup();
+	tst_exit();
+}
+
+
+static void setup(char *argv[])
+{
+	tst_require_root(NULL);
+	tst_tmpdir();
+	TEST_PAUSE;
+	
+	/* check if readahead is supported */
+	syscall(__NR_readahead, 0, 0, 0);
+	
+	pagesize = getpagesize();
+	create_testfile();
+}
+
+static void cleanup(void)
+{
+	TEST_CLEANUP;
+	unlink(testfile);
+	tst_rmdir();
+}
+
+#else /* __NR_readahead */
+int main(void)
+{
+	tst_brkm(TCONF, NULL, "System doesn't support __NR_readahead");
+}
+#endif
+

--- a/distribution/ltp/lite/patches/20120822/send01.c
+++ b/distribution/ltp/lite/patches/20120822/send01.c
@@ -1,0 +1,362 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *   Copyright (c) Cyril Hrubis <chrubis@suse.cz> 2012
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * Test Name: send01
+ *
+ * Test Description:
+ *  Verify that send() returns the proper errno for various failure cases
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/signal.h>
+#include <sys/un.h>
+
+#include <netinet/in.h>
+
+#include "test.h"
+#include "usctest.h"
+
+char *TCID = "send01";
+int testno;
+
+static char buf[1024], bigbuf[128 * 1024];
+static int s;
+static struct sockaddr_in sin1;
+static int sfd;			/* shared between do_child and start_server */
+
+struct test_case_t {		/* test case structure */
+	int domain;		/* PF_INET, PF_UNIX, ... */
+	int type;		/* SOCK_STREAM, SOCK_DGRAM ... */
+	int proto;		/* protocol number (usually 0 = default) */
+	void *buf;		/* send data buffer */
+	int buflen;		/* send's 3rd argument */
+	unsigned flags;		/* send's 4th argument */
+	int retval;
+	int experrno;
+	void (*setup) (void);
+	void (*cleanup) (void);
+	char *desc;
+};
+
+static void cleanup(void);
+static void do_child(void);
+static void setup(void);
+static void setup0(void);
+static void setup1(void);
+static void setup2(void);
+static void setup3(void);
+static void cleanup0(void);
+static void cleanup1(void);
+
+static struct test_case_t tdat[] = {
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .retval = -1,
+	 .experrno = EBADF,
+	 .setup = setup0,
+	 .cleanup = cleanup0,
+	 .desc = "bad file descriptor"}
+	,
+	{.domain = 0,
+	 .type = 0,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .retval = -1,
+	 .experrno = ENOTSOCK,
+	 .setup = setup0,
+	 .cleanup = cleanup0,
+	 .desc = "invalid socket"}
+	,
+#ifndef UCLINUX
+	/* Skip since uClinux does not implement memory protection */
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .buf = (void *)-1,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid send buffer"}
+	,
+#endif
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .buf = bigbuf,
+	 .buflen = sizeof(bigbuf),
+	 .flags = 0,
+	 .retval = -1,
+	 .experrno = EMSGSIZE,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "UDP message too big"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .retval = -1,
+	 .experrno = EPIPE,
+	 .setup = setup2,
+	 .cleanup = cleanup1,
+	 .desc = "local endpoint shutdown"}
+	,
+#ifndef UCLINUX
+	/* Skip since uClinux does not implement memory protection */
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .buf = (void *)-1,
+	 .buflen = sizeof(buf),
+	 .flags = -1,
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup3,
+	 .cleanup = cleanup1,
+	 .desc = "invalid flags set"}
+#endif
+};
+
+int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
+
+int exp_enos[] = { EBADF, ENOTSOCK, EFAULT, EMSGSIZE, EPIPE, EINVAL, 0 };
+
+#ifdef UCLINUX
+static char *argv0;
+#endif
+
+static pid_t start_server(struct sockaddr_in *sin0)
+{
+	struct sockaddr_in sin1 = *sin0;
+	pid_t pid;
+
+	sfd = socket(PF_INET, SOCK_STREAM, 0);
+	if (sfd < 0) {
+		tst_brkm(TBROK | TERRNO, cleanup, "server socket failed");
+		return -1;
+	}
+	if (bind(sfd, (struct sockaddr *)&sin1, sizeof(sin1)) < 0) {
+		tst_brkm(TBROK | TERRNO, cleanup, "server bind failed");
+		return -1;
+	}
+	if (listen(sfd, 10) < 0) {
+		tst_brkm(TBROK | TERRNO, cleanup, "server listen failed");
+		return -1;
+	}
+	switch ((pid = FORK_OR_VFORK())) {
+	case 0:
+#ifdef UCLINUX
+		if (self_exec(argv0, "d", sfd) < 0)
+			tst_brkm(TBROK | TERRNO, cleanup,
+				 "server self_exec failed");
+#else
+		do_child();
+#endif
+		break;
+	case -1:
+		tst_brkm(TBROK | TERRNO, cleanup, "server fork failed");
+	default:
+		close(sfd);
+		return pid;
+	}
+
+	exit(1);
+}
+
+static void do_child(void)
+{
+	fd_set afds, rfds;
+	int nfds, cc, fd;
+	struct sockaddr_in fsin;
+
+	FD_ZERO(&afds);
+	FD_SET(sfd, &afds);
+
+	nfds = getdtablesize();
+
+	/* accept connections until killed */
+	while (1) {
+		socklen_t fromlen;
+
+		memcpy(&rfds, &afds, sizeof(rfds));
+
+		if (select(nfds, &rfds, NULL, NULL, NULL) < 0)
+			if (errno != EINTR)
+				exit(1);
+		if (FD_ISSET(sfd, &rfds)) {
+			int newfd;
+
+			fromlen = sizeof(fsin);
+			newfd = accept(sfd, (struct sockaddr *)&fsin, &fromlen);
+			if (newfd >= 0)
+				FD_SET(newfd, &afds);
+		}
+		for (fd = 0; fd < nfds; ++fd) {
+			if (fd != sfd && FD_ISSET(fd, &rfds)) {
+				cc = read(fd, buf, sizeof(buf));
+				if (cc == 0 || (cc < 0 && errno != EINTR)) {
+					close(fd);
+					FD_CLR(fd, &afds);
+				}
+			}
+		}
+	}
+}
+
+int main(int ac, char *av[])
+{
+	int lc;
+	char *msg;
+
+	if ((msg = parse_opts(ac, av, NULL, NULL)) != NULL)
+		tst_brkm(TBROK, NULL, "OPTION PARSING ERROR - %s", msg);
+
+#ifdef UCLINUX
+	argv0 = av[0];
+	maybe_run_child(&do_child, "d", &sfd);
+#endif
+
+	setup();
+
+	TEST_EXP_ENOS(exp_enos);
+
+	for (lc = 0; TEST_LOOPING(lc); ++lc) {
+
+		Tst_count = 0;
+
+		for (testno = 0; testno < TST_TOTAL; ++testno) {
+			tdat[testno].setup();
+
+			TEST(send(s, tdat[testno].buf, tdat[testno].buflen,
+				  tdat[testno].flags));
+
+			if (TEST_RETURN != -1) {
+				tst_resm(TFAIL, "call succeeded unexpectedly");
+				continue;
+			}
+
+			TEST_ERROR_LOG(TEST_ERRNO);
+
+			if (TEST_ERRNO != tdat[testno].experrno) {
+				tst_resm(TFAIL, "%s ; returned"
+					 " %ld (expected %d), errno %d (expected"
+					 " %d)", tdat[testno].desc,
+					 TEST_RETURN, tdat[testno].retval,
+					 TEST_ERRNO, tdat[testno].experrno);
+			} else {
+				tst_resm(TPASS, "%s successful",
+					 tdat[testno].desc);
+			}
+			tdat[testno].cleanup();
+		}
+	}
+	cleanup();
+
+	tst_exit();
+}
+
+static pid_t server_pid;
+
+static void setup(void)
+{
+	TEST_PAUSE;
+
+	/* initialize sockaddr's */
+	sin1.sin_family = AF_INET;
+	sin1.sin_port = htons((getpid() % 32768) + 11000);
+	sin1.sin_addr.s_addr = INADDR_ANY;
+	server_pid = start_server(&sin1);
+
+	signal(SIGPIPE, SIG_IGN);
+}
+
+static void cleanup(void)
+{
+	kill(server_pid, SIGKILL);
+	TEST_CLEANUP;
+
+}
+
+static void setup0(void)
+{
+	if (tdat[testno].experrno == EBADF)
+		s = 400;	/* anything not an open file */
+	else if ((s = open("/dev/null", O_WRONLY)) == -1)
+		tst_brkm(TBROK | TERRNO, cleanup, "open(/dev/null) failed");
+}
+
+static void cleanup0(void)
+{
+	s = -1;
+}
+
+static void setup1(void)
+{
+	s = socket(tdat[testno].domain, tdat[testno].type, tdat[testno].proto);
+	if (s < 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "socket setup failed");
+	if (connect(s, (const struct sockaddr *)&sin1, sizeof(sin1)) < 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "connect failed");
+}
+
+static void cleanup1(void)
+{
+	close(s);
+	s = -1;
+}
+
+static void setup2(void)
+{
+	setup1();
+
+	if (shutdown(s, 1) < 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "socket setup failed connect "
+			 "test %d", testno);
+}
+
+static void setup3(void)
+{
+	setup1();
+
+	if (tst_kvercmp(3, 6, 0) >= 0)
+		tdat[testno].experrno = ENOTSUP;
+}

--- a/distribution/ltp/lite/patches/20120822/sendmsg01.c
+++ b/distribution/ltp/lite/patches/20120822/sendmsg01.c
@@ -1,0 +1,741 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *   Copyright (c) Cyril Hrubis <chrubis@suse.cz> 2012
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * Test Name: sendmsg01
+ *
+ * Test Description:
+ *  Verify that sendmsg() returns the proper errno for various failure cases
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *	05/2003 Modified by Manoj Iyer - Make setup function set up lo device.
+ */
+
+/*
+ * The #ifndef code below is for 2.5 64-bit kernels, where
+ * the MSG_CMSG_COMPAT flag must be 0 in order for the syscall
+ * and this test to function correctly.
+ */
+#ifndef MSG_CMSG_COMPAT
+#if defined(__powerpc64__) || defined(__mips64) || defined(__x86_64__) || \
+     defined(__sparc64__) || defined(__ia64__) || defined(__s390x__)
+#define MSG_CMSG_COMPAT 0x80000000
+#else
+#define MSG_CMSG_COMPAT 0
+#endif
+#endif /* MSG_CMSG_COMPAT */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <time.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/signal.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <sys/file.h>
+#include <sys/wait.h>
+
+#include <netinet/in.h>
+
+#include "test.h"
+#include "usctest.h"
+
+char *TCID = "sendmsg01";
+int testno;
+
+static char buf[1024], bigbuf[128 * 1024];
+static int s;
+static struct sockaddr_in sin1, sin2;
+static struct sockaddr_un sun1;
+static struct msghdr msgdat;
+static char cbuf[4096];
+static struct cmsghdr *control;
+static int controllen;
+static struct iovec iov[1];
+static int sfd;			/* shared between do_child and start_server */
+static int ufd;			/* shared between do_child and start_server */
+
+static void setup(void);
+static void setup0(void);
+static void setup1(void);
+static void setup2(void);
+static void setup3(void);
+static void setup4(void);
+static void setup5(void);
+static void setup6(void);
+static void setup7(void);
+static void setup8(void);
+
+static void cleanup(void);
+static void cleanup0(void);
+static void cleanup1(void);
+static void cleanup4(void);
+
+static void do_child(void);
+
+struct test_case_t {		/* test case structure */
+	int domain;		/* PF_INET, PF_UNIX, ... */
+	int type;		/* SOCK_STREAM, SOCK_DGRAM ... */
+	int proto;		/* protocol number (usually 0 = default) */
+	struct iovec *iov;
+	int iovcnt;		/* # elements in iovec */
+	void *buf;		/* send data buffer */
+	int buflen;		/* send buffer length */
+	struct msghdr *msg;
+	unsigned flags;
+	struct sockaddr *to;	/* destination */
+	int tolen;		/* length of "to" buffer */
+	int retval;		/* syscall return value */
+	int experrno;		/* expected errno */
+	void (*setup) (void);
+	void (*cleanup) (void);
+	char *desc;
+};
+
+struct test_case_t tdat[] = {
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EBADF,
+	 .setup = setup0,
+	 .cleanup = cleanup0,
+	 .desc = "bad file descriptor"}
+	,
+	{.domain = 0,
+	 .type = 0,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = ENOTSOCK,
+	 .setup = setup0,
+	 .cleanup = cleanup0,
+	 .desc = "invalid socket"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = (void *)-1,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid send buffer"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin2,
+	 .tolen = sizeof(sin2),
+	 .retval = 0,
+	 .experrno = EFAULT,
+	 .setup = setup5,
+	 .cleanup = cleanup1,
+	 .desc = "connected TCP"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EPIPE,
+	 .setup = setup3,
+	 .cleanup = cleanup1,
+	 .desc = "not connected TCP"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = -1,
+	 .retval = -1,
+	 .experrno = EINVAL,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid to buffer length"},
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)-1,
+	 .tolen = -1,
+	 .retval = -1,
+	 .experrno = EINVAL,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid to buffer"},
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = bigbuf,
+	 .buflen = sizeof(bigbuf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EMSGSIZE,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "UDP message too big"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EPIPE,
+	 .setup = setup2,
+	 .cleanup = cleanup1,
+	 .desc = "local endpoint shutdown"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = NULL,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid iovec pointer"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = NULL,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid msghdr pointer"}
+	,
+	{.domain = PF_UNIX,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sun1,
+	 .tolen = sizeof(sun1),
+	 .retval = 0,
+	 .experrno = 0,
+	 .setup = setup4,
+	 .cleanup = cleanup4,
+	 .desc = "rights passing"}
+	,
+	{.domain = PF_UNIX,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = ~MSG_CMSG_COMPAT,
+	 .to = (struct sockaddr *)&sun1,
+	 .tolen = sizeof(sun1),
+	 .retval = -1,
+	 .experrno = EOPNOTSUPP,
+	 .setup = setup4,
+	 .cleanup = cleanup4,
+	 .desc = "invalid flags set w/ control"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = ~MSG_CMSG_COMPAT,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = 0,
+	 .experrno = EOPNOTSUPP,
+	 .setup = setup7,
+	 .cleanup = cleanup1,
+	 .desc = "invalid flags set"}
+	,
+	{.domain = PF_UNIX,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sun1,
+	 .tolen = sizeof(sun1),
+	 .retval = 0,
+	 .experrno = EOPNOTSUPP,
+	 .setup = setup6,
+	 .cleanup = cleanup4,
+	 .desc = "invalid cmsg length"}
+	,
+	{.domain = PF_UNIX,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sun1,
+	 .tolen = sizeof(sun1),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup8,
+	 .cleanup = cleanup4,
+	 .desc = "invalid cmsg pointer"}
+};
+
+int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
+
+int exp_enos[] = {
+	EBADF, ENOTSOCK, EFAULT, EISCONN, ENOTCONN, EINVAL, EMSGSIZE, EPIPE,
+	ENOBUFS, 0
+};
+
+#ifdef UCLINUX
+static char *argv0;
+#endif
+
+int main(int argc, char *argv[])
+{
+	int lc;
+	char *msg;
+
+	msg = parse_opts(argc, argv, NULL, NULL);
+	if (msg != NULL)
+		tst_brkm(TBROK, NULL, "OPTION PARSING ERROR - %s", msg);
+
+#ifdef UCLINUX
+	argv0 = argv[0];
+	maybe_run_child(&do_child, "dd", &sfd, &ufd);
+#endif
+
+	setup();
+
+	TEST_EXP_ENOS(exp_enos);
+
+	for (lc = 0; TEST_LOOPING(lc); ++lc) {
+		Tst_count = 0;
+		for (testno = 0; testno < TST_TOTAL; ++testno) {
+			tdat[testno].setup();
+
+			iov[0].iov_base = tdat[testno].buf;
+			iov[0].iov_len = tdat[testno].buflen;
+			if (tdat[testno].type != SOCK_STREAM) {
+				msgdat.msg_name = tdat[testno].to;
+				msgdat.msg_namelen = tdat[testno].tolen;
+			}
+			msgdat.msg_iov = tdat[testno].iov;
+			msgdat.msg_iovlen = tdat[testno].iovcnt;
+			msgdat.msg_control = control;
+			msgdat.msg_controllen = controllen;
+			msgdat.msg_flags = 0;
+
+			TEST(sendmsg(s, tdat[testno].msg, tdat[testno].flags));
+
+			if (TEST_RETURN > 0)
+				TEST_RETURN = 0;	/* all success equal */
+
+			TEST_ERROR_LOG(TEST_ERRNO);
+
+			if (TEST_RETURN != tdat[testno].retval ||
+			    (TEST_RETURN < 0 &&
+			     TEST_ERRNO != tdat[testno].experrno)) {
+				tst_resm(TFAIL, "%s ; returned"
+					 " %ld (expected %d), errno %d (expected"
+					 " %d)", tdat[testno].desc,
+					 TEST_RETURN, tdat[testno].retval,
+					 TEST_ERRNO, tdat[testno].experrno);
+			} else {
+				tst_resm(TPASS, "%s successful",
+					 tdat[testno].desc);
+			}
+			tdat[testno].cleanup();
+		}
+	}
+	cleanup();
+	tst_exit();
+}
+
+static pid_t start_server(struct sockaddr_in *sin0, struct sockaddr_un *sun0)
+{
+	struct sockaddr_in sin1 = *sin0;
+	pid_t pid;
+
+	/* set up inet socket */
+	sfd = socket(PF_INET, SOCK_STREAM, 0);
+	if (sfd < 0) {
+		tst_brkm(TBROK, cleanup, "server socket failed: %s",
+			 strerror(errno));
+		return -1;
+	}
+	if (bind(sfd, (struct sockaddr *)&sin1, sizeof(sin1)) < 0) {
+		tst_brkm(TBROK, cleanup, "server bind failed: %s",
+			 strerror(errno));
+		return -1;
+	}
+	if (listen(sfd, 10) < 0) {
+		tst_brkm(TBROK, cleanup, "server listen failed: %s",
+			 strerror(errno));
+		return -1;
+	}
+	/* set up UNIX-domain socket */
+	ufd = socket(PF_UNIX, SOCK_DGRAM, 0);
+	if (ufd < 0) {
+		tst_brkm(TBROK, cleanup, "server UD socket failed: %s",
+			 strerror(errno));
+		return -1;
+	}
+	if (bind(ufd, (struct sockaddr *)sun0, sizeof(*sun0))) {
+		tst_brkm(TBROK, cleanup, "server UD bind failed: %s",
+			 strerror(errno));
+		return -1;
+	}
+
+	switch ((pid = FORK_OR_VFORK())) {
+	case 0:
+#ifdef UCLINUX
+		if (self_exec(argv0, "dd", sfd, ufd) < 0)
+			tst_brkm(TBROK, cleanup, "server self_exec failed");
+#else
+		do_child();
+#endif
+		break;
+	case -1:
+		tst_brkm(TBROK, cleanup, "server fork failed: %s",
+			 strerror(errno));
+	default:
+		close(sfd);
+		close(ufd);
+		return pid;
+	}
+
+	exit(1);
+}
+
+static void do_child(void)
+{
+	struct sockaddr_in fsin;
+	struct sockaddr_un fsun;
+	fd_set afds, rfds;
+	int nfds, cc, fd;
+
+	FD_ZERO(&afds);
+	FD_SET(sfd, &afds);
+	FD_SET(ufd, &afds);
+
+	nfds = getdtablesize();
+
+	/* accept connections until killed */
+	while (1) {
+		socklen_t fromlen;
+
+		memcpy(&rfds, &afds, sizeof(rfds));
+
+		if (select(nfds, &rfds, NULL, NULL, NULL) < 0)
+			if (errno != EINTR)
+				exit(1);
+		if (FD_ISSET(sfd, &rfds)) {
+			int newfd;
+
+			fromlen = sizeof(fsin);
+			newfd = accept(sfd, (struct sockaddr *)&fsin, &fromlen);
+			if (newfd >= 0)
+				FD_SET(newfd, &afds);
+		}
+		if (FD_ISSET(ufd, &rfds)) {
+			int newfd;
+
+			fromlen = sizeof(fsun);
+			newfd = accept(ufd, (struct sockaddr *)&fsun, &fromlen);
+			if (newfd >= 0)
+				FD_SET(newfd, &afds);
+		}
+		for (fd = 0; fd < nfds; ++fd) {
+			if (fd != sfd && fd != ufd && FD_ISSET(fd, &rfds)) {
+				cc = read(fd, buf, sizeof(buf));
+				if (cc == 0 || (cc < 0 && errno != EINTR)) {
+					close(fd);
+					FD_CLR(fd, &afds);
+				}
+			}
+		}
+	}
+}
+
+static pid_t pid;
+static char tmpsunpath[1024];
+
+static void setup(void)
+{
+
+	int ret = 0;
+
+	tst_require_root(NULL);
+	tst_sig(FORK, DEF_HANDLER, cleanup);
+	TEST_PAUSE;
+
+	/* initialize sockaddr's */
+	sin1.sin_family = AF_INET;
+	sin1.sin_port = htons((getpid() % 32768) + 11000);
+	sin1.sin_addr.s_addr = INADDR_ANY;
+
+	tst_tmpdir();
+	snprintf(tmpsunpath, 1024, "udsock%ld", (long)time(NULL));
+	sun1.sun_family = AF_UNIX;
+	strcpy(sun1.sun_path, tmpsunpath);
+
+	/* this test will fail or in some cases hang if no eth or lo is
+	 * configured, so making sure in setup that at least lo is up
+	 */
+	ret = system("ip link set lo up");
+	if (WEXITSTATUS(ret) != 0) {
+		ret = system("ifconfig lo up 127.0.0.1");
+		if (WEXITSTATUS(ret) != 0) {
+			tst_brkm(TBROK, cleanup,
+			    "ip/ifconfig failed to bring up loop back device");
+			tst_exit();
+		}
+	}
+
+	pid = start_server(&sin1, &sun1);
+
+	signal(SIGPIPE, SIG_IGN);
+}
+
+static void cleanup(void)
+{
+	if (pid > 0)
+		kill(pid, SIGKILL);	/* kill server, if server exists */
+	unlink(tmpsunpath);
+	TEST_CLEANUP;
+	tst_rmdir();
+}
+
+static void setup0(void)
+{
+	if (tdat[testno].experrno == EBADF)
+		s = 400;	/* anything not an open file */
+	else if ((s = open("/dev/null", O_WRONLY)) == -1)
+		tst_brkm(TBROK, cleanup, "error opening /dev/null - "
+			 "errno: %s", strerror(errno));
+}
+
+static void cleanup0(void)
+{
+	s = -1;
+}
+
+static void setup1(void)
+{
+	s = socket(tdat[testno].domain, tdat[testno].type, tdat[testno].proto);
+	if (s < 0) {
+		tst_brkm(TBROK, cleanup, "socket setup failed: %s",
+			 strerror(errno));
+	}
+	if (tdat[testno].type == SOCK_STREAM &&
+	    connect(s, (struct sockaddr *)tdat[testno].to,
+		    tdat[testno].tolen) < 0) {
+		tst_brkm(TBROK, cleanup, "connect failed: %s", strerror(errno));
+	}
+}
+
+static void cleanup1(void)
+{
+	close(s);
+	s = -1;
+}
+
+static void setup2(void)
+{
+	setup1();		/* get a socket in s */
+	if (shutdown(s, 1) < 0) {
+		tst_brkm(TBROK, cleanup, "socket setup failed connect "
+			 "test %d: %s", testno, strerror(errno));
+	}
+}
+
+static void setup3(void)
+{
+	s = socket(tdat[testno].domain, tdat[testno].type, tdat[testno].proto);
+	if (s < 0) {
+		tst_brkm(TBROK, cleanup, "socket setup failed: %s",
+			 strerror(errno));
+	}
+}
+
+static char tmpfilename[1024];
+static int tfd;
+
+static void setup4(void)
+{
+
+	setup1();		/* get a socket in s */
+
+	strcpy(tmpfilename, "sockXXXXXX");
+	tfd = mkstemp(tmpfilename);
+	if (tfd < 0) {
+		tst_brkm(TBROK, cleanup4, "socket setup failed: %s",
+			 strerror(errno));
+	}
+	control = (struct cmsghdr *)cbuf;
+	memset(cbuf, 0x00, sizeof(cbuf));
+	control->cmsg_len = sizeof(struct cmsghdr) + 4;
+	control->cmsg_level = SOL_SOCKET;
+	control->cmsg_type = SCM_RIGHTS;
+	*(int *)CMSG_DATA(control) = tfd;
+	controllen = control->cmsg_len;
+}
+
+static void cleanup4(void)
+{
+	cleanup1();
+	close(tfd);
+	tfd = -1;
+	control = 0;
+	controllen = 0;
+}
+
+static void setup5(void)
+{
+	s = socket(tdat[testno].domain, tdat[testno].type, tdat[testno].proto);
+	if (s < 0) {
+		tst_brkm(TBROK, cleanup, "socket setup failed: %s",
+			 strerror(errno));
+	}
+
+	if (connect(s, (struct sockaddr *)&sin1, sizeof(sin1)) < 0)
+		tst_brkm(TBROK, cleanup, "connect failed: %s", strerror(errno));
+
+	/* slight change destination (port) so connect() is to different
+	 * 5-tuple than already connected
+	 */
+	sin2 = sin1;
+	sin2.sin_port++;
+}
+
+static void setup6(void)
+{
+	setup4();
+/*
+	controllen = control->cmsg_len = sizeof(struct cmsghdr) - 4;
+*/
+	controllen = control->cmsg_len = 0;
+}
+
+static void setup7(void)
+{
+	setup1();
+
+	if (tst_kvercmp(3, 6, 0) >= 0)
+		tdat[testno].retval = -1;
+}
+
+static void setup8(void)
+{
+	setup4();
+	control = (struct cmsghdr *)-1;
+}

--- a/distribution/ltp/lite/patches/20120822/sendto01.c
+++ b/distribution/ltp/lite/patches/20120822/sendto01.c
@@ -1,0 +1,442 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *   Copyright (c) Cyril Hrubis <chrubis@suse.cz> 2012
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * Test Name: sendto01
+ *
+ * Test Description:
+ *  Verify that sendto() returns the proper errno for various failure cases
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/signal.h>
+#include <sys/un.h>
+
+#include <netinet/in.h>
+
+#include "test.h"
+#include "usctest.h"
+
+char *TCID = "sendto01";
+int testno;
+
+static char buf[1024], bigbuf[128 * 1024];
+static int s;
+static struct sockaddr_in sin1, sin2;
+static int sfd;
+
+struct test_case_t {		/* test case structure */
+	int domain;		/* PF_INET, PF_UNIX, ... */
+	int type;		/* SOCK_STREAM, SOCK_DGRAM ... */
+	int proto;		/* protocol number (usually 0 = default) */
+	void *buf;		/* send data buffer */
+	int buflen;		/* send's 3rd argument */
+	unsigned flags;		/* send's 4th argument */
+	struct sockaddr_in *to;	/* destination */
+	int tolen;		/* length of "to" buffer */
+	int retval;
+	int experrno;
+	void (*setup) (void);
+	void (*cleanup) (void);
+	char *desc;
+};
+
+static void setup(void);
+static void setup0(void);
+static void setup1(void);
+static void setup2(void);
+static void setup3(void);
+static void setup4(void);
+static void cleanup(void);
+static void cleanup0(void);
+static void cleanup1(void);
+static void do_child(void);
+
+struct test_case_t tdat[] = {
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .to = &sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EBADF,
+	 .setup = setup0,
+	 .cleanup = cleanup0,
+	 .desc = "bad file descriptor"}
+	,
+	{.domain = 0,
+	 .type = 0,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .to = &sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = ENOTSOCK,
+	 .setup = setup0,
+	 .cleanup = cleanup0,
+	 .desc = "invalid socket"}
+	,
+#ifndef UCLINUX
+	/* Skip since uClinux does not implement memory protection */
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .buf = (void *)-1,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .to = &sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid send buffer"}
+	,
+#endif
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .to = &sin2,
+	 .tolen = sizeof(sin2),
+	 .retval = 0,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "connected TCP"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .to = &sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EPIPE,
+	 .setup = setup3,
+	 .cleanup = cleanup1,
+	 .desc = "not connected TCP"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .to = &sin1,
+	 .tolen = -1,
+	 .retval = -1,
+	 .experrno = EINVAL,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid to buffer length"}
+	,
+#ifndef UCLINUX
+	/* Skip since uClinux does not implement memory protection */
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .to = (struct sockaddr_in *)-1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid to buffer"}
+	,
+#endif
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .buf = bigbuf,
+	 .buflen = sizeof(bigbuf),
+	 .flags = 0,
+	 .to = &sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EMSGSIZE,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "UDP message too big"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = 0,
+	 .to = &sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EPIPE,
+	 .setup = setup2,
+	 .cleanup = cleanup1,
+	 .desc = "local endpoint shutdown"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .flags = -1,
+	 .to = &sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = 0,
+	 .experrno = EPIPE,
+	 .setup = setup4,
+	 .cleanup = cleanup1,
+	 .desc = "invalid flags set"}
+};
+
+int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
+
+int exp_enos[] = {
+	EBADF, ENOTSOCK, EFAULT, EISCONN, ENOTCONN, EINVAL, EMSGSIZE, EPIPE, 0
+};
+
+#ifdef UCLINUX
+static char *argv0;
+#endif
+
+static pid_t start_server(struct sockaddr_in *sin0)
+{
+	struct sockaddr_in sin1 = *sin0;
+	pid_t pid;
+
+	sfd = socket(PF_INET, SOCK_STREAM, 0);
+	if (sfd < 0) {
+		tst_brkm(TBROK | TERRNO, cleanup, "server socket failed");
+		return -1;
+	}
+	if (bind(sfd, (struct sockaddr *)&sin1, sizeof(sin1)) < 0) {
+		tst_brkm(TBROK | TERRNO, cleanup, "server bind failed");
+		return -1;
+	}
+	if (listen(sfd, 10) < 0) {
+		tst_brkm(TBROK | TERRNO, cleanup, "server listen failed");
+		return -1;
+	}
+	switch ((pid = FORK_OR_VFORK())) {
+	case 0:
+#ifdef UCLINUX
+		if (self_exec(argv0, "d", sfd) < 0)
+			tst_brkm(TBROK | TERRNO, cleanup,
+				 "server self_exec failed");
+#else
+		do_child();
+#endif
+		break;
+	case -1:
+		tst_brkm(TBROK | TERRNO, cleanup, "server fork failed");
+	default:
+		(void)close(sfd);
+		return pid;
+	}
+
+	exit(1);
+}
+
+static void do_child(void)
+{
+	struct sockaddr_in fsin;
+	fd_set afds, rfds;
+	int nfds, cc, fd;
+
+	FD_ZERO(&afds);
+	FD_SET(sfd, &afds);
+
+	nfds = getdtablesize();
+
+	/* accept connections until killed */
+	while (1) {
+		socklen_t fromlen;
+
+		memcpy(&rfds, &afds, sizeof(rfds));
+
+		if (select(nfds, &rfds, NULL, NULL, NULL) < 0 && errno != EINTR)
+			exit(1);
+
+		if (FD_ISSET(sfd, &rfds)) {
+			int newfd;
+
+			fromlen = sizeof(fsin);
+			newfd = accept(sfd, (struct sockaddr *)&fsin, &fromlen);
+			if (newfd >= 0)
+				FD_SET(newfd, &afds);
+		}
+		for (fd = 0; fd < nfds; ++fd) {
+			if (fd != sfd && FD_ISSET(fd, &rfds)) {
+				cc = read(fd, buf, sizeof(buf));
+				if (cc == 0 || (cc < 0 && errno != EINTR)) {
+					(void)close(fd);
+					FD_CLR(fd, &afds);
+				}
+			}
+		}
+	}
+}
+
+int main(int ac, char *av[])
+{
+	int lc;
+	char *msg;
+
+	if ((msg = parse_opts(ac, av, NULL, NULL)) != NULL)
+		tst_brkm(TBROK, NULL, "OPTION PARSING ERROR - %s", msg);
+
+#ifdef UCLINUX
+	argv0 = av[0];
+	maybe_run_child(&do_child, "d", &sfd);
+#endif
+
+	setup();
+
+	TEST_EXP_ENOS(exp_enos);
+
+	for (lc = 0; TEST_LOOPING(lc); ++lc) {
+
+		Tst_count = 0;
+		for (testno = 0; testno < TST_TOTAL; ++testno) {
+			tdat[testno].setup();
+
+			TEST(sendto(s, tdat[testno].buf, tdat[testno].buflen,
+				    tdat[testno].flags,
+				    (const struct sockaddr *)tdat[testno].to,
+				    tdat[testno].tolen));
+
+			if (TEST_RETURN > 0)
+				TEST_RETURN = 0;	/* all success equal */
+
+			TEST_ERROR_LOG(TEST_ERRNO);
+
+			if (TEST_RETURN != tdat[testno].retval ||
+			    (TEST_RETURN < 0 &&
+			     TEST_ERRNO != tdat[testno].experrno)) {
+				tst_resm(TFAIL, "%s ; returned"
+					 " %ld (expected %d), errno %d (expected"
+					 " %d)", tdat[testno].desc,
+					 TEST_RETURN, tdat[testno].retval,
+					 TEST_ERRNO, tdat[testno].experrno);
+			} else {
+				tst_resm(TPASS, "%s successful",
+					 tdat[testno].desc);
+			}
+			tdat[testno].cleanup();
+		}
+	}
+	cleanup();
+
+	tst_exit();
+}
+
+static pid_t server_pid;
+
+static void setup(void)
+{
+	TEST_PAUSE;
+
+	/* initialize sockaddr's */
+	sin1.sin_family = AF_INET;
+	sin1.sin_port = htons((getpid() % 32768) + 11000);
+	sin1.sin_addr.s_addr = INADDR_ANY;
+	server_pid = start_server(&sin1);
+
+	signal(SIGPIPE, SIG_IGN);
+}
+
+static void cleanup(void)
+{
+	kill(server_pid, SIGKILL);
+	TEST_CLEANUP;
+}
+
+static void setup0(void)
+{
+	if (tdat[testno].experrno == EBADF)
+		s = 400;
+	else if ((s = open("/dev/null", O_WRONLY)) == -1)
+		tst_brkm(TBROK | TERRNO, cleanup, "open(/dev/null) failed");
+}
+
+static void cleanup0(void)
+{
+	s = -1;
+}
+
+static void setup1(void)
+{
+	s = socket(tdat[testno].domain, tdat[testno].type, tdat[testno].proto);
+	if (s < 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "socket setup failed");
+	if (connect(s, (const struct sockaddr *)&sin1, sizeof(sin1)) < 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "connect failed");
+}
+
+static void cleanup1(void)
+{
+	(void)close(s);
+	s = -1;
+}
+
+static void setup2(void)
+{
+	setup1();
+	if (shutdown(s, 1) < 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "socket setup failed connect "
+			 "test %d", testno);
+}
+
+static void setup3(void)
+{
+	s = socket(tdat[testno].domain, tdat[testno].type, tdat[testno].proto);
+	if (s < 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "socket setup failed");
+}
+
+static void setup4(void)
+{
+	setup1();
+
+	if (tst_kvercmp(3, 6, 0) >= 0) {
+		tdat[testno].retval = -1;
+		tdat[testno].experrno = ENOTSUP;
+	}
+}

--- a/distribution/ltp/lite/patches/20130109/clone02.c
+++ b/distribution/ltp/lite/patches/20130109/clone02.c
@@ -1,0 +1,482 @@
+/*
+ * Copyright (c) Wipro Technologies Ltd, 2002.  All Rights Reserved.
+ * Copyright (c) 2012 Wanlong Gao <gaowanlong@cn.fujitsu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+/*
+ *	 TEST1
+ *	 -----
+ *		Call clone() with all resources shared.
+ *
+ *		CHILD:
+ *			modify the shared resources
+ *			return 1 on success
+ *		PARENT:
+ *			wait for child to finish
+ *			verify that the shared resourses are modified
+ *			return 1 on success
+ *		If parent & child returns successfully
+ *			test passed
+ *		else
+ *			test failed
+ *
+ *	 TEST2
+ *	 -----
+ *		Call clone() with no resources shared.
+ *
+ *		CHILD:
+ *			modify the resources in child's address space
+ *			return 1 on success
+ *		PARENT:
+ *			wait for child to finish
+ *			verify that the parent's resourses are not modified
+ *			return 1 on success
+ *		If parent & child returns successfully
+ *			test passed
+ *		else
+ *			test failed
+ */
+
+#if defined UCLINUX && !__THROW
+/* workaround for libc bug */
+#define __THROW
+#endif
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <sched.h>
+#include "test.h"
+#include "usctest.h"
+
+#define FLAG_ALL (CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|SIGCHLD)
+#define FLAG_NONE SIGCHLD
+#define PARENT_VALUE 1
+#define CHILD_VALUE 2
+#define TRUE 1
+#define FALSE 0
+
+#include "clone_platform.h"
+
+static void setup(void);
+static int test_setup(void);
+static void cleanup(void);
+static void test_cleanup(void);
+static int child_fn();
+static int parent_test1(void);
+static int parent_test2(void);
+static int test_VM(void);
+static int test_FS(void);
+static int test_FILES(void);
+static int test_SIG(void);
+static int modified_VM(void);
+static int modified_FS(void);
+static int modified_FILES(void);
+static int modified_SIG(void);
+static void sig_child_defined_handler(int);
+static void sig_default_handler();
+
+static int fd_parent;
+static char file_name[25];
+static int parent_variable;
+static char cwd_parent[FILENAME_MAX];
+static int parent_got_signal, child_pid;
+
+char *TCID = "clone02";
+
+struct test_case_t {
+	int flags;
+	int (*parent_fn) ();
+} test_cases[] = {
+	{
+	FLAG_ALL, parent_test1}, {
+	FLAG_NONE, parent_test2}
+};
+
+int TST_TOTAL = sizeof(test_cases) / sizeof(test_cases[0]);
+
+int main(int ac, char **av)
+{
+
+	int lc;
+	char *msg;
+	void *child_stack;
+	int status, i;
+
+	msg = parse_opts(ac, av, NULL, NULL);
+	if (msg != NULL)
+		tst_brkm(TBROK, NULL, "OPTION PARSING ERROR - %s", msg);
+
+	setup();
+
+	child_stack = malloc(CHILD_STACK_SIZE);
+	if (child_stack == NULL)
+		tst_brkm(TBROK, cleanup, "Cannot allocate stack for child");
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		Tst_count = 0;
+
+		for (i = 0; i < TST_TOTAL; ++i) {
+			if (test_setup() != 0) {
+				tst_resm(TWARN, "test_setup() failed,"
+					 "skipping this test case");
+				continue;
+			}
+
+			/* Test the system call */
+			TEST(ltp_clone(test_cases[i].flags, child_fn, NULL,
+				       CHILD_STACK_SIZE, child_stack));
+
+			/* check return code */
+			if (TEST_RETURN == -1) {
+				tst_resm(TFAIL | TTERRNO, "clone() failed");
+				/* Cleanup & continue with next test case */
+				test_cleanup();
+				continue;
+			}
+
+			/* Wait for child to finish */
+			if ((wait(&status)) == -1) {
+				tst_resm(TWARN | TERRNO,
+					 "wait failed; skipping testcase");
+				/* Cleanup & continue with next test case */
+				test_cleanup();
+				continue;
+			}
+
+			if (WTERMSIG(status))
+				tst_resm(TWARN, "child exitied with signal %d",
+					 WTERMSIG(status));
+
+			/*
+			 * Check the return value from child function and
+			 * parent function. If both functions returned
+			 * successfully, test passed, else failed
+			 */
+			if (WIFEXITED(status) && WEXITSTATUS(status) == 0 &&
+			    test_cases[i].parent_fn())
+				tst_resm(TPASS, "Test Passed");
+			else
+				tst_resm(TFAIL, "Test Failed");
+
+			/* Do test specific cleanup */
+			test_cleanup();
+		}
+	}
+
+	free(child_stack);
+
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{
+	tst_sig(FORK, DEF_HANDLER, cleanup);
+	TEST_PAUSE;
+	tst_tmpdir();
+
+	/* Get unique file name for each child process */
+	if ((sprintf(file_name, "parent_file_%ld", syscall(__NR_gettid))) <= 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "sprintf() failed");
+}
+
+static void cleanup(void)
+{
+	TEST_CLEANUP;
+
+	if (unlink(file_name) == -1)
+		tst_resm(TWARN | TERRNO, "unlink(%s) failed", file_name);
+	tst_rmdir();
+}
+
+static int test_setup(void)
+{
+
+	struct sigaction def_act;
+
+	/* Save current working directory of parent */
+	if (getcwd(cwd_parent, sizeof(cwd_parent)) == NULL) {
+		tst_resm(TWARN | TERRNO, "getcwd() failed in test_setup()");
+		return -1;
+	}
+
+	/*
+	 * Set value for parent_variable in parent, which will be
+	 * changed by child in test_VM(), for testing CLONE_VM flag
+	 */
+	parent_variable = PARENT_VALUE;
+
+	/*
+	 * Open file from parent, which will be closed by
+	 * child in test_FILES(), used for testing CLONE_FILES flag
+	 */
+	fd_parent = open(file_name, O_CREAT | O_RDWR, 0777);
+	if (fd_parent == -1) {
+		tst_resm(TWARN | TERRNO, "open() failed in test_setup()");
+		return -1;
+	}
+
+	/*
+	 * set parent_got_signal to FALSE, used for testing
+	 * CLONE_SIGHAND flag
+	 */
+	parent_got_signal = FALSE;
+
+	/* Setup signal handler for SIGUSR2 */
+	def_act.sa_handler = sig_default_handler;
+	def_act.sa_flags = SA_RESTART;
+	sigemptyset(&def_act.sa_mask);
+
+	if (sigaction(SIGUSR2, &def_act, NULL) == -1) {
+		tst_resm(TWARN | TERRNO, "sigaction() failed in test_setup()");
+		return -1;
+	}
+
+	return 0;
+}
+
+static void test_cleanup(void)
+{
+
+	/* Restore parent's working directory */
+	if (chdir(cwd_parent) == -1) {
+		/*
+		 * we have to exit here
+		 *
+		 * XXX (garrcoop): why???
+		 */
+		tst_brkm(TBROK | TERRNO, cleanup,
+			 "chdir() failed in test_cleanup()");
+	}
+
+}
+
+static int child_fn()
+{
+
+	/* save child pid */
+	child_pid = syscall(__NR_gettid);
+
+	if (test_VM() == 0 && test_FILES() == 0 && test_FS() == 0 &&
+	    test_SIG() == 0)
+		exit(0);
+	exit(1);
+}
+
+static int parent_test1(void)
+{
+
+	/*
+	 * For first test case (with all flags set), all resources are
+	 * shared between parent and child. So whatever changes made by
+	 * child should get reflected in parent also. modified_*()
+	 * functions check this. All of them should return 1 for
+	 * parent_test1() to return 1
+	 */
+
+	if (modified_VM() && modified_FILES() && modified_FS() &&
+	    modified_SIG())
+		return 0;
+	return -1;
+}
+
+static int parent_test2(void)
+{
+
+	/*
+	 * For second test case (with no resouce shared), all of the
+	 * modified_*() functions should return 0 for parent_test2()
+	 * to return 1
+	 */
+	if (modified_VM() || modified_FILES() || modified_FS() ||
+	    modified_SIG())
+		return 0;
+
+	return -1;
+}
+
+/*
+ * test_VM() - function to change parent_variable from child's
+ *	       address space. If CLONE_VM flag is set, child shares
+ *	       the memory space with parent so this will be visible
+ *	       to parent also.
+ */
+
+static int test_VM(void)
+{
+	parent_variable = CHILD_VALUE;
+	return 0;
+}
+
+/*
+ * test_FILES() - This function closes a file descriptor opened by
+ *		  parent. If CLONE_FILES flag is set, the parent and
+ *		  the child process share the same file descriptor
+ *		  table. so this affects the parent also
+ */
+static int test_FILES(void)
+{
+	if (close(fd_parent) == -1) {
+		tst_resm(TWARN | TERRNO, "close failed in test_FILES");
+		return -1;
+	}
+	return 0;
+}
+
+/*
+ * test_FS() -  This function changes the current working directory
+ *		of the child process. If CLONE_FS flag is set, this
+ *		will be visible to parent also.
+ */
+static int test_FS(void)
+{
+	char *test_tmpdir;
+	int rval;
+
+	test_tmpdir = get_tst_tmpdir();
+	if (test_tmpdir == NULL) {
+		tst_resm(TWARN | TERRNO, "get_tst_tmpdir failed");
+		rval = -1;
+	} else if (chdir(test_tmpdir) == -1) {
+		tst_resm(TWARN | TERRNO, "chdir failed in test_FS");
+		rval = -1;
+	} else {
+		rval = 0;
+	}
+
+	free(test_tmpdir);
+	return rval;
+}
+
+/*
+ * test_SIG() - This function changes the signal handler for SIGUSR2
+ *		signal for child. If CLONE_SIGHAND flag is set, this
+ *		affects parent also.
+ */
+static int test_SIG(void)
+{
+
+	struct sigaction new_act;
+
+	new_act.sa_handler = sig_child_defined_handler;
+	new_act.sa_flags = SA_RESTART;
+	sigemptyset(&new_act.sa_mask);
+
+	/* Set signal handler to sig_child_defined_handler */
+	if (sigaction(SIGUSR2, &new_act, NULL) == -1) {
+		tst_resm(TWARN | TERRNO, "signal failed in test_SIG");
+		return -1;
+	}
+
+	/* Send SIGUSR2 signal to parent */
+	if (kill(getppid(), SIGUSR2) == -1) {
+		tst_resm(TWARN | TERRNO, "kill failed in test_SIG");
+		return -1;
+	}
+
+	return 0;
+}
+
+/*
+ * modified_VM() - This function is called by parent process to check
+ *		   whether child's modification to parent_variable
+ *		   is visible to parent
+ */
+
+static int modified_VM(void)
+{
+
+	if (parent_variable == CHILD_VALUE)
+		/* child has modified parent_variable */
+		return 1;
+
+	return 0;
+}
+
+/*
+ * modified_FILES() - This function checks for file descriptor table
+ *		      modifications done by child
+ */
+static int modified_FILES(void)
+{
+	char buff[20];
+
+	if (((read(fd_parent, buff, sizeof(buff))) == -1) && (errno == EBADF))
+		/* Child has closed this file descriptor */
+		return 1;
+
+	/* close fd_parent */
+	if ((close(fd_parent)) == -1)
+		tst_resm(TWARN | TERRNO, "close() failed in modified_FILES()");
+
+	return 0;
+}
+
+/*
+ * modified_FS() - This function checks parent's current working directory
+ *		   to see whether its modified by child or not.
+ */
+static int modified_FS(void)
+{
+	char cwd[FILENAME_MAX];
+
+	if ((getcwd(cwd, sizeof(cwd))) == NULL)
+		tst_resm(TWARN | TERRNO, "getcwd() failed");
+
+	if (!(strcmp(cwd, cwd_parent)))
+		/* cwd hasn't changed */
+		return 0;
+
+	return 1;
+}
+
+/*
+ * modified_SIG() - This function checks whether child has changed
+ *		    parent's signal handler for signal, SIGUSR2
+ */
+static int modified_SIG(void)
+{
+
+	if (parent_got_signal)
+		/*
+		 * parent came through sig_child_defined_handler()
+		 * this means child has changed parent's handler
+		 */
+		return 1;
+
+	return 0;
+}
+
+/*
+ * sig_child_defined_handler()  - Signal handler installed by child
+ */
+static void sig_child_defined_handler(int pid)
+{
+	if ((syscall(__NR_gettid)) == child_pid)
+		/* Child got signal, give warning */
+		tst_resm(TWARN, "Child got SIGUSR2 signal");
+	else
+		parent_got_signal = TRUE;
+}
+
+/* sig_default_handler() - Default handler for parent */
+static void sig_default_handler()
+{
+}

--- a/distribution/ltp/lite/patches/20130109/clone07.c
+++ b/distribution/ltp/lite/patches/20130109/clone07.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) International Business Machines  Corp., 2003.
+ * Copyright (c) 2012 Wanlong Gao <gaowanlong@cn.fujitsu.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+/*
+ *	This is a test for a glibc bug for the clone(2) system call.
+ */
+
+#if defined UCLINUX && !__THROW
+/* workaround for libc bug */
+#define __THROW
+#endif
+
+#include <errno.h>
+#include <sched.h>
+#include <sys/wait.h>
+#include "test.h"
+#include "usctest.h"
+#include "clone_platform.h"
+
+#define TRUE 1
+#define FALSE 0
+
+static void setup();
+static void cleanup();
+static int do_child();
+
+char *TCID = "clone07";
+int TST_TOTAL = 1;
+
+static void sigsegv_handler(int);
+static void sigusr2_handler(int);
+static int child_pid;
+static int fail = FALSE;
+
+int main(int ac, char **av)
+{
+
+	int lc, status;
+	char *msg;
+	void *child_stack;
+
+	msg = parse_opts(ac, av, NULL, NULL);
+	if (msg != NULL)
+		tst_brkm(TBROK, NULL, "OPTION PARSING ERROR - %s", msg);
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		Tst_count = 0;
+		child_stack = malloc(CHILD_STACK_SIZE);
+		if (child_stack == NULL)
+			tst_brkm(TBROK, cleanup,
+				 "Cannot allocate stack for child");
+
+		child_pid = ltp_clone(SIGCHLD, do_child, NULL,
+				      CHILD_STACK_SIZE, child_stack);
+		if ((wait(&status)) == -1)
+			tst_brkm(TBROK | TERRNO, cleanup,
+				 "wait failed, status: %d", status);
+
+		free(child_stack);
+	}
+
+	if (fail == FALSE)
+		tst_resm(TPASS,
+			 "Use of return() in child did not cause SIGSEGV");
+	else
+		tst_resm(TFAIL, "Use of return() in child caused SIGSEGV");
+
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{
+	struct sigaction def_act;
+	struct sigaction act;
+
+	TEST_PAUSE;
+
+	act.sa_handler = sigsegv_handler;
+	act.sa_flags = SA_RESTART;
+	sigemptyset(&act.sa_mask);
+	if ((sigaction(SIGSEGV, &act, NULL)) == -1)
+		tst_resm(TWARN | TERRNO,
+			 "sigaction() for SIGSEGV failed in test_setup()");
+
+	/* Setup signal handler for SIGUSR2 */
+	def_act.sa_handler = sigusr2_handler;
+	def_act.sa_flags = SA_RESTART | SA_RESETHAND;
+	sigemptyset(&def_act.sa_mask);
+
+	if ((sigaction(SIGUSR2, &def_act, NULL)) == -1)
+		tst_resm(TWARN | TERRNO,
+			 "sigaction() for SIGUSR2 failed in test_setup()");
+}
+
+static void cleanup(void)
+{
+	TEST_CLEANUP;
+	kill(child_pid, SIGKILL);
+}
+
+static int do_child(void)
+{
+	return 0;
+}
+
+static void sigsegv_handler(int sig)
+{
+	if (child_pid == 0) {
+		kill(getppid(), SIGUSR2);
+		_exit(42);
+	}
+}
+
+/* sig_default_handler() - Default handler for parent */
+static void sigusr2_handler(int sig)
+{
+	if (child_pid != 0)
+		fail = TRUE;
+}

--- a/distribution/ltp/lite/patches/20130109/proc01.c
+++ b/distribution/ltp/lite/patches/20130109/proc01.c
@@ -1,0 +1,475 @@
+/*
+ * proc01.c - Tests Linux /proc file reading.
+ *
+ * Copyright (C) 2001 Stephane Fillod <f4cfe@free.fr>
+ * Copyright (c) 2008, 2009  Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Further, this software is distributed without any warranty that it is
+ * free of the rightful claim of any third person regarding infringement
+ * or the like.  Any license provided herein, whether implied or
+ * otherwise, applies only to this software file.  Patent licenses, if
+ * any, provided herein do not apply to combinations of this program with
+ * other software, or any other product whatsoever.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <fnmatch.h>
+
+#ifdef HAVE_LIBSELINUX_DEVEL
+#include <selinux/selinux.h>
+#endif
+
+#include "test.h"
+#include "usctest.h"
+
+#define MAX_BUFF_SIZE 65536
+#define MAX_FUNC_NAME 256
+
+char *TCID = "proc01";
+int TST_TOTAL = 1;
+
+static int opt_verbose;
+static int opt_procpath;
+static char *opt_procpathstr;
+static int opt_buffsize;
+static int opt_readirq;
+static char *opt_buffsizestr;
+static int opt_maxmbytes;
+static char *opt_maxmbytesstr;
+
+static char *procpath = "/proc";
+static const char selfpath[] = "/proc/self";
+size_t buffsize = 1024;
+static long long maxbytes;
+
+unsigned long long total_read;
+unsigned int total_obj;
+
+struct mapping {
+	char func[MAX_FUNC_NAME];
+	char file[PATH_MAX];
+	int err;
+};
+
+/* Those are known failures for 2.6.18 baremetal kernel and Xen dom0
+   kernel on i686, x86_64, ia64, ppc64 and s390x. In addition, It looks
+   like if SELinux is disabled, the test may still fail on some other
+   entries. */
+static const struct mapping known_issues[] = {
+	{"open", "/proc/acpi/event", EBUSY},
+	{"open", "/proc/sal/cpe/data", EBUSY},
+	{"open", "/proc/sal/cmc/data", EBUSY},
+	{"open", "/proc/sal/init/data", EBUSY},
+	{"open", "/proc/sal/mca/data", EBUSY},
+	{"open", "/proc/fs/nfsd/pool_stats", ENODEV},
+	{"read", "/proc/acpi/event", EAGAIN},
+	{"read", "/proc/kmsg", EAGAIN},
+	{"read", "/proc/sal/cpe/event", EAGAIN},
+	{"read", "/proc/sal/cmc/event", EAGAIN},
+	{"read", "/proc/sal/init/event", EAGAIN},
+	{"read", "/proc/sal/mca/event", EAGAIN},
+	{"read", "/proc/xen/privcmd", EINVAL},
+	{"read", "/proc/self/mem", EIO},
+	{"read", "/proc/self/task/[0-9]*/mem", EIO},
+	{"read", "/proc/self/attr/*", EINVAL},
+	{"read", "/proc/self/task/[0-9]*/attr/*", EINVAL},
+	{"read", "/proc/self/ns/*", EINVAL},
+	{"read", "/proc/self/task/[0-9]*/ns/*", EINVAL},
+	{"read", "/proc/ppc64/rtas/error_log", EINVAL},
+	{"read", "/proc/powerpc/rtas/error_log", EINVAL},
+	{"read", "/proc/fs/nfsd/unlock_filesystem", EINVAL},
+	{"read", "/proc/fs/nfsd/unlock_ip", EINVAL},
+	{"read", "/proc/fs/nfsd/filehandle", EINVAL},
+	{"read", "/proc/fs/nfsd/.getfs", EINVAL},
+	{"read", "/proc/fs/nfsd/.getfd", EINVAL},
+	{"read", "/proc/self/net/rpc/use-gss-proxy", EAGAIN},
+	{"", "", 0}
+};
+
+/*
+ * If a particular LSM is enabled, it is expected that some entries can
+ * be read successfully. Otherwise, those entries will retrun some
+ * failures listed above. Here to add any LSM specific entries.
+ */
+
+/*
+ * Test macro to indicate that SELinux libraries and headers are
+ * installed.
+ */
+#ifdef HAVE_LIBSELINUX_DEVEL
+static const char lsm_should_work[][PATH_MAX] = {
+	"/proc/self/attr/*",
+	"/proc/self/task/[0-9]*/attr/*",
+	""
+};
+
+/* Place holder for none of LSM is detected. */
+#else
+static const char lsm_should_work[][PATH_MAX] = {
+	""
+};
+#endif
+
+/* Known files that does not honor O_NONBLOCK, so they will hang
+   the test while being read. */
+static const char error_nonblock[][PATH_MAX] = {
+	"/proc/xen/xenbus",
+	""
+};
+
+/*
+ * Verify expected failures, and then let the test to continue.
+ *
+ * Return 0 when a problem errno is found.
+ * Return 1 when a known issue is found.
+ *
+ */
+static int found_errno(const char *syscall, const char *obj, int tmperr)
+{
+	int i;
+
+	/* Should not see any error for certain entries if a LSM is enabled. */
+#ifdef HAVE_LIBSELINUX_DEVEL
+	if (is_selinux_enabled()) {
+		for (i = 0; lsm_should_work[i][0] != '\0'; i++) {
+			if (!strcmp(obj, lsm_should_work[i]) ||
+			    !fnmatch(lsm_should_work[i], obj, FNM_PATHNAME)) {
+				return 0;
+			}
+		}
+	}
+#endif
+	for (i = 0; known_issues[i].err != 0; i++) {
+		if (tmperr == known_issues[i].err &&
+		    (!strcmp(obj, known_issues[i].file) ||
+		     !fnmatch(known_issues[i].file, obj, FNM_PATHNAME)) &&
+		    !strcmp(syscall, known_issues[i].func)) {
+			/* Using strcmp / fnmatch could have messed up the
+			 * errno value. */
+			errno = tmperr;
+			tst_resm(TINFO | TERRNO, "%s: known issue", obj);
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static void cleanup(void)
+{
+	TEST_CLEANUP;
+	tst_rmdir();
+}
+
+static void setup(void)
+{
+	tst_sig(FORK, DEF_HANDLER, cleanup);
+	TEST_PAUSE;
+	tst_tmpdir();
+}
+
+void help(void)
+{
+	printf("  -b x    read byte count\n");
+	printf("  -m x    max megabytes to read from single file\n");
+	printf("  -q      read .../irq/... entries\n");
+	printf("  -r x    proc pathname\n");
+	printf("  -v      verbose mode\n");
+}
+
+/*
+ * add the -m option whose parameter is the
+ * pages that should be mapped.
+ */
+static option_t options[] = {
+	{"b:", &opt_buffsize, &opt_buffsizestr},
+	{"m:", &opt_maxmbytes, &opt_maxmbytesstr},
+	{"q", &opt_readirq, NULL},
+	{"r:", &opt_procpath, &opt_procpathstr},
+	{"v", &opt_verbose, NULL},
+	{NULL, NULL, NULL}
+};
+
+/*
+ * NB: this function is recursive
+ * returns 0 if no error encountered, otherwise number of errors (objs)
+ *
+ * REM: Funny enough, while developing this function (actually replacing
+ *	streamed fopen by standard open), I hit a real /proc bug.
+ *	On a 2.2.13-SuSE kernel, "cat /proc/tty/driver/serial" would fail
+ *	with EFAULT, while "cat /proc/tty/driver/serial > somefile" wouldn't.
+ *	Okay, this might be due to a slight serial misconfiguration, but still.
+ *	Analysis with strace showed up the difference was on the count size
+ *	of read (1024 bytes vs 4096 bytes). So I tested further..
+ *	read count of 512 bytes adds /proc/tty/drivers to the list
+ *	of broken proc files, while 64 bytes reads removes
+ *	/proc/tty/driver/serial from the list. Interesting, isn't it?
+ *	Now, there's a -b option to this test, so you can try your luck. --SF
+ *
+ * It's more fun to run this test it as root, as all the files will be accessible!
+ * (however, be careful, there might be some bufferoverflow holes..)
+ * reading proc files might be also a good kernel latency killer.
+ */
+static long readproc(const char *obj)
+{
+	DIR *dir = NULL;	/* pointer to a directory */
+	struct dirent *dir_ent;	/* pointer to directory entries */
+	char dirobj[PATH_MAX];	/* object inside directory to modify */
+	struct stat statbuf;	/* used to hold stat information */
+	int fd, tmperr, i;
+	ssize_t nread;
+	static char buf[MAX_BUFF_SIZE];	/* static kills reentrancy, but we don't care about the contents */
+	unsigned long long file_total_read = 0;
+
+	/* Determine the file type */
+	if (lstat(obj, &statbuf) < 0) {
+
+		/* permission denied is not considered as error */
+		if (errno != EACCES) {
+			tst_resm(TFAIL | TERRNO, "%s: lstat", obj);
+			return 1;
+		}
+		return 0;
+
+	}
+
+	/* Prevent loops, but read /proc/self. */
+	if (S_ISLNK(statbuf.st_mode) && strcmp(obj, selfpath))
+		return 0;
+
+	total_obj++;
+
+	/* Take appropriate action, depending on the file type */
+	if (S_ISDIR(statbuf.st_mode) || !strcmp(obj, selfpath)) {
+
+		/* object is a directory */
+
+		/*
+		 * Skip over the /proc/irq directory, unless the user
+		 * requested that we read the directory because it could
+		 * map to a broken driver which effectively `hangs' the
+		 * test.
+		 */
+		if (!opt_readirq && !strcmp("/proc/irq", obj)) {
+			return 0;
+			/* Open the directory to get access to what is in it */
+		} else if ((dir = opendir(obj)) == NULL) {
+			if (errno != EACCES) {
+				tst_resm(TFAIL | TERRNO, "%s: opendir", obj);
+				return 1;
+			}
+			return 0;
+		} else {
+
+			long ret_val = 0;
+
+			/* Loop through the entries in the directory */
+			for (dir_ent = (struct dirent *)readdir(dir);
+			     dir_ent != NULL;
+			     dir_ent = (struct dirent *)readdir(dir)) {
+
+				/* Ignore ".", "..", "kcore", and
+				 * "/proc/<pid>" (unless this is our
+				 * starting point as directed by the
+				 * user).
+				 */
+				if (strcmp(dir_ent->d_name, ".") &&
+				    strcmp(dir_ent->d_name, "..") &&
+				    strcmp(dir_ent->d_name, "kcore") &&
+				    (fnmatch("[0-9]*", dir_ent->d_name,
+					     FNM_PATHNAME) ||
+				     strcmp(obj, procpath))) {
+
+					if (opt_verbose) {
+						fprintf(stderr, "%s\n",
+							dir_ent->d_name);
+					}
+
+					/* Recursively call this routine to test the
+					 * current entry */
+					snprintf(dirobj, PATH_MAX,
+						 "%s/%s", obj, dir_ent->d_name);
+					ret_val += readproc(dirobj);
+
+				}
+
+			}
+
+			/* Close the directory */
+			if (dir)
+				(void)closedir(dir);
+
+			return ret_val;
+
+		}
+
+	} else {		/* if it's not a dir, read it! */
+
+		if (!S_ISREG(statbuf.st_mode))
+			return 0;
+
+#ifdef DEBUG
+		fprintf(stderr, "%s", obj);
+#endif
+
+		/* is O_NONBLOCK enough to escape from FIFO's ? */
+		fd = open(obj, O_RDONLY | O_NONBLOCK);
+		if (fd < 0) {
+			tmperr = errno;
+
+			if (!found_errno("open", obj, tmperr)) {
+
+				errno = tmperr;
+
+				if (errno != EACCES) {
+					tst_resm(TFAIL | TERRNO,
+						 "%s: open failed", obj);
+					return 1;
+				}
+
+			}
+			return 0;
+
+		}
+
+		/* Skip write-only files. */
+		if ((statbuf.st_mode & S_IRUSR) == 0 &&
+		    (statbuf.st_mode & S_IWUSR) != 0) {
+			tst_resm(TINFO, "%s: is write-only.", obj);
+			return 0;
+		}
+
+		/* Skip files does not honor O_NONBLOCK. */
+		for (i = 0; error_nonblock[i][0] != '\0'; i++) {
+			if (!strcmp(obj, error_nonblock[i])) {
+				tst_resm(TWARN, "%s: does not honor "
+					 "O_NONBLOCK", obj);
+				return 0;
+			}
+		}
+
+		file_total_read = 0;
+		do {
+
+			nread = read(fd, buf, buffsize);
+
+			if (nread < 0) {
+
+				tmperr = errno;
+				(void)close(fd);
+
+				/* ignore no perm (not root) and no
+				 * process (terminated) errors */
+				if (!found_errno("read", obj, tmperr)) {
+
+					errno = tmperr;
+
+					if (errno != EACCES && errno != ESRCH) {
+						tst_resm(TFAIL | TERRNO,
+							 "read failed: "
+							 "%s", obj);
+						return 1;
+					}
+					return 0;
+
+				}
+
+			} else
+				file_total_read += nread;
+
+			if (opt_verbose) {
+#ifdef DEBUG
+				fprintf(stderr, "%ld", nread);
+#endif
+				fprintf(stderr, ".");
+			}
+
+			if ((maxbytes > 0) && (file_total_read > maxbytes)) {
+				tst_resm(TINFO, "%s: reached maxmbytes (-m)",
+					 obj);
+				break;
+			}
+		} while (0 < nread);
+		total_read += file_total_read;
+
+		if (opt_verbose)
+			fprintf(stderr, "\n");
+
+		if (0 <= fd)
+			(void)close(fd);
+
+	}
+
+	/* It's better to assume success by default rather than failure. */
+	return 0;
+
+}
+
+int main(int argc, char *argv[])
+{
+	char *msg;
+	int lc;
+
+	msg = parse_opts(argc, argv, options, help);
+	if (msg != NULL)
+		tst_brkm(TBROK, cleanup, "OPTION PARSING ERROR - %s", msg);
+
+	if (opt_buffsize) {
+		size_t bs;
+		bs = atoi(opt_buffsizestr);
+		if (bs <= MAX_BUFF_SIZE)
+			buffsize = bs;
+		else
+			tst_brkm(TBROK, cleanup,
+				 "Invalid arg for -b (max: %u): %s",
+				 MAX_BUFF_SIZE, opt_buffsizestr);
+	}
+	if (opt_maxmbytes)
+		maxbytes = atoi(opt_maxmbytesstr) * 1024 * 1024;
+
+	if (opt_procpath)
+		procpath = opt_procpathstr;
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		Tst_count = 0;
+
+		TEST(readproc(procpath));
+
+		if (TEST_RETURN != 0) {
+			tst_resm(TFAIL, "readproc() failed with %ld errors.",
+				 TEST_RETURN);
+		} else {
+			tst_resm(TPASS, "readproc() completed successfully, "
+				 "total read: %llu bytes, %u objs", total_read,
+				 total_obj);
+		}
+	}
+
+	cleanup();
+	tst_exit();
+}

--- a/distribution/ltp/lite/patches/20130109/waitid02.c
+++ b/distribution/ltp/lite/patches/20130109/waitid02.c
@@ -1,0 +1,296 @@
+/******************************************************************************/
+/* Copyright (c) Crackerjack Project., 2007                                   */
+/*                                                                            */
+/* This program is free software;  you can redistribute it and/or modify      */
+/* it under the terms of the GNU General Public License as published by       */
+/* the Free Software Foundation; either version 2 of the License, or          */
+/* (at your option) any later version.                                        */
+/*                                                                            */
+/* This program is distributed in the hope that it will be useful,            */
+/* but WITHOUT ANY WARRANTY;  without even the implied warranty of            */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See                  */
+/* the GNU General Public License for more details.                           */
+/*                                                                            */
+/* You should have received a copy of the GNU General Public License along    */
+/* with this program; if not, write to the Free Software Foundation,  Inc.,   */
+/* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA                 */
+/*                                                                            */
+/******************************************************************************/
+/******************************************************************************/
+/*                                                                            */
+/* File:        waitid02.c                                           	      */
+/*                                                                            */
+/* Description: This tests the waitid() syscall                               */
+/*                                                                            */
+/* Usage:  <for command-line>                                                 */
+/* waitid02 [-c n] [-e][-i n] [-I x] [-p x] [-t]                              */
+/*      where,  -c n : Run n copies concurrently.                             */
+/*              -e   : Turn on errno logging.                                 */
+/*              -i n : Execute test n times.                                  */
+/*              -I x : Execute test for x seconds.                            */
+/*              -P x : Pause for x seconds between iterations.                */
+/*              -t   : Turn on syscall timing.                                */
+/*                                                                            */
+/* Total Tests: 1                                                             */
+/*                                                                            */
+/* Test Name:   waitid02                                                      */
+/* History:     Porting from Crackerjack to LTP is done by                    */
+/*              Manas Kumar Nayak maknayak@in.ibm.com>                        */
+/******************************************************************************/
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "test.h"
+#include "usctest.h"
+#include "linux_syscall_numbers.h"
+
+struct testcase_t {
+	const char *msg;
+	idtype_t idtype;
+	id_t id;
+	pid_t child;
+	int options;
+	int exp_ret;
+	int exp_errno;
+	void (*setup) (struct testcase_t *);
+	void (*cleanup) (struct testcase_t *);
+};
+
+static void setup(void);
+static void cleanup(void);
+
+static void setup2(struct testcase_t *);
+static void setup3(struct testcase_t *);
+static void setup4(struct testcase_t *);
+static void setup5(struct testcase_t *);
+static void setup6(struct testcase_t *);
+static void cleanup2(struct testcase_t *);
+static void cleanup5(struct testcase_t *);
+static void cleanup6(struct testcase_t *);
+
+struct testcase_t tdat[] = {
+	{
+		.msg = "WNOHANG",
+		.idtype = P_ALL,
+		.id = 0,
+		.options = WNOHANG,
+		.exp_ret = -1,
+		.exp_errno = EINVAL,
+	},
+	{
+		.msg = "WNOHANG | WEXITED no child",
+		.idtype = P_ALL,
+		.id = 0,
+		.options = WNOHANG | WEXITED,
+		.exp_ret = -1,
+		.exp_errno = ECHILD,
+	},
+	{
+		.msg = "WNOHANG | WEXITED with child",
+		.idtype = P_ALL,
+		.id = 0,
+		.options = WNOHANG | WEXITED,
+		.exp_ret = 0,
+		.setup = setup2,
+		.cleanup = cleanup2
+	},
+	{
+		.msg = "P_PGID, WEXITED wait for child",
+		.idtype = P_PGID,
+		.options = WEXITED,
+		.exp_ret = 0,
+		.setup = setup3,
+	},
+	{
+		.msg = "P_PID, WEXITED wait for child",
+		.idtype = P_PID,
+		.options = WEXITED,
+		.exp_ret = 0,
+		.setup = setup4,
+	},
+	{
+		.msg = "P_PID, WSTOPPED | WNOWAIT",
+		.idtype = P_PID,
+		.options = WSTOPPED | WNOWAIT,
+		.exp_ret = 0,
+		.setup = setup5,
+		.cleanup = cleanup5
+	},
+	{
+		.msg = "P_PID, WCONTINUED",
+		.idtype = P_PID,
+		.options = WCONTINUED,
+		.exp_ret = 0,
+		.setup = setup6,
+		.cleanup = cleanup6
+	},
+
+};
+
+char *TCID = "waitid02";
+static int TST_TOTAL = ARRAY_SIZE(tdat);
+static struct tst_checkpoint checkpoint;
+
+static void makechild(struct testcase_t *t, void (*childfn)(void))
+{
+	t->child = fork();
+	switch (t->child) {
+	case -1:
+		tst_brkm(TBROK | TERRNO, cleanup, "fork");
+		break;
+	case 0:
+		childfn();
+		exit(0);
+	}
+}
+
+static void wait4child(pid_t pid)
+{
+	int status;
+	if (waitpid(pid, &status, 0) == -1)
+		tst_brkm(TBROK | TERRNO, cleanup, "waitpid");
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		tst_resm(TFAIL, "child returns %d", status);
+}
+
+static void dummy_child(void)
+{
+}
+
+static void waiting_child(void)
+{
+	TST_CHECKPOINT_CHILD_WAIT(&checkpoint);
+}
+
+static void stopped_child(void)
+{
+	kill(getpid(), SIGSTOP);
+	TST_CHECKPOINT_CHILD_WAIT(&checkpoint);
+}
+
+static void setup2(struct testcase_t *t)
+{
+	makechild(t, waiting_child);
+}
+
+static void cleanup2(struct testcase_t *t)
+{
+	TST_CHECKPOINT_SIGNAL_CHILD(cleanup, &checkpoint);
+	wait4child(t->child);
+}
+
+static void setup3(struct testcase_t *t)
+{
+	t->id = getpgid(0);
+	makechild(t, dummy_child);
+}
+
+static void setup4(struct testcase_t *t)
+{
+	makechild(t, dummy_child);
+	t->id = t->child;
+}
+
+static void setup5(struct testcase_t *t)
+{
+	makechild(t, stopped_child);
+	t->id = t->child;
+}
+
+static void cleanup5(struct testcase_t *t)
+{
+	kill(t->child, SIGCONT);
+	TST_CHECKPOINT_SIGNAL_CHILD(cleanup, &checkpoint);
+	wait4child(t->child);
+}
+
+static void setup6(struct testcase_t *t)
+{
+	siginfo_t infop;
+	makechild(t, stopped_child);
+	t->id = t->child;
+	if (waitid(P_PID, t->child, &infop, WSTOPPED) != 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "waitpid setup6");
+	kill(t->child, SIGCONT);
+}
+
+static void cleanup6(struct testcase_t *t)
+{
+	TST_CHECKPOINT_SIGNAL_CHILD(cleanup, &checkpoint);
+	wait4child(t->child);
+}
+
+static void setup(void)
+{
+	TEST_PAUSE;
+	tst_tmpdir();
+	TST_CHECKPOINT_INIT(&checkpoint);
+}
+
+static void cleanup(void)
+{
+	TEST_CLEANUP;
+	tst_rmdir();
+	tst_exit();
+}
+
+static void test_waitid(struct testcase_t *t)
+{
+	siginfo_t infop;
+
+	if (t->setup)
+		t->setup(t);
+
+	tst_resm(TINFO, "%s", t->msg);
+	tst_resm(TINFO, "(%d) waitid(%d, %d, %p, %d)", getpid(), t->idtype,
+			t->id, &infop, t->options);
+	memset(&infop, 0, sizeof(infop));
+
+	TEST(waitid(t->idtype, t->id, &infop, t->options));
+	if (TEST_RETURN == t->exp_ret) {
+		if (TEST_RETURN == -1) {
+			if (TEST_ERRNO == t->exp_errno)
+				tst_resm(TPASS, "exp_errno=%d", t->exp_errno);
+			else
+				tst_resm(TFAIL|TTERRNO, "exp_errno=%d",
+					t->exp_errno);
+		} else {
+			tst_resm(TPASS, "ret: %d", t->exp_ret);
+		}
+	} else {
+		tst_resm(TFAIL|TTERRNO, "ret=%ld expected=%d",
+			TEST_RETURN, t->exp_ret);
+	}
+	tst_resm(TINFO, "si_pid = %d ; si_code = %d ; si_status = %d",
+			infop.si_pid, infop.si_code,
+			infop.si_status);
+
+	if (t->cleanup)
+		t->cleanup(t);
+}
+
+int main(int ac, char **av)
+{
+	int lc, testno;
+	char *msg;
+
+	msg = parse_opts(ac, av, NULL, NULL);
+	if (msg != NULL) {
+		tst_brkm(TBROK, NULL, "OPTION PARSING ERROR - %s", msg);
+		tst_exit();
+	}
+
+	setup();
+	for (lc = 0; TEST_LOOPING(lc); ++lc) {
+		for (testno = 0; testno < TST_TOTAL; testno++)
+			test_waitid(&tdat[testno]);
+	}
+	cleanup();
+	tst_exit();
+}

--- a/distribution/ltp/lite/patches/20130904/kernel_Makefile
+++ b/distribution/ltp/lite/patches/20130904/kernel_Makefile
@@ -1,0 +1,72 @@
+#
+#    kernel test suite Makefile.
+#
+#    Copyright (C) 2009, Cisco Systems Inc.
+#    Copyright (C) 2010, Linux Test Project.
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License along
+#    with this program; if not, write to the Free Software Foundation, Inc.,
+#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Garrett Cooper, July 2009
+#
+
+top_srcdir		?= ../..
+
+include $(top_srcdir)/include/mk/env_pre.mk
+
+# NOTE (garrcoop): mce-test isn't integrated into the build.
+
+# Build syscalls in all scenarios.
+SUBDIRS			:= syscalls
+
+# Build lib
+SUBDIRS			+= lib
+
+ifneq ($(UCLINUX),1)
+# KEEP THIS LIST ALPHABETIZED PLEASE!
+SUBDIRS			+= connectors \
+			   containers \
+			   controllers \
+			   fs \
+			   hotplug \
+			   io \
+			   ipc \
+			   logging \
+			   mem \
+			   numa \
+			   performance_counters \
+			   pty \
+			   sched \
+			   security \
+			   timers \
+			   tracing \
+
+ifeq ($(WITH_POWER_MANAGEMENT_TESTSUITE),yes)
+SUBDIRS			+= power_management
+endif
+
+endif
+
+MAKE_DEPS		:= include/linux_syscall_numbers.h
+
+include:
+	mkdir -p "$@"
+
+linux-syscall-numbers-clean:: include
+	$(MAKE) -C $^ -f "$(abs_srcdir)/$^/Makefile" clean
+
+include/linux_syscall_numbers.h: include
+	$(MAKE) -C $^ -f "$(abs_srcdir)/$^/Makefile" all
+
+include $(top_srcdir)/include/mk/generic_trunk_target.mk

--- a/distribution/ltp/lite/patches/20130904/proc01.c
+++ b/distribution/ltp/lite/patches/20130904/proc01.c
@@ -1,0 +1,476 @@
+/*
+ * proc01.c - Tests Linux /proc file reading.
+ *
+ * Copyright (C) 2001 Stephane Fillod <f4cfe@free.fr>
+ * Copyright (c) 2008, 2009  Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Further, this software is distributed without any warranty that it is
+ * free of the rightful claim of any third person regarding infringement
+ * or the like.  Any license provided herein, whether implied or
+ * otherwise, applies only to this software file.  Patent licenses, if
+ * any, provided herein do not apply to combinations of this program with
+ * other software, or any other product whatsoever.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <fnmatch.h>
+
+#ifdef HAVE_LIBSELINUX_DEVEL
+#include <selinux/selinux.h>
+#endif
+
+#include "test.h"
+#include "usctest.h"
+
+#define MAX_BUFF_SIZE 65536
+#define MAX_FUNC_NAME 256
+
+char *TCID = "proc01";
+int TST_TOTAL = 1;
+
+static int opt_verbose;
+static int opt_procpath;
+static char *opt_procpathstr;
+static int opt_buffsize;
+static int opt_readirq;
+static char *opt_buffsizestr;
+static int opt_maxmbytes;
+static char *opt_maxmbytesstr;
+
+static char *procpath = "/proc";
+static const char selfpath[] = "/proc/self";
+size_t buffsize = 1024;
+static long long maxbytes;
+
+unsigned long long total_read;
+unsigned int total_obj;
+
+struct mapping {
+	char func[MAX_FUNC_NAME];
+	char file[PATH_MAX];
+	int err;
+};
+
+/* Those are known failures for 2.6.18 baremetal kernel and Xen dom0
+   kernel on i686, x86_64, ia64, ppc64 and s390x. In addition, It looks
+   like if SELinux is disabled, the test may still fail on some other
+   entries. */
+static const struct mapping known_issues[] = {
+	{"open", "/proc/acpi/event", EBUSY},
+	{"open", "/proc/sal/cpe/data", EBUSY},
+	{"open", "/proc/sal/cmc/data", EBUSY},
+	{"open", "/proc/sal/init/data", EBUSY},
+	{"open", "/proc/sal/mca/data", EBUSY},
+	{"open", "/proc/fs/nfsd/pool_stats", ENODEV},
+	{"read", "/proc/acpi/event", EAGAIN},
+	{"read", "/proc/kmsg", EAGAIN},
+	{"read", "/proc/sal/cpe/event", EAGAIN},
+	{"read", "/proc/sal/cmc/event", EAGAIN},
+	{"read", "/proc/sal/init/event", EAGAIN},
+	{"read", "/proc/sal/mca/event", EAGAIN},
+	{"read", "/proc/xen/privcmd", EIO},
+	{"read", "/proc/xen/privcmd", EINVAL},
+	{"read", "/proc/self/mem", EIO},
+	{"read", "/proc/self/task/[0-9]*/mem", EIO},
+	{"read", "/proc/self/attr/*", EINVAL},
+	{"read", "/proc/self/task/[0-9]*/attr/*", EINVAL},
+	{"read", "/proc/self/ns/*", EINVAL},
+	{"read", "/proc/self/task/[0-9]*/ns/*", EINVAL},
+	{"read", "/proc/ppc64/rtas/error_log", EINVAL},
+	{"read", "/proc/powerpc/rtas/error_log", EINVAL},
+	{"read", "/proc/fs/nfsd/unlock_filesystem", EINVAL},
+	{"read", "/proc/fs/nfsd/unlock_ip", EINVAL},
+	{"read", "/proc/fs/nfsd/filehandle", EINVAL},
+	{"read", "/proc/fs/nfsd/.getfs", EINVAL},
+	{"read", "/proc/fs/nfsd/.getfd", EINVAL},
+	{"read", "/proc/self/net/rpc/use-gss-proxy", EAGAIN},
+	{"", "", 0}
+};
+
+/*
+ * If a particular LSM is enabled, it is expected that some entries can
+ * be read successfully. Otherwise, those entries will retrun some
+ * failures listed above. Here to add any LSM specific entries.
+ */
+
+/*
+ * Test macro to indicate that SELinux libraries and headers are
+ * installed.
+ */
+#ifdef HAVE_LIBSELINUX_DEVEL
+static const char lsm_should_work[][PATH_MAX] = {
+	"/proc/self/attr/*",
+	"/proc/self/task/[0-9]*/attr/*",
+	""
+};
+
+/* Place holder for none of LSM is detected. */
+#else
+static const char lsm_should_work[][PATH_MAX] = {
+	""
+};
+#endif
+
+/* Known files that does not honor O_NONBLOCK, so they will hang
+   the test while being read. */
+static const char error_nonblock[][PATH_MAX] = {
+	"/proc/xen/xenbus",
+	""
+};
+
+/*
+ * Verify expected failures, and then let the test to continue.
+ *
+ * Return 0 when a problem errno is found.
+ * Return 1 when a known issue is found.
+ *
+ */
+static int found_errno(const char *syscall, const char *obj, int tmperr)
+{
+	int i;
+
+	/* Should not see any error for certain entries if a LSM is enabled. */
+#ifdef HAVE_LIBSELINUX_DEVEL
+	if (is_selinux_enabled()) {
+		for (i = 0; lsm_should_work[i][0] != '\0'; i++) {
+			if (!strcmp(obj, lsm_should_work[i]) ||
+			    !fnmatch(lsm_should_work[i], obj, FNM_PATHNAME)) {
+				return 0;
+			}
+		}
+	}
+#endif
+	for (i = 0; known_issues[i].err != 0; i++) {
+		if (tmperr == known_issues[i].err &&
+		    (!strcmp(obj, known_issues[i].file) ||
+		     !fnmatch(known_issues[i].file, obj, FNM_PATHNAME)) &&
+		    !strcmp(syscall, known_issues[i].func)) {
+			/* Using strcmp / fnmatch could have messed up the
+			 * errno value. */
+			errno = tmperr;
+			tst_resm(TINFO | TERRNO, "%s: known issue", obj);
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static void cleanup(void)
+{
+	TEST_CLEANUP;
+	tst_rmdir();
+}
+
+static void setup(void)
+{
+	tst_sig(FORK, DEF_HANDLER, cleanup);
+	TEST_PAUSE;
+	tst_tmpdir();
+}
+
+void help(void)
+{
+	printf("  -b x    read byte count\n");
+	printf("  -m x    max megabytes to read from single file\n");
+	printf("  -q      read .../irq/... entries\n");
+	printf("  -r x    proc pathname\n");
+	printf("  -v      verbose mode\n");
+}
+
+/*
+ * add the -m option whose parameter is the
+ * pages that should be mapped.
+ */
+static option_t options[] = {
+	{"b:", &opt_buffsize, &opt_buffsizestr},
+	{"m:", &opt_maxmbytes, &opt_maxmbytesstr},
+	{"q", &opt_readirq, NULL},
+	{"r:", &opt_procpath, &opt_procpathstr},
+	{"v", &opt_verbose, NULL},
+	{NULL, NULL, NULL}
+};
+
+/*
+ * NB: this function is recursive
+ * returns 0 if no error encountered, otherwise number of errors (objs)
+ *
+ * REM: Funny enough, while developing this function (actually replacing
+ *	streamed fopen by standard open), I hit a real /proc bug.
+ *	On a 2.2.13-SuSE kernel, "cat /proc/tty/driver/serial" would fail
+ *	with EFAULT, while "cat /proc/tty/driver/serial > somefile" wouldn't.
+ *	Okay, this might be due to a slight serial misconfiguration, but still.
+ *	Analysis with strace showed up the difference was on the count size
+ *	of read (1024 bytes vs 4096 bytes). So I tested further..
+ *	read count of 512 bytes adds /proc/tty/drivers to the list
+ *	of broken proc files, while 64 bytes reads removes
+ *	/proc/tty/driver/serial from the list. Interesting, isn't it?
+ *	Now, there's a -b option to this test, so you can try your luck. --SF
+ *
+ * It's more fun to run this test it as root, as all the files will be accessible!
+ * (however, be careful, there might be some bufferoverflow holes..)
+ * reading proc files might be also a good kernel latency killer.
+ */
+static long readproc(const char *obj)
+{
+	DIR *dir = NULL;	/* pointer to a directory */
+	struct dirent *dir_ent;	/* pointer to directory entries */
+	char dirobj[PATH_MAX];	/* object inside directory to modify */
+	struct stat statbuf;	/* used to hold stat information */
+	int fd, tmperr, i;
+	ssize_t nread;
+	static char buf[MAX_BUFF_SIZE];	/* static kills reentrancy, but we don't care about the contents */
+	unsigned long long file_total_read = 0;
+
+	/* Determine the file type */
+	if (lstat(obj, &statbuf) < 0) {
+
+		/* permission denied is not considered as error */
+		if (errno != EACCES) {
+			tst_resm(TFAIL | TERRNO, "%s: lstat", obj);
+			return 1;
+		}
+		return 0;
+
+	}
+
+	/* Prevent loops, but read /proc/self. */
+	if (S_ISLNK(statbuf.st_mode) && strcmp(obj, selfpath))
+		return 0;
+
+	total_obj++;
+
+	/* Take appropriate action, depending on the file type */
+	if (S_ISDIR(statbuf.st_mode) || !strcmp(obj, selfpath)) {
+
+		/* object is a directory */
+
+		/*
+		 * Skip over the /proc/irq directory, unless the user
+		 * requested that we read the directory because it could
+		 * map to a broken driver which effectively `hangs' the
+		 * test.
+		 */
+		if (!opt_readirq && !strcmp("/proc/irq", obj)) {
+			return 0;
+			/* Open the directory to get access to what is in it */
+		} else if ((dir = opendir(obj)) == NULL) {
+			if (errno != EACCES) {
+				tst_resm(TFAIL | TERRNO, "%s: opendir", obj);
+				return 1;
+			}
+			return 0;
+		} else {
+
+			long ret_val = 0;
+
+			/* Loop through the entries in the directory */
+			for (dir_ent = (struct dirent *)readdir(dir);
+			     dir_ent != NULL;
+			     dir_ent = (struct dirent *)readdir(dir)) {
+
+				/* Ignore ".", "..", "kcore", and
+				 * "/proc/<pid>" (unless this is our
+				 * starting point as directed by the
+				 * user).
+				 */
+				if (strcmp(dir_ent->d_name, ".") &&
+				    strcmp(dir_ent->d_name, "..") &&
+				    strcmp(dir_ent->d_name, "kcore") &&
+				    (fnmatch("[0-9]*", dir_ent->d_name,
+					     FNM_PATHNAME) ||
+				     strcmp(obj, procpath))) {
+
+					if (opt_verbose) {
+						fprintf(stderr, "%s\n",
+							dir_ent->d_name);
+					}
+
+					/* Recursively call this routine to test the
+					 * current entry */
+					snprintf(dirobj, PATH_MAX,
+						 "%s/%s", obj, dir_ent->d_name);
+					ret_val += readproc(dirobj);
+
+				}
+
+			}
+
+			/* Close the directory */
+			if (dir)
+				(void)closedir(dir);
+
+			return ret_val;
+
+		}
+
+	} else {		/* if it's not a dir, read it! */
+
+		if (!S_ISREG(statbuf.st_mode))
+			return 0;
+
+#ifdef DEBUG
+		fprintf(stderr, "%s", obj);
+#endif
+
+		/* is O_NONBLOCK enough to escape from FIFO's ? */
+		fd = open(obj, O_RDONLY | O_NONBLOCK);
+		if (fd < 0) {
+			tmperr = errno;
+
+			if (!found_errno("open", obj, tmperr)) {
+
+				errno = tmperr;
+
+				if (errno != EACCES) {
+					tst_resm(TFAIL | TERRNO,
+						 "%s: open failed", obj);
+					return 1;
+				}
+
+			}
+			return 0;
+
+		}
+
+		/* Skip write-only files. */
+		if ((statbuf.st_mode & S_IRUSR) == 0 &&
+		    (statbuf.st_mode & S_IWUSR) != 0) {
+			tst_resm(TINFO, "%s: is write-only.", obj);
+			return 0;
+		}
+
+		/* Skip files does not honor O_NONBLOCK. */
+		for (i = 0; error_nonblock[i][0] != '\0'; i++) {
+			if (!strcmp(obj, error_nonblock[i])) {
+				tst_resm(TWARN, "%s: does not honor "
+					 "O_NONBLOCK", obj);
+				return 0;
+			}
+		}
+
+		file_total_read = 0;
+		do {
+
+			nread = read(fd, buf, buffsize);
+
+			if (nread < 0) {
+
+				tmperr = errno;
+				(void)close(fd);
+
+				/* ignore no perm (not root) and no
+				 * process (terminated) errors */
+				if (!found_errno("read", obj, tmperr)) {
+
+					errno = tmperr;
+
+					if (errno != EACCES && errno != ESRCH) {
+						tst_resm(TFAIL | TERRNO,
+							 "read failed: "
+							 "%s", obj);
+						return 1;
+					}
+					return 0;
+
+				}
+
+			} else
+				file_total_read += nread;
+
+			if (opt_verbose) {
+#ifdef DEBUG
+				fprintf(stderr, "%ld", nread);
+#endif
+				fprintf(stderr, ".");
+			}
+
+			if ((maxbytes > 0) && (file_total_read > maxbytes)) {
+				tst_resm(TINFO, "%s: reached maxmbytes (-m)",
+					 obj);
+				break;
+			}
+		} while (0 < nread);
+		total_read += file_total_read;
+
+		if (opt_verbose)
+			fprintf(stderr, "\n");
+
+		if (0 <= fd)
+			(void)close(fd);
+
+	}
+
+	/* It's better to assume success by default rather than failure. */
+	return 0;
+
+}
+
+int main(int argc, char *argv[])
+{
+	char *msg;
+	int lc;
+
+	msg = parse_opts(argc, argv, options, help);
+	if (msg != NULL)
+		tst_brkm(TBROK, cleanup, "OPTION PARSING ERROR - %s", msg);
+
+	if (opt_buffsize) {
+		size_t bs;
+		bs = atoi(opt_buffsizestr);
+		if (bs <= MAX_BUFF_SIZE)
+			buffsize = bs;
+		else
+			tst_brkm(TBROK, cleanup,
+				 "Invalid arg for -b (max: %u): %s",
+				 MAX_BUFF_SIZE, opt_buffsizestr);
+	}
+	if (opt_maxmbytes)
+		maxbytes = atoi(opt_maxmbytesstr) * 1024 * 1024;
+
+	if (opt_procpath)
+		procpath = opt_procpathstr;
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+
+		TEST(readproc(procpath));
+
+		if (TEST_RETURN != 0) {
+			tst_resm(TFAIL, "readproc() failed with %ld errors.",
+				 TEST_RETURN);
+		} else {
+			tst_resm(TPASS, "readproc() completed successfully, "
+				 "total read: %llu bytes, %u objs", total_read,
+				 total_obj);
+		}
+	}
+
+	cleanup();
+	tst_exit();
+}

--- a/distribution/ltp/lite/patches/20130904/sendmsg01.c
+++ b/distribution/ltp/lite/patches/20130904/sendmsg01.c
@@ -1,0 +1,732 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *   Copyright (c) Cyril Hrubis <chrubis@suse.cz> 2012
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+/*
+ * Test Name: sendmsg01
+ *
+ * Test Description:
+ *  Verify that sendmsg() returns the proper errno for various failure cases
+ *
+ * HISTORY
+ *	07/2001 Ported by Wayne Boyer
+ *	05/2003 Modified by Manoj Iyer - Make setup function set up lo device.
+ */
+
+/*
+ * The #ifndef code below is for 2.5 64-bit kernels, where
+ * the MSG_CMSG_COMPAT flag must be 0 in order for the syscall
+ * and this test to function correctly.
+ */
+#ifndef MSG_CMSG_COMPAT
+#if defined(__powerpc64__) || defined(__mips64) || defined(__x86_64__) || \
+     defined(__sparc64__) || defined(__ia64__) || defined(__s390x__)
+#define MSG_CMSG_COMPAT 0x80000000
+#else
+#define MSG_CMSG_COMPAT 0
+#endif
+#endif /* MSG_CMSG_COMPAT */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <time.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/signal.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <sys/file.h>
+#include <sys/wait.h>
+
+#include <netinet/in.h>
+
+#include "test.h"
+#include "usctest.h"
+
+char *TCID = "sendmsg01";
+int testno;
+
+static char buf[1024], bigbuf[128 * 1024];
+static int s;
+static struct sockaddr_in sin1, sin2;
+static struct sockaddr_un sun1;
+static struct msghdr msgdat;
+static char cbuf[4096];
+static struct cmsghdr *control;
+static int controllen;
+static struct iovec iov[1];
+static int sfd;			/* shared between do_child and start_server */
+static int ufd;			/* shared between do_child and start_server */
+
+static void setup(void);
+static void setup0(void);
+static void setup1(void);
+static void setup2(void);
+static void setup3(void);
+static void setup4(void);
+static void setup5(void);
+static void setup6(void);
+static void setup8(void);
+
+static void cleanup(void);
+static void cleanup0(void);
+static void cleanup1(void);
+static void cleanup4(void);
+
+static void do_child(void);
+
+struct test_case_t {		/* test case structure */
+	int domain;		/* PF_INET, PF_UNIX, ... */
+	int type;		/* SOCK_STREAM, SOCK_DGRAM ... */
+	int proto;		/* protocol number (usually 0 = default) */
+	struct iovec *iov;
+	int iovcnt;		/* # elements in iovec */
+	void *buf;		/* send data buffer */
+	int buflen;		/* send buffer length */
+	struct msghdr *msg;
+	unsigned flags;
+	struct sockaddr *to;	/* destination */
+	int tolen;		/* length of "to" buffer */
+	int retval;		/* syscall return value */
+	int experrno;		/* expected errno */
+	void (*setup) (void);
+	void (*cleanup) (void);
+	char *desc;
+};
+
+struct test_case_t tdat[] = {
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EBADF,
+	 .setup = setup0,
+	 .cleanup = cleanup0,
+	 .desc = "bad file descriptor"}
+	,
+	{.domain = 0,
+	 .type = 0,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = ENOTSOCK,
+	 .setup = setup0,
+	 .cleanup = cleanup0,
+	 .desc = "invalid socket"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = (void *)-1,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid send buffer"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin2,
+	 .tolen = sizeof(sin2),
+	 .retval = 0,
+	 .experrno = EFAULT,
+	 .setup = setup5,
+	 .cleanup = cleanup1,
+	 .desc = "connected TCP"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EPIPE,
+	 .setup = setup3,
+	 .cleanup = cleanup1,
+	 .desc = "not connected TCP"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = 1,
+	 .retval = -1,
+	 .experrno = EINVAL,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid to buffer length"},
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)-1,
+	 .tolen = sizeof(struct sockaddr),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid to buffer"},
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = bigbuf,
+	 .buflen = sizeof(bigbuf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EMSGSIZE,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "UDP message too big"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EPIPE,
+	 .setup = setup2,
+	 .cleanup = cleanup1,
+	 .desc = "local endpoint shutdown"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = NULL,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid iovec pointer"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_STREAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = NULL,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid msghdr pointer"}
+	,
+	{.domain = PF_UNIX,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sun1,
+	 .tolen = sizeof(sun1),
+	 .retval = 0,
+	 .experrno = 0,
+	 .setup = setup4,
+	 .cleanup = cleanup4,
+	 .desc = "rights passing"}
+	,
+	{.domain = PF_UNIX,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = ~MSG_CMSG_COMPAT,
+	 .to = (struct sockaddr *)&sun1,
+	 .tolen = sizeof(sun1),
+	 .retval = -1,
+	 .experrno = EOPNOTSUPP,
+	 .setup = setup4,
+	 .cleanup = cleanup4,
+	 .desc = "invalid flags set w/ control"}
+	,
+	{.domain = PF_INET,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = MSG_OOB,
+	 .to = (struct sockaddr *)&sin1,
+	 .tolen = sizeof(sin1),
+	 .retval = -1,
+	 .experrno = EOPNOTSUPP,
+	 .setup = setup1,
+	 .cleanup = cleanup1,
+	 .desc = "invalid flags set"}
+	,
+	{.domain = PF_UNIX,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sun1,
+	 .tolen = sizeof(sun1),
+	 .retval = 0,
+	 .experrno = EOPNOTSUPP,
+	 .setup = setup6,
+	 .cleanup = cleanup4,
+	 .desc = "invalid cmsg length"}
+	,
+	{.domain = PF_UNIX,
+	 .type = SOCK_DGRAM,
+	 .proto = 0,
+	 .iov = iov,
+	 .iovcnt = 1,
+	 .buf = buf,
+	 .buflen = sizeof(buf),
+	 .msg = &msgdat,
+	 .flags = 0,
+	 .to = (struct sockaddr *)&sun1,
+	 .tolen = sizeof(sun1),
+	 .retval = -1,
+	 .experrno = EFAULT,
+	 .setup = setup8,
+	 .cleanup = cleanup4,
+	 .desc = "invalid cmsg pointer"}
+};
+
+int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
+
+int exp_enos[] = {
+	EBADF, ENOTSOCK, EFAULT, EISCONN, ENOTCONN, EINVAL, EMSGSIZE, EPIPE,
+	ENOBUFS, 0
+};
+
+#ifdef UCLINUX
+static char *argv0;
+#endif
+
+int main(int argc, char *argv[])
+{
+	int lc;
+	char *msg;
+
+	msg = parse_opts(argc, argv, NULL, NULL);
+	if (msg != NULL)
+		tst_brkm(TBROK, NULL, "OPTION PARSING ERROR - %s", msg);
+
+#ifdef UCLINUX
+	argv0 = argv[0];
+	maybe_run_child(&do_child, "dd", &sfd, &ufd);
+#endif
+
+	setup();
+
+	TEST_EXP_ENOS(exp_enos);
+
+	for (lc = 0; TEST_LOOPING(lc); ++lc) {
+		tst_count = 0;
+		for (testno = 0; testno < TST_TOTAL; ++testno) {
+			tdat[testno].setup();
+
+			iov[0].iov_base = tdat[testno].buf;
+			iov[0].iov_len = tdat[testno].buflen;
+			if (tdat[testno].type != SOCK_STREAM) {
+				msgdat.msg_name = tdat[testno].to;
+				msgdat.msg_namelen = tdat[testno].tolen;
+			}
+			msgdat.msg_iov = tdat[testno].iov;
+			msgdat.msg_iovlen = tdat[testno].iovcnt;
+			msgdat.msg_control = control;
+			msgdat.msg_controllen = controllen;
+			msgdat.msg_flags = 0;
+
+			TEST(sendmsg(s, tdat[testno].msg, tdat[testno].flags));
+
+			if (TEST_RETURN > 0)
+				TEST_RETURN = 0;	/* all success equal */
+
+			TEST_ERROR_LOG(TEST_ERRNO);
+
+			if (TEST_RETURN != tdat[testno].retval ||
+			    (TEST_RETURN < 0 &&
+			     TEST_ERRNO != tdat[testno].experrno)) {
+				tst_resm(TFAIL, "%s ; returned"
+					 " %ld (expected %d), errno %d (expected"
+					 " %d)", tdat[testno].desc,
+					 TEST_RETURN, tdat[testno].retval,
+					 TEST_ERRNO, tdat[testno].experrno);
+			} else {
+				tst_resm(TPASS, "%s successful",
+					 tdat[testno].desc);
+			}
+			tdat[testno].cleanup();
+		}
+	}
+	cleanup();
+	tst_exit();
+}
+
+static pid_t start_server(struct sockaddr_in *sin0, struct sockaddr_un *sun0)
+{
+	struct sockaddr_in sin1 = *sin0;
+	pid_t pid;
+
+	/* set up inet socket */
+	sfd = socket(PF_INET, SOCK_STREAM, 0);
+	if (sfd < 0) {
+		tst_brkm(TBROK, cleanup, "server socket failed: %s",
+			 strerror(errno));
+		return -1;
+	}
+	if (bind(sfd, (struct sockaddr *)&sin1, sizeof(sin1)) < 0) {
+		tst_brkm(TBROK, cleanup, "server bind failed: %s",
+			 strerror(errno));
+		return -1;
+	}
+	if (listen(sfd, 10) < 0) {
+		tst_brkm(TBROK, cleanup, "server listen failed: %s",
+			 strerror(errno));
+		return -1;
+	}
+	/* set up UNIX-domain socket */
+	ufd = socket(PF_UNIX, SOCK_DGRAM, 0);
+	if (ufd < 0) {
+		tst_brkm(TBROK, cleanup, "server UD socket failed: %s",
+			 strerror(errno));
+		return -1;
+	}
+	if (bind(ufd, (struct sockaddr *)sun0, sizeof(*sun0))) {
+		tst_brkm(TBROK, cleanup, "server UD bind failed: %s",
+			 strerror(errno));
+		return -1;
+	}
+
+	switch ((pid = FORK_OR_VFORK())) {
+	case 0:
+#ifdef UCLINUX
+		if (self_exec(argv0, "dd", sfd, ufd) < 0)
+			tst_brkm(TBROK, cleanup, "server self_exec failed");
+#else
+		do_child();
+#endif
+		break;
+	case -1:
+		tst_brkm(TBROK, cleanup, "server fork failed: %s",
+			 strerror(errno));
+	default:
+		close(sfd);
+		close(ufd);
+		return pid;
+	}
+
+	exit(1);
+}
+
+static void do_child(void)
+{
+	struct sockaddr_in fsin;
+	struct sockaddr_un fsun;
+	fd_set afds, rfds;
+	int nfds, cc, fd;
+
+	FD_ZERO(&afds);
+	FD_SET(sfd, &afds);
+	FD_SET(ufd, &afds);
+
+	nfds = getdtablesize();
+
+	/* accept connections until killed */
+	while (1) {
+		socklen_t fromlen;
+
+		memcpy(&rfds, &afds, sizeof(rfds));
+
+		if (select(nfds, &rfds, NULL, NULL, NULL) < 0)
+			if (errno != EINTR)
+				exit(1);
+		if (FD_ISSET(sfd, &rfds)) {
+			int newfd;
+
+			fromlen = sizeof(fsin);
+			newfd = accept(sfd, (struct sockaddr *)&fsin, &fromlen);
+			if (newfd >= 0)
+				FD_SET(newfd, &afds);
+		}
+		if (FD_ISSET(ufd, &rfds)) {
+			int newfd;
+
+			fromlen = sizeof(fsun);
+			newfd = accept(ufd, (struct sockaddr *)&fsun, &fromlen);
+			if (newfd >= 0)
+				FD_SET(newfd, &afds);
+		}
+		for (fd = 0; fd < nfds; ++fd) {
+			if (fd != sfd && fd != ufd && FD_ISSET(fd, &rfds)) {
+				cc = read(fd, buf, sizeof(buf));
+				if (cc == 0 || (cc < 0 && errno != EINTR)) {
+					close(fd);
+					FD_CLR(fd, &afds);
+				}
+			}
+		}
+	}
+}
+
+static pid_t pid;
+static char tmpsunpath[1024];
+
+static void setup(void)
+{
+
+	int ret = 0;
+
+	tst_require_root(NULL);
+	tst_sig(FORK, DEF_HANDLER, cleanup);
+	TEST_PAUSE;
+
+	/* initialize sockaddr's */
+	sin1.sin_family = AF_INET;
+	sin1.sin_port = htons((getpid() % 32768) + 11000);
+	sin1.sin_addr.s_addr = INADDR_ANY;
+
+	tst_tmpdir();
+	snprintf(tmpsunpath, 1024, "udsock%ld", (long)time(NULL));
+	sun1.sun_family = AF_UNIX;
+	strcpy(sun1.sun_path, tmpsunpath);
+
+	/* this test will fail or in some cases hang if no eth or lo is
+	 * configured, so making sure in setup that at least lo is up
+	 */
+	ret = system("ip link set lo up");
+	if (WEXITSTATUS(ret) != 0) {
+		ret = system("ifconfig lo up 127.0.0.1");
+		if (WEXITSTATUS(ret) != 0) {
+			tst_brkm(TBROK, cleanup,
+			    "ip/ifconfig failed to bring up loop back device");
+			tst_exit();
+		}
+	}
+
+	pid = start_server(&sin1, &sun1);
+
+	signal(SIGPIPE, SIG_IGN);
+}
+
+static void cleanup(void)
+{
+	if (pid > 0)
+		kill(pid, SIGKILL);	/* kill server, if server exists */
+	unlink(tmpsunpath);
+	TEST_CLEANUP;
+	tst_rmdir();
+}
+
+static void setup0(void)
+{
+	if (tdat[testno].experrno == EBADF)
+		s = 400;	/* anything not an open file */
+	else if ((s = open("/dev/null", O_WRONLY)) == -1)
+		tst_brkm(TBROK, cleanup, "error opening /dev/null - "
+			 "errno: %s", strerror(errno));
+}
+
+static void cleanup0(void)
+{
+	s = -1;
+}
+
+static void setup1(void)
+{
+	s = socket(tdat[testno].domain, tdat[testno].type, tdat[testno].proto);
+	if (s < 0) {
+		tst_brkm(TBROK, cleanup, "socket setup failed: %s",
+			 strerror(errno));
+	}
+	if (tdat[testno].type == SOCK_STREAM &&
+	    connect(s, (struct sockaddr *)tdat[testno].to,
+		    tdat[testno].tolen) < 0) {
+		tst_brkm(TBROK, cleanup, "connect failed: %s", strerror(errno));
+	}
+}
+
+static void cleanup1(void)
+{
+	close(s);
+	s = -1;
+}
+
+static void setup2(void)
+{
+	setup1();		/* get a socket in s */
+	if (shutdown(s, 1) < 0) {
+		tst_brkm(TBROK, cleanup, "socket setup failed connect "
+			 "test %d: %s", testno, strerror(errno));
+	}
+}
+
+static void setup3(void)
+{
+	s = socket(tdat[testno].domain, tdat[testno].type, tdat[testno].proto);
+	if (s < 0) {
+		tst_brkm(TBROK, cleanup, "socket setup failed: %s",
+			 strerror(errno));
+	}
+}
+
+static char tmpfilename[1024];
+static int tfd;
+
+static void setup4(void)
+{
+
+	setup1();		/* get a socket in s */
+
+	strcpy(tmpfilename, "sockXXXXXX");
+	tfd = mkstemp(tmpfilename);
+	if (tfd < 0) {
+		tst_brkm(TBROK, cleanup4, "socket setup failed: %s",
+			 strerror(errno));
+	}
+	control = (struct cmsghdr *)cbuf;
+	memset(cbuf, 0x00, sizeof(cbuf));
+	control->cmsg_len = sizeof(struct cmsghdr) + 4;
+	control->cmsg_level = SOL_SOCKET;
+	control->cmsg_type = SCM_RIGHTS;
+	*(int *)CMSG_DATA(control) = tfd;
+	controllen = control->cmsg_len;
+}
+
+static void cleanup4(void)
+{
+	cleanup1();
+	close(tfd);
+	tfd = -1;
+	control = 0;
+	controllen = 0;
+}
+
+static void setup5(void)
+{
+	s = socket(tdat[testno].domain, tdat[testno].type, tdat[testno].proto);
+	if (s < 0) {
+		tst_brkm(TBROK, cleanup, "socket setup failed: %s",
+			 strerror(errno));
+	}
+
+	if (connect(s, (struct sockaddr *)&sin1, sizeof(sin1)) < 0)
+		tst_brkm(TBROK, cleanup, "connect failed: %s", strerror(errno));
+
+	/* slight change destination (port) so connect() is to different
+	 * 5-tuple than already connected
+	 */
+	sin2 = sin1;
+	sin2.sin_port++;
+}
+
+static void setup6(void)
+{
+	setup4();
+/*
+	controllen = control->cmsg_len = sizeof(struct cmsghdr) - 4;
+*/
+	controllen = control->cmsg_len = 0;
+}
+
+static void setup8(void)
+{
+	setup4();
+	control = (struct cmsghdr *)-1;
+}

--- a/distribution/ltp/lite/patches/20140115/readahead02.c
+++ b/distribution/ltp/lite/patches/20140115/readahead02.c
@@ -1,0 +1,381 @@
+/*
+ * Copyright (C) 2012 Linux Test Project, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of version 2 of the GNU General Public
+ * License as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Further, this software is distributed without any warranty that it
+ * is free of the rightful claim of any third person regarding
+ * infringement or the like.  Any license provided herein, whether
+ * implied or otherwise, applies only to this software file.  Patent
+ * licenses, if any, provided herein do not apply to combinations of
+ * this program with other software, or any other product whatsoever.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/*
+ * functional test for readahead() syscall
+ *
+ * This test is measuring effects of readahead syscall.
+ * It mmaps/reads a test file with and without prior call to readahead.
+ *
+ */
+#define _GNU_SOURCE
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "config.h"
+#include "test.h"
+#include "usctest.h"
+#include "safe_macros.h"
+#include "linux_syscall_numbers.h"
+
+char *TCID = "readahead02";
+int TST_TOTAL = 1;
+
+#if defined(__NR_readahead)
+static const char testfile[] = "testfile";
+static const char drop_caches_fname[] = "/proc/sys/vm/drop_caches";
+static const char meminfo_fname[] = "/proc/meminfo";
+static size_t testfile_size = 64 * 1024 * 1024;
+static int opt_fsize;
+static char *opt_fsizestr;
+static int pagesize;
+
+option_t options[] = {
+	{"s:", &opt_fsize, &opt_fsizestr},
+	{NULL, NULL, NULL}
+};
+
+static void setup(void);
+static void cleanup(void);
+
+static void help(void)
+{
+	printf("  -s x    testfile size (default 64MB)\n");
+}
+
+static int check_ret(long expected_ret)
+{
+	if (expected_ret == TEST_RETURN) {
+		tst_resm(TPASS, "expected ret success - "
+			 "returned value = %ld", TEST_RETURN);
+		return 0;
+	}
+	tst_resm(TFAIL, "unexpected failure - "
+		 "returned value = %ld, expected: %ld",
+		 TEST_RETURN, expected_ret);
+	return 1;
+}
+
+static int has_file(const char *fname, int required)
+{
+	int ret;
+	struct stat buf;
+	ret = stat(fname, &buf);
+	if (ret == -1) {
+		if (errno == ENOENT)
+			if (required)
+				tst_brkm(TCONF, cleanup, "%s not available",
+					 fname);
+			else
+				return 0;
+		else
+			tst_brkm(TBROK | TERRNO, cleanup, "stat %s", fname);
+	}
+	return 1;
+}
+
+static void drop_caches(void)
+{
+	int ret;
+	FILE *f;
+
+	f = fopen(drop_caches_fname, "w");
+	if (f) {
+		ret = fprintf(f, "1");
+		fclose(f);
+		if (ret < 1)
+			tst_brkm(TBROK, cleanup, "Failed to drop caches");
+	} else {
+		tst_brkm(TBROK, cleanup, "Failed to open drop_caches");
+	}
+}
+
+static unsigned long parse_entry(const char *fname, const char *entry)
+{
+	FILE *f;
+	long value = -1;
+	int ret;
+	char *line = NULL;
+	size_t linelen;
+
+	f = fopen(fname, "r");
+	if (f) {
+		do {
+			ret = getline(&line, &linelen, f);
+			if (sscanf(line, entry, &value) == 1)
+				break;
+		} while (ret != -1);
+		fclose(f);
+	}
+	return value;
+}
+
+static unsigned long get_bytes_read(void)
+{
+	char fname[128];
+	char entry[] = "read_bytes: %lu";
+	sprintf(fname, "/proc/%u/io", getpid());
+	return parse_entry(fname, entry);
+}
+
+static unsigned long get_cached_size(void)
+{
+	char entry[] = "Cached: %lu";
+	return parse_entry(meminfo_fname, entry);
+}
+
+static void create_testfile(void)
+{
+	FILE *f;
+	char *tmp;
+	size_t i;
+
+	tst_resm(TINFO, "creating test file of size: %ld", testfile_size);
+	tmp = SAFE_MALLOC(cleanup, pagesize);
+
+	/* round to page size */
+	testfile_size = testfile_size & ~((long)pagesize - 1);
+
+	f = fopen(testfile, "w");
+	if (!f) {
+		free(tmp);
+		tst_brkm(TBROK | TERRNO, cleanup, "Failed to create %s",
+			 testfile);
+	}
+
+	for (i = 0; i < testfile_size; i += pagesize)
+		if (fwrite(tmp, pagesize, 1, f) < 1) {
+			free(tmp);
+			tst_brkm(TBROK, cleanup, "Failed to create %s",
+				 testfile);
+		}
+	fflush(f);
+	fsync(fileno(f));
+	fclose(f);
+	free(tmp);
+}
+
+/* read_testfile - mmap testfile and read every page.
+ * This functions measures how many I/O and time it takes to fully
+ * read contents of test file.
+ *
+ * @do_readahead: call readahead prior to reading file content?
+ * @fname: name of file to test
+ * @fsize: how many bytes to read/mmap
+ * @read_bytes: returns difference of bytes read, parsed from /proc/<pid>/io
+ * @usec: returns how many microsecond it took to go over fsize bytes
+ * @cached: returns cached kB from /proc/meminfo
+ */
+static void read_testfile(int do_readahead, const char *fname, size_t fsize,
+			  unsigned long *read_bytes, long *usec,
+			  unsigned long *cached)
+{
+	int fd, ret;
+	size_t i;
+	long read_bytes_start;
+	unsigned char *p, tmp;
+	unsigned long time_start_usec, time_end_usec;
+	off_t offset;
+	struct timeval now;
+
+	fd = open(fname, O_RDONLY);
+	if (fd < 0)
+		tst_brkm(TBROK | TERRNO, cleanup, "Failed to open %s", fname);
+
+	if (do_readahead) {
+		/* read ahead in chunks, 2MB is maximum since 3.14-rcX */
+		for (i = 0; i < fsize; i += 2*1024*1024) {
+			ret = ltp_syscall(__NR_readahead, fd,
+				(off64_t) i, 2*1024*1024);
+			if (ret == -1)
+				tst_resm(TFAIL|TERRNO, "readahead off:%lu", i);
+		}
+		check_ret(0);
+		*cached = get_cached_size();
+
+		/* offset of file shouldn't change after readahead */
+		offset = lseek(fd, 0, SEEK_CUR);
+		if (offset == (off_t) - 1)
+			tst_brkm(TBROK | TERRNO, cleanup, "lseek failed");
+		if (offset == 0)
+			tst_resm(TPASS, "offset is still at 0 as expected");
+		else
+			tst_resm(TFAIL, "offset has changed to: %lu", offset);
+	}
+
+	if (gettimeofday(&now, NULL) == -1)
+		tst_brkm(TBROK | TERRNO, cleanup, "gettimeofday failed");
+	time_start_usec = now.tv_sec * 1000000 + now.tv_usec;
+	read_bytes_start = get_bytes_read();
+
+	p = mmap(NULL, fsize, PROT_READ, MAP_SHARED | MAP_POPULATE, fd, 0);
+	if (p == MAP_FAILED)
+		tst_brkm(TBROK | TERRNO, cleanup, "mmap failed");
+
+	/* for old kernels, where MAP_POPULATE doesn't work, touch each page */
+	tmp = 0;
+	for (i = 0; i < fsize; i += pagesize)
+		tmp = tmp ^ p[i];
+	/* prevent gcc from optimizing out loop above */
+	if (tmp != 0)
+		tst_brkm(TBROK, NULL, "This line should not be reached");
+
+	if (!do_readahead)
+		*cached = get_cached_size();
+
+	if (munmap(p, fsize) == -1)
+		tst_brkm(TBROK | TERRNO, cleanup, "munmap failed");
+
+	*read_bytes = get_bytes_read() - read_bytes_start;
+	if (gettimeofday(&now, NULL) == -1)
+		tst_brkm(TBROK | TERRNO, cleanup, "gettimeofday failed");
+	time_end_usec = now.tv_sec * 1000000 + now.tv_usec;
+	*usec = time_end_usec - time_start_usec;
+
+	if (close(fd) == -1)
+		tst_brkm(TBROK | TERRNO, cleanup, "close failed");
+}
+
+static void test_readahead(void)
+{
+	unsigned long read_bytes, read_bytes_ra;
+	long usec, usec_ra;
+	unsigned long cached_max, cached_low, cached, cached_ra;
+	char proc_io_fname[128];
+	sprintf(proc_io_fname, "/proc/%u/io", getpid());
+
+	/* find out how much can cache hold if we read whole file */
+	read_testfile(0, testfile, testfile_size, &read_bytes, &usec, &cached);
+	cached_max = get_cached_size();
+	sync();
+	drop_caches();
+	cached_low = get_cached_size();
+	cached_max = cached_max - cached_low;
+
+	tst_resm(TINFO, "read_testfile(0)");
+	read_testfile(0, testfile, testfile_size, &read_bytes, &usec, &cached);
+	cached = cached - cached_low;
+
+	sync();
+	drop_caches();
+	cached_low = get_cached_size();
+	tst_resm(TINFO, "read_testfile(1)");
+	read_testfile(1, testfile, testfile_size, &read_bytes_ra,
+		      &usec_ra, &cached_ra);
+	cached_ra = cached_ra - cached_low;
+
+	tst_resm(TINFO, "read_testfile(0) took: %ld usec", usec);
+	tst_resm(TINFO, "read_testfile(1) took: %ld usec", usec_ra);
+	if (has_file(proc_io_fname, 0)) {
+		tst_resm(TINFO, "read_testfile(0) read: %ld bytes", read_bytes);
+		tst_resm(TINFO, "read_testfile(1) read: %ld bytes",
+			 read_bytes_ra);
+		/* actual number of read bytes depends on total RAM */
+		if (read_bytes_ra < read_bytes)
+			tst_resm(TPASS, "readahead saved some I/O");
+		else
+			tst_resm(TFAIL, "readahead failed to save any I/O");
+	} else {
+		tst_resm(TCONF, "Your system doesn't have /proc/pid/io,"
+			 " unable to determine read bytes during test");
+	}
+
+	tst_resm(TINFO, "cache can hold at least: %ld kB", cached_max);
+	tst_resm(TINFO, "read_testfile(0) used cache: %ld kB", cached);
+	tst_resm(TINFO, "read_testfile(1) used cache: %ld kB", cached_ra);
+
+	if (cached_max * 1024 >= testfile_size) {
+		/*
+		 * if cache can hold ~testfile_size then cache increase
+		 * for readahead should be at least testfile_size/2
+		 */
+		if (cached_ra * 1024 > testfile_size / 2)
+			tst_resm(TPASS, "using cache as expected");
+		else
+			tst_resm(TWARN, "using less cache than expected");
+	} else {
+		tst_resm(TCONF, "Page cache on your system is too small "
+			 "to hold whole testfile.");
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	char *msg;
+	int lc;
+
+	msg = parse_opts(argc, argv, options, help);
+	if (msg != NULL)
+		tst_brkm(TBROK, NULL, "OPTION PARSING ERROR - %s", msg);
+
+	if (opt_fsize)
+		testfile_size = atoi(opt_fsizestr);
+
+	setup();
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+		test_readahead();
+	}
+	cleanup();
+	tst_exit();
+}
+
+static void setup(void)
+{
+	tst_require_root(NULL);
+	tst_tmpdir();
+	TEST_PAUSE;
+
+	has_file(drop_caches_fname, 1);
+	has_file(meminfo_fname, 1);
+
+	/* check if readahead is supported */
+	ltp_syscall(__NR_readahead, 0, 0, 0);
+
+	pagesize = getpagesize();
+	create_testfile();
+}
+
+static void cleanup(void)
+{
+	TEST_CLEANUP;
+	unlink(testfile);
+	tst_rmdir();
+}
+
+#else /* __NR_readahead */
+int main(void)
+{
+	tst_brkm(TCONF, NULL, "System doesn't support __NR_readahead");
+}
+#endif

--- a/distribution/ltp/lite/patches/20150119/proc01.c
+++ b/distribution/ltp/lite/patches/20150119/proc01.c
@@ -1,0 +1,478 @@
+/*
+ * proc01.c - Tests Linux /proc file reading.
+ *
+ * Copyright (C) 2001 Stephane Fillod <f4cfe@free.fr>
+ * Copyright (c) 2008, 2009  Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Further, this software is distributed without any warranty that it is
+ * free of the rightful claim of any third person regarding infringement
+ * or the like.  Any license provided herein, whether implied or
+ * otherwise, applies only to this software file.  Patent licenses, if
+ * any, provided herein do not apply to combinations of this program with
+ * other software, or any other product whatsoever.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <fnmatch.h>
+
+#ifdef HAVE_LIBSELINUX_DEVEL
+#include <selinux/selinux.h>
+#endif
+
+#include "test.h"
+#include "usctest.h"
+
+#define MAX_BUFF_SIZE 65536
+#define MAX_FUNC_NAME 256
+
+char *TCID = "proc01";
+int TST_TOTAL = 1;
+
+static int opt_verbose;
+static int opt_procpath;
+static char *opt_procpathstr;
+static int opt_buffsize;
+static int opt_readirq;
+static char *opt_buffsizestr;
+static int opt_maxmbytes;
+static char *opt_maxmbytesstr;
+
+static char *procpath = "/proc";
+static const char selfpath[] = "/proc/self";
+size_t buffsize = 1024;
+static long long maxbytes;
+
+unsigned long long total_read;
+unsigned int total_obj;
+
+struct mapping {
+	char func[MAX_FUNC_NAME];
+	char file[PATH_MAX];
+	int err;
+};
+
+/* Those are known failures for 2.6.18 baremetal kernel and Xen dom0
+   kernel on i686, x86_64, ia64, ppc64 and s390x. In addition, It looks
+   like if SELinux is disabled, the test may still fail on some other
+   entries. */
+static const struct mapping known_issues[] = {
+	{"open", "/proc/acpi/event", EBUSY},
+	{"open", "/proc/sal/cpe/data", EBUSY},
+	{"open", "/proc/sal/cmc/data", EBUSY},
+	{"open", "/proc/sal/init/data", EBUSY},
+	{"open", "/proc/sal/mca/data", EBUSY},
+	{"open", "/proc/fs/nfsd/pool_stats", ENODEV},
+	{"read", "/proc/acpi/event", EAGAIN},
+	{"read", "/proc/kmsg", EAGAIN},
+	{"read", "/proc/sal/cpe/event", EAGAIN},
+	{"read", "/proc/sal/cmc/event", EAGAIN},
+	{"read", "/proc/sal/init/event", EAGAIN},
+	{"read", "/proc/sal/mca/event", EAGAIN},
+	{"read", "/proc/xen/privcmd", EIO},
+	{"read", "/proc/xen/privcmd", EINVAL},
+	{"read", "/proc/self/mem", EIO},
+	{"read", "/proc/self/task/[0-9]*/mem", EIO},
+	{"read", "/proc/self/attr/*", EINVAL},
+	{"read", "/proc/self/task/[0-9]*/attr/*", EINVAL},
+	{"read", "/proc/self/ns/*", EINVAL},
+	{"read", "/proc/self/task/[0-9]*/ns/*", EINVAL},
+	{"read", "/proc/ppc64/rtas/error_log", EINVAL},
+	{"read", "/proc/powerpc/rtas/error_log", EINVAL},
+	{"read", "/proc/fs/nfsd/unlock_filesystem", EINVAL},
+	{"read", "/proc/fs/nfsd/unlock_ip", EINVAL},
+	{"read", "/proc/fs/nfsd/filehandle", EINVAL},
+	{"read", "/proc/fs/nfsd/.getfs", EINVAL},
+	{"read", "/proc/fs/nfsd/.getfd", EINVAL},
+	{"read", "/proc/self/net/rpc/use-gss-proxy", EAGAIN},
+	{"", "", 0}
+};
+
+/*
+ * If a particular LSM is enabled, it is expected that some entries can
+ * be read successfully. Otherwise, those entries will retrun some
+ * failures listed above. Here to add any LSM specific entries.
+ */
+
+/*
+ * Test macro to indicate that SELinux libraries and headers are
+ * installed.
+ */
+#ifdef HAVE_LIBSELINUX_DEVEL
+static const char lsm_should_work[][PATH_MAX] = {
+	"/proc/self/attr/*",
+	"/proc/self/task/[0-9]*/attr/*",
+	""
+};
+
+/* Place holder for none of LSM is detected. */
+#else
+static const char lsm_should_work[][PATH_MAX] = {
+	""
+};
+#endif
+
+/* Known files that does not honor O_NONBLOCK, so they will hang
+   the test while being read. */
+static const char error_nonblock[][PATH_MAX] = {
+	"/proc/xen/xenbus",
+	"/proc/bus/usb",
+	""
+};
+
+/*
+ * Verify expected failures, and then let the test to continue.
+ *
+ * Return 0 when a problem errno is found.
+ * Return 1 when a known issue is found.
+ *
+ */
+static int found_errno(const char *syscall, const char *obj, int tmperr)
+{
+	int i;
+
+	/* Should not see any error for certain entries if a LSM is enabled. */
+#ifdef HAVE_LIBSELINUX_DEVEL
+	if (is_selinux_enabled()) {
+		for (i = 0; lsm_should_work[i][0] != '\0'; i++) {
+			if (!strcmp(obj, lsm_should_work[i]) ||
+			    !fnmatch(lsm_should_work[i], obj, FNM_PATHNAME)) {
+				return 0;
+			}
+		}
+	}
+#endif
+	for (i = 0; known_issues[i].err != 0; i++) {
+		if (tmperr == known_issues[i].err &&
+		    (!strcmp(obj, known_issues[i].file) ||
+		     !fnmatch(known_issues[i].file, obj, FNM_PATHNAME)) &&
+		    !strcmp(syscall, known_issues[i].func)) {
+			/* Using strcmp / fnmatch could have messed up the
+			 * errno value. */
+			errno = tmperr;
+			tst_resm(TINFO | TERRNO, "%s: known issue", obj);
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static void cleanup(void)
+{
+	TEST_CLEANUP;
+	tst_rmdir();
+}
+
+static void setup(void)
+{
+	tst_sig(FORK, DEF_HANDLER, cleanup);
+	TEST_PAUSE;
+	tst_tmpdir();
+}
+
+void help(void)
+{
+	printf("  -b x    read byte count\n");
+	printf("  -m x    max megabytes to read from single file\n");
+	printf("  -q      read .../irq/... entries\n");
+	printf("  -r x    proc pathname\n");
+	printf("  -v      verbose mode\n");
+}
+
+/*
+ * add the -m option whose parameter is the
+ * pages that should be mapped.
+ */
+static option_t options[] = {
+	{"b:", &opt_buffsize, &opt_buffsizestr},
+	{"m:", &opt_maxmbytes, &opt_maxmbytesstr},
+	{"q", &opt_readirq, NULL},
+	{"r:", &opt_procpath, &opt_procpathstr},
+	{"v", &opt_verbose, NULL},
+	{NULL, NULL, NULL}
+};
+
+/*
+ * NB: this function is recursive
+ * returns 0 if no error encountered, otherwise number of errors (objs)
+ *
+ * REM: Funny enough, while developing this function (actually replacing
+ *	streamed fopen by standard open), I hit a real /proc bug.
+ *	On a 2.2.13-SuSE kernel, "cat /proc/tty/driver/serial" would fail
+ *	with EFAULT, while "cat /proc/tty/driver/serial > somefile" wouldn't.
+ *	Okay, this might be due to a slight serial misconfiguration, but still.
+ *	Analysis with strace showed up the difference was on the count size
+ *	of read (1024 bytes vs 4096 bytes). So I tested further..
+ *	read count of 512 bytes adds /proc/tty/drivers to the list
+ *	of broken proc files, while 64 bytes reads removes
+ *	/proc/tty/driver/serial from the list. Interesting, isn't it?
+ *	Now, there's a -b option to this test, so you can try your luck. --SF
+ *
+ * It's more fun to run this test it as root, as all the files will be accessible!
+ * (however, be careful, there might be some bufferoverflow holes..)
+ * reading proc files might be also a good kernel latency killer.
+ */
+static long readproc(const char *obj)
+{
+	DIR *dir = NULL;	/* pointer to a directory */
+	struct dirent *dir_ent;	/* pointer to directory entries */
+	char dirobj[PATH_MAX];	/* object inside directory to modify */
+	struct stat statbuf;	/* used to hold stat information */
+	int fd, tmperr, i;
+	ssize_t nread;
+	static char buf[MAX_BUFF_SIZE];	/* static kills reentrancy, but we don't care about the contents */
+	unsigned long long file_total_read = 0;
+
+	/* Skip files does not honor O_NONBLOCK. */
+	for (i = 0; error_nonblock[i][0] != '\0'; i++) {
+		if (!strcmp(obj, error_nonblock[i])) {
+			tst_resm(TINFO, "%s: does not honor "
+					"O_NONBLOCK", obj);
+			return 0;
+		}
+	}
+
+	/* Determine the file type */
+	if (lstat(obj, &statbuf) < 0) {
+
+		/* permission denied is not considered as error */
+		if (errno != EACCES) {
+			tst_resm(TFAIL | TERRNO, "%s: lstat", obj);
+			return 1;
+		}
+		return 0;
+
+	}
+
+	/* Prevent loops, but read /proc/self. */
+	if (S_ISLNK(statbuf.st_mode) && strcmp(obj, selfpath))
+		return 0;
+
+	total_obj++;
+
+	/* Take appropriate action, depending on the file type */
+	if (S_ISDIR(statbuf.st_mode) || !strcmp(obj, selfpath)) {
+
+		/* object is a directory */
+
+		/*
+		 * Skip over the /proc/irq directory, unless the user
+		 * requested that we read the directory because it could
+		 * map to a broken driver which effectively `hangs' the
+		 * test.
+		 */
+		if (!opt_readirq && !strcmp("/proc/irq", obj)) {
+			return 0;
+			/* Open the directory to get access to what is in it */
+		} else if ((dir = opendir(obj)) == NULL) {
+			if (errno != EACCES) {
+				tst_resm(TFAIL | TERRNO, "%s: opendir", obj);
+				return 1;
+			}
+			return 0;
+		} else {
+
+			long ret_val = 0;
+
+			/* Loop through the entries in the directory */
+			for (dir_ent = (struct dirent *)readdir(dir);
+			     dir_ent != NULL;
+			     dir_ent = (struct dirent *)readdir(dir)) {
+
+				/* Ignore ".", "..", "kcore", and
+				 * "/proc/<pid>" (unless this is our
+				 * starting point as directed by the
+				 * user).
+				 */
+				if (strcmp(dir_ent->d_name, ".") &&
+				    strcmp(dir_ent->d_name, "..") &&
+				    strcmp(dir_ent->d_name, "kcore") &&
+				    (fnmatch("[0-9]*", dir_ent->d_name,
+					     FNM_PATHNAME) ||
+				     strcmp(obj, procpath))) {
+
+					if (opt_verbose) {
+						fprintf(stderr, "%s\n",
+							dir_ent->d_name);
+					}
+
+					/* Recursively call this routine to test the
+					 * current entry */
+					snprintf(dirobj, PATH_MAX,
+						 "%s/%s", obj, dir_ent->d_name);
+					ret_val += readproc(dirobj);
+
+				}
+
+			}
+
+			/* Close the directory */
+			if (dir)
+				(void)closedir(dir);
+
+			return ret_val;
+
+		}
+
+	} else {		/* if it's not a dir, read it! */
+
+		if (!S_ISREG(statbuf.st_mode))
+			return 0;
+
+#ifdef DEBUG
+		fprintf(stderr, "%s", obj);
+#endif
+
+		/* is O_NONBLOCK enough to escape from FIFO's ? */
+		fd = open(obj, O_RDONLY | O_NONBLOCK);
+		if (fd < 0) {
+			tmperr = errno;
+
+			if (!found_errno("open", obj, tmperr)) {
+
+				errno = tmperr;
+
+				if (errno != EACCES) {
+					tst_resm(TFAIL | TERRNO,
+						 "%s: open failed", obj);
+					return 1;
+				}
+
+			}
+			return 0;
+
+		}
+
+		/* Skip write-only files. */
+		if ((statbuf.st_mode & S_IRUSR) == 0 &&
+		    (statbuf.st_mode & S_IWUSR) != 0) {
+			tst_resm(TINFO, "%s: is write-only.", obj);
+			return 0;
+		}
+
+
+		file_total_read = 0;
+		do {
+
+			nread = read(fd, buf, buffsize);
+
+			if (nread < 0) {
+
+				tmperr = errno;
+				(void)close(fd);
+
+				/* ignore no perm (not root) and no
+				 * process (terminated) errors */
+				if (!found_errno("read", obj, tmperr)) {
+
+					errno = tmperr;
+
+					if (errno != EACCES && errno != ESRCH) {
+						tst_resm(TFAIL | TERRNO,
+							 "read failed: "
+							 "%s", obj);
+						return 1;
+					}
+					return 0;
+
+				}
+
+			} else
+				file_total_read += nread;
+
+			if (opt_verbose) {
+#ifdef DEBUG
+				fprintf(stderr, "%ld", nread);
+#endif
+				fprintf(stderr, ".");
+			}
+
+			if ((maxbytes > 0) && (file_total_read > maxbytes)) {
+				tst_resm(TINFO, "%s: reached maxmbytes (-m)",
+					 obj);
+				break;
+			}
+		} while (0 < nread);
+		total_read += file_total_read;
+
+		if (opt_verbose)
+			fprintf(stderr, "\n");
+
+		if (0 <= fd)
+			(void)close(fd);
+
+	}
+
+	/* It's better to assume success by default rather than failure. */
+	return 0;
+
+}
+
+int main(int argc, char *argv[])
+{
+	const char *msg;
+	int lc;
+
+	msg = parse_opts(argc, argv, options, help);
+	if (msg != NULL)
+		tst_brkm(TBROK, cleanup, "OPTION PARSING ERROR - %s", msg);
+
+	if (opt_buffsize) {
+		size_t bs;
+		bs = atoi(opt_buffsizestr);
+		if (bs <= MAX_BUFF_SIZE)
+			buffsize = bs;
+		else
+			tst_brkm(TBROK, cleanup,
+				 "Invalid arg for -b (max: %u): %s",
+				 MAX_BUFF_SIZE, opt_buffsizestr);
+	}
+	if (opt_maxmbytes)
+		maxbytes = atoi(opt_maxmbytesstr) * 1024 * 1024;
+
+	if (opt_procpath)
+		procpath = opt_procpathstr;
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+
+		TEST(readproc(procpath));
+
+		if (TEST_RETURN != 0) {
+			tst_resm(TFAIL, "readproc() failed with %ld errors.",
+				 TEST_RETURN);
+		} else {
+			tst_resm(TPASS, "readproc() completed successfully, "
+				 "total read: %llu bytes, %u objs", total_read,
+				 total_obj);
+		}
+	}
+
+	cleanup();
+	tst_exit();
+}

--- a/distribution/ltp/lite/patches/20150420/proc01.c
+++ b/distribution/ltp/lite/patches/20150420/proc01.c
@@ -1,0 +1,474 @@
+/*
+ * proc01.c - Tests Linux /proc file reading.
+ *
+ * Copyright (C) 2001 Stephane Fillod <f4cfe@free.fr>
+ * Copyright (c) 2008, 2009  Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it would be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Further, this software is distributed without any warranty that it is
+ * free of the rightful claim of any third person regarding infringement
+ * or the like.  Any license provided herein, whether implied or
+ * otherwise, applies only to this software file.  Patent licenses, if
+ * any, provided herein do not apply to combinations of this program with
+ * other software, or any other product whatsoever.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <fnmatch.h>
+
+#ifdef HAVE_LIBSELINUX_DEVEL
+#include <selinux/selinux.h>
+#endif
+
+#include "test.h"
+
+#define MAX_BUFF_SIZE 65536
+#define MAX_FUNC_NAME 256
+
+char *TCID = "proc01";
+int TST_TOTAL = 1;
+
+static int opt_verbose;
+static int opt_procpath;
+static char *opt_procpathstr;
+static int opt_buffsize;
+static int opt_readirq;
+static char *opt_buffsizestr;
+static int opt_maxmbytes;
+static char *opt_maxmbytesstr;
+
+static char *procpath = "/proc";
+static const char selfpath[] = "/proc/self";
+size_t buffsize = 1024;
+static long long maxbytes;
+
+unsigned long long total_read;
+unsigned int total_obj;
+
+struct mapping {
+	char func[MAX_FUNC_NAME];
+	char file[PATH_MAX];
+	int err;
+};
+
+/* Those are known failures for 2.6.18 baremetal kernel and Xen dom0
+   kernel on i686, x86_64, ia64, ppc64 and s390x. In addition, It looks
+   like if SELinux is disabled, the test may still fail on some other
+   entries. */
+static const struct mapping known_issues[] = {
+	{"open", "/proc/acpi/event", EBUSY},
+	{"open", "/proc/sal/cpe/data", EBUSY},
+	{"open", "/proc/sal/cmc/data", EBUSY},
+	{"open", "/proc/sal/init/data", EBUSY},
+	{"open", "/proc/sal/mca/data", EBUSY},
+	{"open", "/proc/fs/nfsd/pool_stats", ENODEV},
+	{"read", "/proc/acpi/event", EAGAIN},
+	{"read", "/proc/kmsg", EAGAIN},
+	{"read", "/proc/sal/cpe/event", EAGAIN},
+	{"read", "/proc/sal/cmc/event", EAGAIN},
+	{"read", "/proc/sal/init/event", EAGAIN},
+	{"read", "/proc/sal/mca/event", EAGAIN},
+	{"read", "/proc/xen/privcmd", EIO},
+	{"read", "/proc/xen/privcmd", EINVAL},
+	{"read", "/proc/self/mem", EIO},
+	{"read", "/proc/self/task/[0-9]*/mem", EIO},
+	{"read", "/proc/self/attr/*", EINVAL},
+	{"read", "/proc/self/task/[0-9]*/attr/*", EINVAL},
+	{"read", "/proc/self/ns/*", EINVAL},
+	{"read", "/proc/self/task/[0-9]*/ns/*", EINVAL},
+	{"read", "/proc/ppc64/rtas/error_log", EINVAL},
+	{"read", "/proc/powerpc/rtas/error_log", EINVAL},
+	{"read", "/proc/fs/nfsd/unlock_filesystem", EINVAL},
+	{"read", "/proc/fs/nfsd/unlock_ip", EINVAL},
+	{"read", "/proc/fs/nfsd/filehandle", EINVAL},
+	{"read", "/proc/fs/nfsd/.getfs", EINVAL},
+	{"read", "/proc/fs/nfsd/.getfd", EINVAL},
+	{"read", "/proc/self/net/rpc/use-gss-proxy", EAGAIN},
+	{"read", "/proc/sys/net/ipv6/conf/*/stable_secret", EIO},
+	{"", "", 0}
+};
+
+/*
+ * If a particular LSM is enabled, it is expected that some entries can
+ * be read successfully. Otherwise, those entries will retrun some
+ * failures listed above. Here to add any LSM specific entries.
+ */
+
+/*
+ * Test macro to indicate that SELinux libraries and headers are
+ * installed.
+ */
+#ifdef HAVE_LIBSELINUX_DEVEL
+static const char lsm_should_work[][PATH_MAX] = {
+	"/proc/self/attr/*",
+	"/proc/self/task/[0-9]*/attr/*",
+	""
+};
+
+/* Place holder for none of LSM is detected. */
+#else
+static const char lsm_should_work[][PATH_MAX] = {
+	""
+};
+#endif
+
+/* Known files that does not honor O_NONBLOCK, so they will hang
+   the test while being read. */
+static const char error_nonblock[][PATH_MAX] = {
+	"/proc/xen/xenbus",
+	"/proc/bus/usb",
+	""
+};
+
+/*
+ * Verify expected failures, and then let the test to continue.
+ *
+ * Return 0 when a problem errno is found.
+ * Return 1 when a known issue is found.
+ *
+ */
+static int found_errno(const char *syscall, const char *obj, int tmperr)
+{
+	int i;
+
+	/* Should not see any error for certain entries if a LSM is enabled. */
+#ifdef HAVE_LIBSELINUX_DEVEL
+	if (is_selinux_enabled()) {
+		for (i = 0; lsm_should_work[i][0] != '\0'; i++) {
+			if (!strcmp(obj, lsm_should_work[i]) ||
+			    !fnmatch(lsm_should_work[i], obj, FNM_PATHNAME)) {
+				return 0;
+			}
+		}
+	}
+#endif
+	for (i = 0; known_issues[i].err != 0; i++) {
+		if (tmperr == known_issues[i].err &&
+		    (!strcmp(obj, known_issues[i].file) ||
+		     !fnmatch(known_issues[i].file, obj, FNM_PATHNAME)) &&
+		    !strcmp(syscall, known_issues[i].func)) {
+			/* Using strcmp / fnmatch could have messed up the
+			 * errno value. */
+			errno = tmperr;
+			tst_resm(TINFO | TERRNO, "%s: known issue", obj);
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static void cleanup(void)
+{
+	tst_rmdir();
+}
+
+static void setup(void)
+{
+	tst_sig(FORK, DEF_HANDLER, cleanup);
+	TEST_PAUSE;
+	tst_tmpdir();
+}
+
+void help(void)
+{
+	printf("  -b x    read byte count\n");
+	printf("  -m x    max megabytes to read from single file\n");
+	printf("  -q      read .../irq/... entries\n");
+	printf("  -r x    proc pathname\n");
+	printf("  -v      verbose mode\n");
+}
+
+/*
+ * add the -m option whose parameter is the
+ * pages that should be mapped.
+ */
+static option_t options[] = {
+	{"b:", &opt_buffsize, &opt_buffsizestr},
+	{"m:", &opt_maxmbytes, &opt_maxmbytesstr},
+	{"q", &opt_readirq, NULL},
+	{"r:", &opt_procpath, &opt_procpathstr},
+	{"v", &opt_verbose, NULL},
+	{NULL, NULL, NULL}
+};
+
+/*
+ * NB: this function is recursive
+ * returns 0 if no error encountered, otherwise number of errors (objs)
+ *
+ * REM: Funny enough, while developing this function (actually replacing
+ *	streamed fopen by standard open), I hit a real /proc bug.
+ *	On a 2.2.13-SuSE kernel, "cat /proc/tty/driver/serial" would fail
+ *	with EFAULT, while "cat /proc/tty/driver/serial > somefile" wouldn't.
+ *	Okay, this might be due to a slight serial misconfiguration, but still.
+ *	Analysis with strace showed up the difference was on the count size
+ *	of read (1024 bytes vs 4096 bytes). So I tested further..
+ *	read count of 512 bytes adds /proc/tty/drivers to the list
+ *	of broken proc files, while 64 bytes reads removes
+ *	/proc/tty/driver/serial from the list. Interesting, isn't it?
+ *	Now, there's a -b option to this test, so you can try your luck. --SF
+ *
+ * It's more fun to run this test it as root, as all the files will be accessible!
+ * (however, be careful, there might be some bufferoverflow holes..)
+ * reading proc files might be also a good kernel latency killer.
+ */
+static long readproc(const char *obj)
+{
+	DIR *dir = NULL;	/* pointer to a directory */
+	struct dirent *dir_ent;	/* pointer to directory entries */
+	char dirobj[PATH_MAX];	/* object inside directory to modify */
+	struct stat statbuf;	/* used to hold stat information */
+	int fd, tmperr, i;
+	ssize_t nread;
+	static char buf[MAX_BUFF_SIZE];	/* static kills reentrancy, but we don't care about the contents */
+	unsigned long long file_total_read = 0;
+
+	/* Skip files does not honor O_NONBLOCK. */
+	for (i = 0; error_nonblock[i][0] != '\0'; i++) {
+		if (!strcmp(obj, error_nonblock[i])) {
+			tst_resm(TINFO, "%s: does not honor "
+					"O_NONBLOCK", obj);
+			return 0;
+		}
+	}
+
+	/* Determine the file type */
+	if (lstat(obj, &statbuf) < 0) {
+
+		/* permission denied is not considered as error */
+		if (errno != EACCES) {
+			tst_resm(TFAIL | TERRNO, "%s: lstat", obj);
+			return 1;
+		}
+		return 0;
+
+	}
+
+	/* Prevent loops, but read /proc/self. */
+	if (S_ISLNK(statbuf.st_mode) && strcmp(obj, selfpath))
+		return 0;
+
+	total_obj++;
+
+	/* Take appropriate action, depending on the file type */
+	if (S_ISDIR(statbuf.st_mode) || !strcmp(obj, selfpath)) {
+
+		/* object is a directory */
+
+		/*
+		 * Skip over the /proc/irq directory, unless the user
+		 * requested that we read the directory because it could
+		 * map to a broken driver which effectively `hangs' the
+		 * test.
+		 */
+		if (!opt_readirq && !strcmp("/proc/irq", obj)) {
+			return 0;
+			/* Open the directory to get access to what is in it */
+		} else if ((dir = opendir(obj)) == NULL) {
+			if (errno != EACCES) {
+				tst_resm(TFAIL | TERRNO, "%s: opendir", obj);
+				return 1;
+			}
+			return 0;
+		} else {
+
+			long ret_val = 0;
+
+			/* Loop through the entries in the directory */
+			for (dir_ent = (struct dirent *)readdir(dir);
+			     dir_ent != NULL;
+			     dir_ent = (struct dirent *)readdir(dir)) {
+
+				/* Ignore ".", "..", "kcore", and
+				 * "/proc/<pid>" (unless this is our
+				 * starting point as directed by the
+				 * user).
+				 */
+				if (strcmp(dir_ent->d_name, ".") &&
+				    strcmp(dir_ent->d_name, "..") &&
+				    strcmp(dir_ent->d_name, "kcore") &&
+				    (fnmatch("[0-9]*", dir_ent->d_name,
+					     FNM_PATHNAME) ||
+				     strcmp(obj, procpath))) {
+
+					if (opt_verbose) {
+						fprintf(stderr, "%s\n",
+							dir_ent->d_name);
+					}
+
+					/* Recursively call this routine to test the
+					 * current entry */
+					snprintf(dirobj, PATH_MAX,
+						 "%s/%s", obj, dir_ent->d_name);
+					ret_val += readproc(dirobj);
+
+				}
+
+			}
+
+			/* Close the directory */
+			if (dir)
+				(void)closedir(dir);
+
+			return ret_val;
+
+		}
+
+	} else {		/* if it's not a dir, read it! */
+
+		if (!S_ISREG(statbuf.st_mode))
+			return 0;
+
+#ifdef DEBUG
+		fprintf(stderr, "%s", obj);
+#endif
+
+		/* is O_NONBLOCK enough to escape from FIFO's ? */
+		fd = open(obj, O_RDONLY | O_NONBLOCK);
+		if (fd < 0) {
+			tmperr = errno;
+
+			if (!found_errno("open", obj, tmperr)) {
+
+				errno = tmperr;
+
+				if (errno != EACCES) {
+					tst_resm(TFAIL | TERRNO,
+						 "%s: open failed", obj);
+					return 1;
+				}
+
+			}
+			return 0;
+
+		}
+
+		/* Skip write-only files. */
+		if ((statbuf.st_mode & S_IRUSR) == 0 &&
+		    (statbuf.st_mode & S_IWUSR) != 0) {
+			tst_resm(TINFO, "%s: is write-only.", obj);
+			return 0;
+		}
+
+
+		file_total_read = 0;
+		do {
+
+			nread = read(fd, buf, buffsize);
+
+			if (nread < 0) {
+
+				tmperr = errno;
+				(void)close(fd);
+
+				/* ignore no perm (not root) and no
+				 * process (terminated) errors */
+				if (!found_errno("read", obj, tmperr)) {
+
+					errno = tmperr;
+
+					if (errno != EACCES && errno != ESRCH) {
+						tst_resm(TFAIL | TERRNO,
+							 "read failed: "
+							 "%s", obj);
+						return 1;
+					}
+					return 0;
+
+				}
+
+			} else
+				file_total_read += nread;
+
+			if (opt_verbose) {
+#ifdef DEBUG
+				fprintf(stderr, "%ld", nread);
+#endif
+				fprintf(stderr, ".");
+			}
+
+			if ((maxbytes > 0) && (file_total_read > maxbytes)) {
+				tst_resm(TINFO, "%s: reached maxmbytes (-m)",
+					 obj);
+				break;
+			}
+		} while (0 < nread);
+		total_read += file_total_read;
+
+		if (opt_verbose)
+			fprintf(stderr, "\n");
+
+		if (0 <= fd)
+			(void)close(fd);
+
+	}
+
+	/* It's better to assume success by default rather than failure. */
+	return 0;
+
+}
+
+int main(int argc, char *argv[])
+{
+	int lc;
+
+	tst_parse_opts(argc, argv, options, help);
+
+	if (opt_buffsize) {
+		size_t bs;
+		bs = atoi(opt_buffsizestr);
+		if (bs <= MAX_BUFF_SIZE)
+			buffsize = bs;
+		else
+			tst_brkm(TBROK, cleanup,
+				 "Invalid arg for -b (max: %u): %s",
+				 MAX_BUFF_SIZE, opt_buffsizestr);
+	}
+	if (opt_maxmbytes)
+		maxbytes = atoi(opt_maxmbytesstr) * 1024 * 1024;
+
+	if (opt_procpath)
+		procpath = opt_procpathstr;
+
+	setup();
+
+	for (lc = 0; TEST_LOOPING(lc); lc++) {
+		tst_count = 0;
+
+		TEST(readproc(procpath));
+
+		if (TEST_RETURN != 0) {
+			tst_resm(TFAIL, "readproc() failed with %ld errors.",
+				 TEST_RETURN);
+		} else {
+			tst_resm(TPASS, "readproc() completed successfully, "
+				 "total read: %llu bytes, %u objs", total_read,
+				 total_obj);
+		}
+	}
+
+	cleanup();
+	tst_exit();
+}

--- a/distribution/ltp/lite/patches/20150420/syslog-lib.sh
+++ b/distribution/ltp/lite/patches/20150420/syslog-lib.sh
@@ -1,0 +1,157 @@
+#! /bin/sh
+#
+#  Copyright (c) Linux Test Project, 2010
+#
+#  This program is free software;  you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY;  without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+#  the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program;  if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+##################################################################
+
+readonly MAILLOG=/var/log/maillog
+
+# Signals to trap.
+readonly TRAP_SIGS="1 2 3 6 11 15"
+
+# configuration file for syslog or syslog-ng
+CONFIG_FILE=""
+
+# rsyslogd .conf specific args.
+RSYSLOG_CONFIG=
+
+# number of seconds to wait for another syslog test to complete
+WAIT_COUNT=60
+
+cleanup()
+{
+	# Reentrant cleanup -> bad. Especially since rsyslogd on Fedora 13
+	# seems to get stuck FOREVER when not running as root. Lame...
+	disable_traps
+	exit_code=$1
+
+	# Restore the previous syslog daemon state.
+	if [ -f "$CONFIG_FILE.ltpback" ]; then
+		if mv "$CONFIG_FILE.ltpback" "$CONFIG_FILE"; then
+			# Make sure that restart_syslog_daemon doesn't loop
+			# back to cleanup again.
+			restart_syslog_daemon "return 1"
+			# Maintain any nonzero exit codes
+			if [ $exit_code -ne $? ]; then
+				exit_code=1
+			fi
+		else
+			exit_code=1
+		fi
+	fi
+
+	exit $exit_code
+}
+
+setup()
+{
+	tst_require_root
+
+	trap '	disable_traps
+		tst_resm TBROK "Testing is terminating due to a signal"
+		cleanup 1' $TRAP_SIGS || exit 1
+
+	if [ "$SYSLOG_DAEMON" = "syslog" ]; then
+		CONFIG_FILE="/etc/syslog.conf"
+	elif [ "$SYSLOG_DAEMON" = "syslog-ng" ]; then
+		CONFIG_FILE="/etc/syslog-ng/syslog-ng.conf"
+	elif [ "$SYSLOG_DAEMON" = "rsyslog" ]; then
+		CONFIG_FILE="/etc/rsyslog.conf"
+		if grep -q -r '^\$ModLoad[[:space:]]*imjournal' /etc/rsyslog.conf /etc/rsyslog.d/ ; then
+			systemd_journal=$(grep -Ehoi "^[^#].*(imjournal|workdirectory).*" -r /etc/rsyslog.conf /etc/rsyslog.d/)
+			RSYSLOG_CONFIG=$(cat <<EOF
+$systemd_journal
+EOF
+)
+		else
+			log_socket=$(grep -ho "^\$SystemLogSocketName .*" -r /etc/rsyslog.conf /etc/rsyslog.d/ | head -1)
+			RSYSLOG_CONFIG=$(cat <<EOF
+\$ModLoad imuxsock.so
+$log_socket
+EOF
+)
+		fi
+	else
+		tst_resm TBROK "Couldn't find syslogd, syslog-ng or rsyslogd"
+		cleanup 1
+	fi
+
+	# Back up configuration file
+	if [ -f "$CONFIG_FILE" ]; then
+		# Pause if another LTP syslog test is running
+		while [ -f "$CONFIG_FILE.ltpback" -a $WAIT_COUNT -gt 0 ]; do
+			: $(( WAIT_COUNT -= 1 ))
+			sleep 1
+		done
+		# Oops -- $CONFIG_FILE.ltpback is still there!
+		if [ $WAIT_COUNT -eq 0 ]; then
+			tst_resm TBROK "another syslog test is stuck"
+			cleanup 1
+		elif ! cp "$CONFIG_FILE" "$CONFIG_FILE.ltpback"; then
+			tst_resm TBROK "failed to backup $CONFIG_FILE"
+			cleanup 1
+		fi
+	else
+		tst_resm TBROK "$CONFIG_FILE not found!"
+	fi
+
+}
+
+disable_traps()
+{
+	trap - $TRAP_SIGS
+}
+
+# For most cases this isn't exotic. If you're running upstart however, you
+# might have fun here :).
+restart_syslog_daemon()
+{
+	# Default to running `cleanup 1' when dealing with error cases.
+	if [ $# -eq 0 ]; then
+		cleanup_command="cleanup 1"
+	else
+		cleanup_command=$1
+	fi
+
+	tst_resm TINFO "restarting syslog daemon"
+
+	if [ -n "$SYSLOG_DAEMON" ]; then
+		restart_daemon $SYSLOG_DAEMON
+		if [ $? -eq 0 ]; then
+			# XXX: this really shouldn't exist; if *syslogd isn't
+			# ready once the restart directive has been issued,
+			# then it needs to be fixed.
+			sleep 2
+		else
+			#
+			# Some distributions name the service syslog even if
+			# the package is syslog-ng or rsyslog, so try it once
+			# more with just syslog.
+			#
+			restart_daemon "syslog"
+
+			if [ $? -ne 0 ]; then
+				$cleanup_command
+			fi
+		fi
+	fi
+}
+
+export TST_TOTAL=${TST_TOTAL:=1}
+export TST_COUNT=1
+export TCID=${TCID:="$(basename "$0")"}
+. cmdlib.sh

--- a/distribution/ltp/lite/patches/20150903/mtest01.c
+++ b/distribution/ltp/lite/patches/20150903/mtest01.c
@@ -1,0 +1,305 @@
+/*
+ *
+ *   Copyright (c) International Business Machines  Corp., 2001
+ *
+ *   This program is free software;  you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY;  without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *   the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program;  if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ *  FILE		: mtest01.c
+ *  DESCRIPTION : mallocs memory <chunksize> at a time until malloc fails.
+ *  HISTORY:
+ *	04/10/2001 Paul Larson (plars@us.ibm.com)
+ *	  written
+ *	11/09/2001 Manoj Iyer (manjo@austin.ibm.com)
+ *	  Modified.
+ *	  - Removed compile warnings.
+ *	  - Added header file #include <unistd.h> definition for getopt()
+ *	05/13/2003 Robbie Williamson (robbiew@us.ibm.com)
+ *	  Modified.
+ *	  - Rewrote the test to be able to execute on large memory machines.
+ *
+ */
+
+#include <sys/types.h>
+#include <sys/sysinfo.h>
+#include <sys/wait.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "test.h"
+
+#define FIVE_HUNDRED_MB (unsigned long long)(500*1024*1024)
+#define ONE_GB	(unsigned long long)(1024*1024*1024)
+#define THREE_GB (unsigned long long)(3*ONE_GB)
+
+char *TCID = "mtest01";
+int TST_TOTAL = 1;
+static sig_atomic_t pid_count;
+static sig_atomic_t sigchld_count;
+
+static void handler(int signo)
+{
+	if (signo == SIGCHLD)
+		sigchld_count++;
+	pid_count++;
+}
+
+int main(int argc, char *argv[])
+{
+	int c;
+	char *mem;
+	float percent;
+	unsigned int maxpercent = 0, dowrite = 0, verbose = 0, j;
+	unsigned long bytecount, alloc_bytes, max_pids;
+	unsigned long long original_maxbytes, maxbytes = 0;
+	unsigned long long pre_mem = 0, post_mem = 0;
+	unsigned long long total_ram, total_free, D, C;
+	int chunksize = 1024 * 1024;	/* one meg at a time by default */
+	struct sysinfo sstats;
+	int i, pid_cntr;
+	pid_t pid, *pid_list;
+	struct sigaction act;
+
+	act.sa_handler = handler;
+	act.sa_flags = 0;
+	sigemptyset(&act.sa_mask);
+	sigaction(SIGRTMIN, &act, 0);
+	sigaction(SIGCHLD, &act, 0);
+
+	while ((c = getopt(argc, argv, "c:b:p:wvh")) != -1) {
+		switch (c) {
+		case 'c':
+			chunksize = atoi(optarg);
+			break;
+		case 'b':
+			if (maxpercent != 0)
+				tst_brkm(TBROK, NULL,
+					 "ERROR: -b option cannot be used with -p "
+					 "option at the same time");
+			maxbytes = atoll(optarg);
+			break;
+		case 'p':
+			if (maxbytes != 0)
+				tst_brkm(TBROK, NULL,
+					 "ERROR: -p option cannot be used with -b "
+					 "option at the same time");
+			maxpercent = atoi(optarg);
+			if (maxpercent <= 0)
+				tst_brkm(TBROK, NULL,
+					 "ERROR: -p option requires number greater "
+					 "than 0");
+			if (maxpercent > 99)
+				tst_brkm(TBROK, NULL,
+					 "ERROR: -p option cannot be greater than "
+					 "99");
+			break;
+		case 'w':
+			dowrite = 1;
+			break;
+		case 'v':
+			verbose = 1;
+			break;
+		case 'h':
+		default:
+			printf
+			    ("usage: %s [-c <bytes>] [-b <bytes>|-p <percent>] [-v]\n",
+			     argv[0]);
+			printf
+			    ("\t-c <num>\tsize of chunk in bytes to malloc on each pass\n");
+			printf
+			    ("\t-b <bytes>\tmaximum number of bytes to allocate before stopping\n");
+			printf
+			    ("\t-p <bytes>\tpercent of total memory used at which the program stops\n");
+			printf
+			    ("\t-w\t\twrite to the memory after allocating\n");
+			printf("\t-v\t\tverbose\n");
+			printf("\t-h\t\tdisplay usage\n");
+			exit(1);
+		}
+	}
+
+	sysinfo(&sstats);
+	total_ram = sstats.totalram + sstats.totalswap;
+	total_free = sstats.freeram + sstats.freeswap;
+	/* Total Free Pre-Test RAM */
+	pre_mem = sstats.mem_unit * total_free;
+	max_pids = total_ram / (unsigned long)FIVE_HUNDRED_MB + 1;
+
+	if ((pid_list = malloc(max_pids * sizeof(pid_t))) == NULL)
+		tst_brkm(TBROK | TERRNO, NULL, "malloc failed.");
+	memset(pid_list, 0, max_pids * sizeof(pid_t));
+
+	/* Currently used memory */
+	C = sstats.mem_unit * (total_ram - total_free);
+	tst_resm(TINFO, "Total memory already used on system = %llu kbytes",
+		 C / 1024);
+
+	if (maxpercent) {
+		percent = (float)maxpercent / 100.00;
+
+		/* Desired memory needed to reach maxpercent */
+		D = percent * (sstats.mem_unit * total_ram);
+		tst_resm(TINFO,
+			 "Total memory used needed to reach maximum = %llu kbytes",
+			 D / 1024);
+
+		/* Are we already using more than maxpercent? */
+		if (C > D) {
+			tst_resm(TFAIL,
+				 "More memory than the maximum amount you specified "
+				 " is already being used");
+			free(pid_list);
+			tst_exit();
+		}
+
+		/* set maxbytes to the extra amount we want to allocate */
+		maxbytes = D - C;
+		tst_resm(TINFO, "Filling up %d%% of ram which is %llu kbytes",
+			 maxpercent, maxbytes / 1024);
+	}
+	original_maxbytes = maxbytes;
+	i = 0;
+	pid_cntr = 0;
+	pid = fork();
+	if (pid != 0)
+		pid_cntr++;
+	pid_list[i] = pid;
+
+#if defined (_s390_)		/* s390's 31bit addressing requires smaller chunks */
+	while (pid != 0 && maxbytes > FIVE_HUNDRED_MB) {
+		i++;
+		maxbytes -= FIVE_HUNDRED_MB;
+		pid = fork();
+		if (pid != 0) {
+			pid_cntr++;
+			pid_list[i] = pid;
+		}
+	}
+	if (maxbytes > FIVE_HUNDRED_MB)
+		alloc_bytes = FIVE_HUNDRED_MB;
+	else
+		alloc_bytes = (unsigned long)maxbytes;
+
+#elif __WORDSIZE == 32
+	while (pid != 0 && maxbytes > ONE_GB) {
+		i++;
+		maxbytes -= ONE_GB;
+		pid = fork();
+		if (pid != 0) {
+			pid_cntr++;
+			pid_list[i] = pid;
+		}
+	}
+	if (maxbytes > ONE_GB)
+		alloc_bytes = ONE_GB;
+	else
+		alloc_bytes = (unsigned long)maxbytes;
+
+#elif __WORDSIZE == 64
+	while (pid != 0 && maxbytes > THREE_GB) {
+		i++;
+		maxbytes -= THREE_GB;
+		pid = fork();
+		if (pid != 0) {
+			pid_cntr++;
+			pid_list[i] = pid;
+		}
+	}
+	if (maxbytes > THREE_GB)
+		alloc_bytes = THREE_GB;
+	else
+		alloc_bytes = maxbytes;
+#endif
+
+	if (pid == 0) {
+		bytecount = chunksize;
+		while (1) {
+			if ((mem = malloc(chunksize)) == NULL) {
+				tst_resm(TBROK | TERRNO,
+					 "stopped at %lu bytes", bytecount);
+				free(pid_list);
+				tst_exit();
+			}
+			if (dowrite)
+				for (j = 0; j < chunksize; j++)
+					*(mem + j) = 'a';
+			if (verbose)
+				tst_resm(TINFO,
+					 "allocated %lu bytes chunksize is %d",
+					 bytecount, chunksize);
+			bytecount += chunksize;
+			if (alloc_bytes && bytecount >= alloc_bytes)
+				break;
+		}
+		if (dowrite)
+			tst_resm(TINFO, "... %lu bytes allocated and used.",
+				 bytecount);
+		else
+			tst_resm(TINFO, "... %lu bytes allocated only.",
+				 bytecount);
+		kill(getppid(), SIGRTMIN);
+		while (1)
+			sleep(1);
+	} else {
+		i = 0;
+		sysinfo(&sstats);
+
+		if (dowrite) {
+			/* Total Free Post-Test RAM */
+			post_mem =
+			    (unsigned long long)sstats.mem_unit *
+			    sstats.freeram;
+			post_mem =
+			    post_mem +
+			    (unsigned long long)sstats.mem_unit *
+			    sstats.freeswap;
+
+			while ((((unsigned long long)pre_mem - post_mem) <
+				(unsigned long long)original_maxbytes) &&
+			       pid_count < pid_cntr && !sigchld_count) {
+				sleep(1);
+				sysinfo(&sstats);
+				post_mem =
+				    (unsigned long long)sstats.mem_unit *
+				    sstats.freeram;
+				post_mem =
+				    post_mem +
+				    (unsigned long long)sstats.mem_unit *
+				    sstats.freeswap;
+			}
+		}
+
+		if (sigchld_count) {
+			tst_resm(TFAIL, "child process exited unexpectedly");
+		} else if (dowrite) {
+			tst_resm(TPASS, "%llu kbytes allocated and used.",
+				 original_maxbytes / 1024);
+		} else {
+			tst_resm(TPASS, "%llu kbytes allocated only.",
+				 original_maxbytes / 1024);
+		}
+
+		while (pid_list[i] != 0) {
+			kill(pid_list[i], SIGKILL);
+			i++;
+		}
+	}
+	free(pid_list);
+	tst_exit();
+}

--- a/distribution/ltp/lite/patches/20150903/proc01_ignore_bus_usb.patch
+++ b/distribution/ltp/lite/patches/20150903/proc01_ignore_bus_usb.patch
@@ -1,0 +1,43 @@
+diff --git a/testcases/kernel/fs/proc/proc01.c b/testcases/kernel/fs/proc/proc01.c
+index f513110..39c4d8d 100644
+--- a/testcases/kernel/fs/proc/proc01.c
++++ b/testcases/kernel/fs/proc/proc01.c
+@@ -138,6 +138,7 @@ static const char lsm_should_work[][PATH_MAX] = {
+    the test while being read. */
+ static const char error_nonblock[][PATH_MAX] = {
+ 	"/proc/xen/xenbus",
++	"/proc/bus/usb",
+ 	""
+ };
+ 
+@@ -243,6 +244,15 @@ static long readproc(const char *obj)
+ 	static char buf[MAX_BUFF_SIZE];	/* static kills reentrancy, but we don't care about the contents */
+ 	unsigned long long file_total_read = 0;
+ 
++	/* Skip files does not honor O_NONBLOCK. */
++	for (i = 0; error_nonblock[i][0] != '\0'; i++) {
++		if (!strcmp(obj, error_nonblock[i])) {
++			tst_resm(TINFO, "%s: does not honor "
++					"O_NONBLOCK", obj);
++			return 0;
++		}
++	}
++
+ 	/* Determine the file type */
+ 	if (lstat(obj, &statbuf) < 0) {
+ 
+@@ -361,14 +371,6 @@ static long readproc(const char *obj)
+ 			return 0;
+ 		}
+ 
+-		/* Skip files does not honor O_NONBLOCK. */
+-		for (i = 0; error_nonblock[i][0] != '\0'; i++) {
+-			if (!strcmp(obj, error_nonblock[i])) {
+-				tst_resm(TINFO, "%s: does not honor "
+-					 "O_NONBLOCK", obj);
+-				return 0;
+-			}
+-		}
+ 
+ 		file_total_read = 0;
+ 		do {

--- a/distribution/ltp/lite/patches/20150903/syslog01
+++ b/distribution/ltp/lite/patches/20150903/syslog01
@@ -1,0 +1,130 @@
+#! /bin/sh -x
+
+#  Copyright (c) International Business Machines  Corp., 2002
+#
+#  This program is free software;  you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY;  without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+#  the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program;  if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+#  02/05/03  Modified - Manoj Iyer <manjo@mail.utexas.edu> use USCTEST macros
+#			fixed bugs.
+#  07/26/05  Michael Reed  <mreedltp@vnet.ibm.com>
+#			Made changes to account for the replacement of syslogd
+#			with syslog-ng
+#
+##################################################################
+# case1: Test whether messages are logged to the specified file  #
+# in the configuration file.					 #
+#								 #
+# Send messages to syslogd at some level and facility	 	 #
+# and grep for those messages.					 #
+#								 #
+# syslog.conf should contain:					 #
+# *.crit		/usr/adm/critical			 #
+# mail.info		/usr/spool/adm/syslog			 #
+##################################################################
+
+. syslog-lib.sh || exit 1
+
+syslog_case1()
+{
+	date "+%s.%N"
+
+	tst_resm TINFO "testing whether messages are logged into log file"
+
+	# Create the configuration file specific to this test case.
+
+	case "$CONFIG_FILE" in
+	/etc/syslog.conf|/etc/rsyslog.conf)
+		echo "$RSYSLOG_CONFIG" > $CONFIG_FILE
+		echo "*.*		/var/log/messages" >> $CONFIG_FILE
+		echo "mail.info	$MAILLOG" >> $CONFIG_FILE
+		;;
+
+	/etc/syslog-ng/syslog-ng.conf)
+		echo "source src{ internal(); unix-dgram(\"/dev/log\"); \
+		      udp(ip(\"0.0.0.0\") port(514)); };" > $CONFIG_FILE
+		echo " " >> $CONFIG_FILE
+		echo " " >> $CONFIG_FILE
+		echo "# Added for syslog testcase"  >> $CONFIG_FILE
+		echo "filter f_syslog	 { level(crit);};" >> $CONFIG_FILE
+		echo "filter f_syslogMail { level(info)	and facility(mail); };" >> $CONFIG_FILE
+		echo "destination syslog-messages { file(\"/var/log/messages\");};" >> $CONFIG_FILE
+		echo "log { source(src); filter(f_syslog); destination(syslog-messages); };" >> $CONFIG_FILE
+		echo "destination syslog-mail { file(\"$MAILLOG\");};" >> $CONFIG_FILE
+		echo "log { source(src); filter(f_syslogMail); destination(syslog-mail); };"  >> $CONFIG_FILE
+		;;
+	esac
+
+	date "+%s.%N"
+	stat /var/lib/rsyslog/imjournal.state
+	ls -la /var/lib/rsyslog/
+	restart_syslog_daemon
+	date "+%s.%N"
+	stat /var/lib/rsyslog/imjournal.state
+	ls -la /var/lib/rsyslog/
+	sleep 2
+
+	# Grepping pattern has to be changed whenever the executable name
+	# changes, ex: syslogtst executable.
+	# This check is neccessary for syslog-ng because $MAILLOG is
+	# only created after syslogtst
+	if [ -e "$MAILLOG" ]; then
+		oldvalue1=`grep -c "syslogtst: mail info test" $MAILLOG`
+	else
+		oldvalue1=0
+	fi
+
+	date "+%s.%N"
+	# Call syslogtst executable with case number as argument
+	if syslogtst 1 2>/dev/null; then
+
+		date "+%s.%N"
+		sleep 5
+		date "+%s.%N"
+
+		if [ ! -e $MAILLOG ]; then
+			tst_resm TBROK "$MAILLOG no such log file"
+			cleanup 1
+		fi
+		date "+%s.%N"
+
+		newvalue1=`grep -c "syslogtst: mail info test" $MAILLOG`
+		if [ "x$(( $newvalue1 - $oldvalue1 ))" != "x1" ]; then
+			status_flag=1
+			tail -15 $MAILLOG
+			tail -15 /var/log/messages
+			systemctl -l -n 100 status rsyslog
+			systemctl -l -n 100 status systemd-journald
+			stat /var/lib/rsyslog/imjournal.state
+			ls -la /var/lib/rsyslog/
+			journalctl | tail -100
+		fi
+		date "+%s.%N"
+
+	else
+		status_flag=1
+	fi
+
+}
+
+export TST_TOTAL=1
+export TST_COUNT=1
+export TCID=syslog01
+
+tst_resm TINFO "Send messages to syslogd at some level "
+tst_resm TINFO "and facility and grep for those messages."
+
+setup
+syslog_case1
+cleanup ${status_flag:=0}

--- a/distribution/ltp/lite/patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch
+++ b/distribution/ltp/lite/patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/tst_timer_test.c b/lib/tst_timer_test.c
+index cd4ebcaa89e0..c08b7cadb385 100644
+--- a/lib/tst_timer_test.c
++++ b/lib/tst_timer_test.c
+@@ -194,7 +194,7 @@ static int cmp(const void *a, const void *b)
+ static long long compute_threshold(long long requested_us,
+ 				   unsigned int nsamples)
+ {
+-	unsigned int slack_per_scall = MIN(100000, requested_us / 1000);
++	unsigned int slack_per_scall = requested_us / 100;
+ 
+ 	slack_per_scall = MAX(slack_per_scall, timerslack);
+ 

--- a/distribution/ltp/lite/patches/oom_hang_workaround.patch
+++ b/distribution/ltp/lite/patches/oom_hang_workaround.patch
@@ -1,0 +1,37 @@
+diff --git a/testcases/kernel/mem/lib/mem.c b/testcases/kernel/mem/lib/mem.c
+index 118b6c0..b4b1349 100644
+--- a/testcases/kernel/mem/lib/mem.c
++++ b/testcases/kernel/mem/lib/mem.c
+@@ -4,6 +4,7 @@
+ #include <sys/mount.h>
+ #include <sys/stat.h>
+ #include <sys/wait.h>
++#include <sys/sysinfo.h>
+ #include <errno.h>
+ #include <fcntl.h>
+ #if HAVE_NUMA_H
+@@ -120,12 +121,24 @@ void oom(int testcase, int lite, int retcode, int allow_sigkill)
+ {
+ 	pid_t pid;
+ 	int status, threads;
++	struct sysinfo sstats;
++
++	TEST(sysinfo(&sstats));
++	if (TEST_RETURN)
++		tst_brkm(TBROK | TTERRNO, NULL, "sysinfo");
++
+ 
+ 	switch (pid = fork()) {
+ 	case -1:
+ 		tst_brkm(TBROK | TERRNO, cleanup, "fork");
+ 	case 0:
+ 		threads = MAX(1, tst_ncpus() - 1);
++		if ((sstats.totalram / 1024) * sstats.mem_unit < 64UL * 1024 * 1024) {
++			tst_resm(TINFO, "Less than 64G RAM, use single thread");
++			tst_resm(TINFO, "ltp/oom1 cause the system hang");
++			threads = 1;
++		}
++
+ 		child_alloc(testcase, lite, threads);
+ 	default:
+ 		break;

--- a/distribution/ltp/lite/patches/oom_hang_workaround2.patch
+++ b/distribution/ltp/lite/patches/oom_hang_workaround2.patch
@@ -1,0 +1,34 @@
+diff --git a/testcases/kernel/mem/lib/mem.c b/testcases/kernel/mem/lib/mem.c
+index dd82b08..82492c0 100644
+--- a/testcases/kernel/mem/lib/mem.c
++++ b/testcases/kernel/mem/lib/mem.c
+@@ -6,6 +6,7 @@
+ #include <sys/mount.h>
+ #include <sys/stat.h>
+ #include <sys/wait.h>
++#include <sys/sysinfo.h>
+ #include <sys/param.h>
+ #include <errno.h>
+ #include <fcntl.h>
+@@ -127,9 +128,21 @@ void oom(int testcase, int lite, int retcode, int allow_sigkill)
+ 	pid_t pid;
+ 	int status, threads;
+ 
++	struct sysinfo sstats;
++
++	TEST(sysinfo(&sstats));
++	if (TEST_RETURN)
++		tst_brk(TBROK | TTERRNO, "sysinfo");
++
+ 	switch (pid = SAFE_FORK()) {
+ 	case 0:
+ 		threads = MAX(1, tst_ncpus() - 1);
++		if ((sstats.totalram / 1024) * sstats.mem_unit < 64UL * 1024 * 1024) {
++			tst_res(TINFO, "Less than 64G RAM, use single thread");
++			tst_res(TINFO, "ltp/oom1 cause the system hang");
++			threads = 1;
++		}
++
+ 		child_alloc(testcase, lite, threads);
+ 	default:
+ 		break;

--- a/distribution/ltp/lite/runtest.sh
+++ b/distribution/ltp/lite/runtest.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+
+. /usr/bin/rhts-environment.sh
+. ../include/runtest.sh
+. ../include/knownissue.sh
+
+#export AVC_ERROR=+no_avc_check
+#export RHTS_OPTION_STRONGER_AVC=
+
+core_pattern="$(cat /proc/sys/kernel/core_pattern)"
+core_pattern_ltp_dir="/mnt/testarea/ltp/cores"
+
+# prepare_aiodio_scratchspace
+# exports:
+#   SCRATCH_MNT
+#   BIG_FILE
+#   BUF_ALIGN
+function prepare_aiodio_scratchspace()
+{
+	export SCRATCH_MNT=/mnt/scratchspace
+	echo "Preparing scratchspace at: $SCRATCH_MNT" | tee -a $OUTPUTFILE
+	if [ ! -e $SCRATCH_MNT ]; then
+		echo "Creating $SCRATCH_MNT"           | tee -a $OUTPUTFILE
+		mkdir $SCRATCH_MNT
+	fi
+
+	mkdir -p $SCRATCH_MNT/aiodio/junkdir
+	export BIG_FILE="$SCRATCH_MNT/bigfile"
+
+	block_size=0
+	mntpoint=`df "$SCRATCH_MNT" | tail -n +2 | head -1`
+	if [ -n "$mntpoint" ]; then
+		block_size=`blockdev --getbsz $mntpoint`
+		echo "$SCRATCH_MNT's mount point is: $mntpoint" | tee -a $OUTPUTFILE
+		echo "$mntpoint's block size is: $block_size"   | tee -a $OUTPUTFILE
+	fi
+	if [ "$block_size" -ge 512 ]; then
+		export BUF_ALIGN=$block_size
+	else
+		export BUF_ALIGN=4096
+	fi
+
+	echo "SCRATCH_MNT: $SCRATCH_MNT" | tee -a $OUTPUTFILE
+	echo "BIG_FILE:    $BIG_FILE"    | tee -a $OUTPUTFILE
+	echo "BUF_ALIGN:   $BUF_ALIGN"   | tee -a $OUTPUTFILE
+}
+
+function clean_aiodio_scratchspace()
+{
+	rm -rf $SCRATCH_MNT/aiodio
+}
+
+function tolerate_s390_high_steal_time()
+{
+	local runtest=$1
+
+	uname -m | grep -q s390
+	if [ $? -ne 0 ]; then
+		return
+	fi
+
+	sed -i 's/nanosleep01 nanosleep01/nanosleep01 timeout 300 sh -c "nanosleep01 || true"/' "$runtest"
+	sed -i 's/clock_nanosleep01 clock_nanosleep01/clock_nanosleep01 timeout 300 sh -c "clock_nanosleep01 || true"/' "$runtest"
+	sed -i 's/clock_nanosleep02 clock_nanosleep02/clock_nanosleep02 timeout 300 sh -c "clock_nanosleep02 || true"/' "$runtest"
+	sed -i 's/futex_wait_bitset01 futex_wait_bitset01/futex_wait_bitset01 timeout 30 sh -c "futex_wait_bitset01 || true"/' "$runtest"
+	sed -i 's/futex_wait05 futex_wait05/futex_wait05 timeout 30 sh -c "futex_wait05 || true"/' "$runtest"
+	sed -i 's/epoll_pwait01 epoll_pwait01/epoll_pwait01 timeout 30 sh -c "epoll_pwait01 || true"/' "$runtest"
+	sed -i 's/poll02 poll02/poll02 timeout 30 sh -c "poll02 || true"/' "$runtest"
+	sed -i 's/pselect01 pselect01/pselect01 timeout 30 sh -c "pselect01 || true"/' "$runtest"
+	sed -i 's/pselect01_64 pselect01_64/pselect01_64 timeout 30 sh -c "pselect01_64 || true"/' "$runtest"
+	sed -i 's/select04 select04/select04 timeout 30 sh -c "select04 || true"/' "$runtest"
+}
+
+function exclude_disruptive_for_kt1()
+{
+	local runtest=$1
+
+	if is_rhel7; then
+		if [ "$osver" -le 705 ]; then
+			# ltp/oom1 cause the system hang
+			sed -i 's/oom01 oom01/#DISABLED oom01 oom01/' "$runtest"
+			sed -i 's/oom02 oom02/#DISABLED oom02 oom02/' "$runtest"
+
+			# OOM sporadically triggers when process tries to malloc and dirty 80% of RAM+swap
+			sed -i 's/mtest01w mtest01 -p80 -w/mtest01w sh -c "mtest01 -p80 -w || true"/' "$runtest"
+		fi
+	fi
+}
+
+function runtest_prepare()
+{
+	t="RHELKT1LITE.FILTERED"
+	cp -f RHELKT1LITE "$t"
+
+	case $SKIP_LEVEL in
+	   "0")
+		knownissue_exclude  "none"  "$t"
+		;;
+	   "1")
+		knownissue_exclude  "fatal" "$t"
+		;;
+	     *)
+		# skip all the issues by default
+		knownissue_exclude  "all"   "$t"
+		;;
+	esac
+
+	tolerate_s390_high_steal_time "$t"
+
+	exclude_disruptive_for_kt1 "$t"
+
+	cp -fv "$t" $LTPDIR/runtest/
+}
+
+function ltp_lite_begin()
+{
+	# disable NTP and chronyd
+	tservice=""
+	pgrep chronyd > /dev/null
+	if [ $? -eq 0 ]; then
+		tservice="chronyd"
+		service chronyd stop
+	fi
+	DisableNTP
+
+	# make sure there's enough entropy for getrandom tests
+	rngd -r /dev/urandom
+
+	prepare_aiodio_scratchspace
+
+	runtest_prepare
+
+	echo "ulimit -c unlimited" | tee -a $OUTPUTFILE
+	ulimit -c unlimited
+	mkdir -p $core_pattern_ltp_dir
+	echo "$core_pattern_ltp_dir/core" > /proc/sys/kernel/core_pattern
+	echo 1 > /proc/sys/kernel/core_uses_pid
+
+	echo "numactl --hardware" | tee -a $OUTPUTFILE
+	echo "-----" | tee -a $OUTPUTFILE
+	numactl --hardware >> ./numactl.txt 2>&1
+	cat ./numactl.txt | tee -a $OUTPUTFILE
+	echo "-----" | tee -a $OUTPUTFILE
+
+	echo "Using config file: $t" | tee -a $OUTPUTFILE
+	ss -antup >> $OUTPUTFILE 2>&1
+
+	cp -f $OUTPUTFILE ./setup.txt
+	SubmitLog ./setup.txt
+}
+
+ltp_lite_run()
+{
+	RunFiltTest && return
+
+	rm -f /mnt/testarea/$t.*
+	rm -f /mnt/testarea/ltp/output/*
+	CleanUp $t
+
+	OUTPUTFILE=`mktemp /tmp/tmp.XXXXXX`
+	service cgconfig stop
+
+	RunTest $t
+}
+
+ltp_lite_end()
+{
+	echo "$core_pattern" > /proc/sys/kernel/core_pattern
+
+	clean_aiodio_scratchspace
+
+	# restore either NTP or chronyd
+	if [ -n "$tservice" ]; then
+		service chronyd start
+	else
+		EnableNTP
+	fi
+
+	./grab_corefiles.sh >> $DEBUGLOG 2>&1
+	SubmitLog $DEBUGLOG
+}
+
+# ---------- Start Test -------------
+if [ "${REBOOTCOUNT}" -ge 1 ]; then
+	echo "===== Test has already been run,
+	Check logs for possible failures ======"
+	report_result CHECKLOGS FAIL 99
+	exit 0
+fi
+
+# report patch errors from ltp/include
+grep -i -e "FAIL" -e "ERROR" patchinc.log > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+	report_result "ltp-include-patch-errors" "WARN"
+fi
+
+# Sometimes it takes too long to waiting for syscalls
+# finish and I want to know whether the compilation is
+# finish or not.
+report_result "install" "PASS"
+
+ltp_lite_begin
+
+ltp_lite_run
+
+ltp_lite_end
+
+exit 0

--- a/distribution/ltp/lite/timeout.my
+++ b/distribution/ltp/lite/timeout.my
@@ -1,0 +1,5 @@
+#!/bin/sh
+time=$1
+shift
+perl -e "alarm $time; exec @ARGV" "$@"
+


### PR DESCRIPTION
hi @veruu  I have included the latest version and should be properly scrubbed of any internal references, please let me know if further changes are required, thanks!

```
# git clone https://github.com/rasibley/tests-beaker
Cloning into 'tests-beaker'...
remote: Counting objects: 212, done.
remote: Compressing objects: 100% (156/156), done.
remote: Total 212 (delta 27), reused 189 (delta 26), pack-reused 20
Receiving objects: 100% (212/212), 189.89 KiB | 0 bytes/s, done.
Resolving deltas: 100% (29/29), done.

# make run
============ Download package ============
        if [ $? -ne 0 ]; then \
                echo "global sync seems not working correctly, using upstream location" ;\
                wget https://github.com/linux-test-project/ltp/releases/download/20180515/ltp-full-20180515.tar.bz2 -O ltp-full-20180515.bz2 ;\
        fi
rm -f *~ testinfo.desc
rm -rf ltp-full-20180515
rm -rf m4-1.4.16
rm -rf autoconf-2.69
rm -rf *.rpm
============ Unzip package ============
tar xjf ltp-full-20180515.bz2
make --ignore-errors patch-inc > patchinc.log 2>&1
cat patchinc.log
make[1]: Entering directory `/root/tests-beaker/distribution/ltp/lite'
============ Critical Patch ============
patching file runtest/crashme
============ General Patch ============
 === applying general upstream fixes. ===
 === applying general internal fixes. ===
patching file testcases/cve/cve-2017-5669.c
patching file testcases/open_posix_testsuite/conformance/interfaces/pthread_cancel/3-1.c
patching file testcases/open_posix_testsuite/include/posixtest.h
patching file testcases/cve/meltdown.c
 - cron_tests.sh has been rewritten since ltp-20170516
 - fix crashme testcase on systems with NX flag.
patch -p1 -d ltp-full-20180515 < ../include/patches/INTERNAL/rhel-scrashme-remove-f00f-test-on-system-with-NX-bit.patch
patching file runtest/crashme
make[1]: Leaving directory `/root/tests-beaker/distribution/ltp/lite'
============ Patch ltp-lite test suite. ============
patch -d ltp-full-20180515 -p1 < patches/20150903/proc01_ignore_bus_usb.patch
patching file testcases/kernel/fs/proc/proc01.c
Hunk #1 succeeded at 142 (offset 4 lines).
Hunk #2 succeeded at 248 (offset 4 lines).
Hunk #3 succeeded at 375 (offset 4 lines).
if ! ./is_baremetal.sh; then patch -d ltp-full-20180515 -p1 < patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch; fi
+ uname -m
+ grep s390
+ hostname
+ grep guest

....<snip>

INFO: ltp-pan reported all tests PASS
LTP Version: 20180515

       ###############################################################

            Done executing testcases.
            LTP Version:  20180515
       ###############################################################

real 1506.23
user 622.77
sys 611.20
RHELKT1LITE.FILTERED Passed: 
```
