### PR TITLE
Increase the threshold for timing tests on VMs

### DIFF
--- a/distribution/ltp/lite/patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch
+++ b/distribution/ltp/lite/patches/ltp-include-relax-timer-thresholds-for-non-baremetal.patch
@@ -7,7 +7,7 @@ index cd4ebcaa89e0..c08b7cadb385 100644
  				   unsigned int nsamples)
  {
 -	unsigned int slack_per_scall = MIN(100000, requested_us / 1000);
-+	unsigned int slack_per_scall = requested_us / 100;
++	unsigned int slack_per_scall = requested_us / 50;
  
  	slack_per_scall = MAX(slack_per_scall, timerslack);
  


### PR DESCRIPTION
They often fail with "XXX slept too long". We still want to run these
test to make sure the functionality is OK, so let's try to increase the
time they can take. One of the possible causes why the old thresholds
are not enough anymore are the Spectre/Meltdown patches, since the
number of times these tests started failing increased significantly
after the mitigations were applied.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>