### PR TITLE
ltp - report pass with corefiles

### DIFF
--- a/distribution/ltp/lite/grab_corefiles.sh
+++ b/distribution/ltp/lite/grab_corefiles.sh
@@ -25,7 +25,7 @@ echo "List of files to pack: $bin_core_list"
 if [ -n "$bin_core_list" ]; then
     tar cfvz binaries_and_corefiles.tar.gz $bin_core_list
     rhts_submit_log -l binaries_and_corefiles.tar.gz
-    report_result unexpected_corefile_found WARN 1
+    report_result unexpected_corefile_found PASS 0
 else
     echo "No cores to submit"
 fi


### PR DESCRIPTION
The core files may be dumped because of a problem in kernel, but also
because of a completely unrelated one. Because of the later, we don't
want to report a warning to the developer if a core file is found but
all the tests passed.

Changing only the reported result but keeping the core files in the job
allows for debugging / reporting a problem to unrelated component if
it's needed.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>