### PR TITLE
Restore new-kernel-pkg

### DIFF
--- a/distribution/kpkginstall/new-kernel-pkg
+++ b/distribution/kpkginstall/new-kernel-pkg
@@ -1,0 +1,931 @@
+#!/bin/bash
+#
+# new-kernel-pkg
+# Invoked upon installation or removal of a kernel package, the following
+# tasks are/can be done here:
+# creation/removal of initrd
+# run of depmod/removal of depmod generated files
+# addition/removal of kernel images from grub/lilo configuration (via grubby)
+#
+# Copyright 2002-2008 Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+PATH=/sbin:/bin:$PATH
+
+lilo=/sbin/lilo
+
+# some defaults that are sane for most arches
+kernelName=vmlinuz
+
+if [ -x ./grubby ]; then
+    grubby=./grubby
+else
+    grubby=/sbin/grubby
+fi
+
+[ -f /etc/sysconfig/kernel ] && . /etc/sysconfig/kernel
+[ -f /etc/sysconfig/uboot ] && . /etc/sysconfig/uboot
+
+cfgGrub2=""
+cfgGrub2Efi=""
+cfgGrub=""
+cfgLilo=""
+cfgExtlinux=""
+cfguBoot=""
+runLilo=""
+grubConfig=""
+grub2Config=""
+grub2EfiConfig=""
+extlinuxConfig=""
+ubootScript="/boot/boot.scr"
+
+ARCH=$(uname -m)
+
+if [ $ARCH = 'ia64' ]; then
+    liloConfig=/boot/efi/EFI/redhat/elilo.conf
+    bootPrefix=/boot/efi/EFI/redhat
+    liloFlag=elilo
+    isx86=""
+elif [ $ARCH = 'ppc64' -o $ARCH = 'ppc' ]; then
+    liloConfig=/etc/yaboot.conf
+    grub2Config=$(readlink -f /etc/grub2.cfg 2>/dev/null)
+    bootPrefix=/boot
+    lilo=/sbin/ybin
+    liloFlag=yaboot
+    runLilo="yes"
+    isx86=""
+elif [ $ARCH = 'sparc' -o $ARCH = 'sparc64' ]; then
+    liloConfig=/etc/silo.conf
+    bootPrefix=/boot
+    liloFlag=silo
+    lilo=/sbin/silo
+    isx86=""
+elif [ $ARCH = 's390' -o $ARCH = 's390x' ]; then
+    liloConfig=/etc/zipl.conf
+    bootPrefix=/boot
+    liloFlag=zipl
+    lilo=/sbin/zipl
+    runLilo="yes"
+    isx86=""
+elif [[ ${ARCH} =~ armv[5|7].*l ]] ; then
+    liloConfig=""
+    bootPrefix=/boot
+    extlinuxConfig=$(readlink -f /etc/extlinux.conf 2>/dev/null)
+    ubootDir=${UBOOT_DIR:-"/boot"}
+    ubootScript=$ubootDir/${UBOOT_SCR:-"boot.scr"}
+    ubootKList=${UBOOT_KLIST:-"klist.txt"}
+    ubootDevice=/dev/${UBOOT_DEVICE:-"mmcblk0p1"}
+    ubootDefaultImage=${UBOOT_UIMAGE:-"uImage"}
+    ubootDefaultInitrd=${UBOOT_UINITRD:-"uInitrd"}
+    ubootAddress=${UBOOT_IMGADDR:-"0x00008000"}
+    mounted=""
+    liloFlag=""
+    isx86=""
+else
+    # this leaves i?86 and x86_64
+    liloConfig=/etc/lilo.conf
+    grubConfig=$(readlink -f /etc/grub.conf 2>/dev/null)
+    grub2Config=$(readlink -f /etc/grub2.cfg 2>/dev/null)
+    grub2EfiConfig=$(readlink -f /etc/grub2-efi.cfg 2>/dev/null)
+    extlinuxConfig=$(readlink -f /etc/extlinux.conf 2>/dev/null)
+    bootPrefix=/boot
+    liloFlag=lilo
+    isx86="yes"
+fi
+
+mode=""
+version=""
+initrd=""
+dracut=""
+dracuthostonly=""
+initrdfile=""
+devtreefile=""
+moddep=""
+verbose=""
+makedefault=""
+package=""
+mbkernel="$HYPERVISOR"
+mbargs="$HYPERVISOR_ARGS"
+adddracutargs=""
+addplymouthinitrd=""
+DEBUGARG="systemd.log_level=debug systemd.log_target=kmsg"
+
+usage() {
+    echo "Usage: `basename $0` [-v] [--mkinitrd] [--rminitrd] [--dracut]" >&2
+    echo "       [--initrdfile=<initrd-image>] [--depmod] [--rmmoddep]" >&2
+    echo "       [--kernel-args=<args>] [--remove-args=<args>]" >&2
+    echo "       [--banner=<banner>] [--multiboot=multiboot]" >&2
+    echo "       [--mbargs=mbargs] [--make-default] [--add-dracut-args]" >&2
+    echo "       [--add-plymouth-initrd]" >&2
+    echo "       [--host-only] [--devtree=<devicetree.dtb>] [--devtreedir=</devicetree/path/>]" >&2
+    echo "       <--install | --remove | --update | --rpmposttrans> <kernel-version>" >&2
+    echo "       (ex: `basename $0` --mkinitrd --depmod --install 2.4.7-2)" >&2
+    exit 1
+}
+
+rungrubby() {
+	if [ "$1" == "--debug" ]; then
+		[ "$MAKEDEBUG" != "yes" ] && return 0
+		[ -n "$verbose" ] && echo "- First, making a debug entry."
+		if [ $ARCH = 's390' -o $ARCH = 's390x' ]; then
+			declare -x debugtitle="_with_debugging"
+		else
+			declare -x debugtitle=" with debugging"
+		fi
+		declare -x debugargs="$DEBUGARG"
+		shift
+	else
+		[ -n "$verbose" ] && echo "- Making a normal entry."
+	fi
+	$(eval $grubby $@)
+	export -n debugargs
+	export -n debugtitle
+	unset debugargs
+	unset debugtitle
+}
+
+set_title() {
+    if [ -n "$banner" ]; then
+	if [ $ARCH = 's390' -o $ARCH = 's390x' ]; then
+	    title=$(echo $banner | sed 's/ /_/g')
+	else
+	    title="$banner ($version)"
+	fi
+    elif [ $ARCH = 's390' -o $ARCH = 's390x' ]; then
+	title=$(echo $version | sed 's/ /_/g')
+    elif [ -f /etc/os-release ]; then
+	. /etc/os-release
+	title="$NAME ($version) $VERSION"
+    elif [ -f /etc/redhat-release ]; then
+	title="$(sed 's/ release.*$//' < /etc/redhat-release) ($version)"
+    else
+	title="Red Hat Linux ($version)"
+    fi
+}
+
+install() {
+    # XXX kernel should be able to be specified also (or work right on ia64)
+    if [ ! -f $kernelImage ] ; then
+	[ -n "$verbose" ] && echo "kernel for $version does not exist, not running grubby"
+	return
+    fi
+
+    INITRD=""
+    if [ -f $initrdfile ]; then
+	[ -n "$verbose" ] && echo "found $initrdfile and using it with grubby"
+	INITRD="--initrd $initrdfile"
+
+	if [ -n "$addplymouthinitrd" ]; then
+	    INITRD="$INITRD --extra-initrd $bootPrefix/initrd-plymouth.img"
+	fi
+    fi
+
+    DEVTREE=""
+    if [ -n "$devtreefile" -a -f "$devtreefile" ]; then
+	[ -n "$verbose" ] && echo "found $devtreefile and using it with grubby"
+	DEVTREE="--devtree $devtreefile"
+    fi
+
+    DEVTREEDIR=""
+    if [ -n "$devtreedir" -a -d "$devtreedir" ]; then
+	[ -n "$verbose" ] && echo "found $devtreedir and using it with grubby"
+	DEVTREEDIR="--devtreedir $devtreedir"
+    fi
+
+    # FIXME: is this a good heuristic to find out if we're on iSeries?
+    if [ -d /proc/iSeries ]; then
+	[ -n "$verbose" ] && echo "On an iSeries, just making img file"
+	if [ -z $initrdfile  ]; then
+	    [ -n "$verbose" ] && echo "No initrd, just adding system map"
+	    /sbin/addSystemMap $bootPrefix/System.map-$version $kernelImage $bootPrefix/vmlinitrd-$version
+	else
+	    /sbin/addSystemMap $bootPrefix/System.map-$version $kernelImage $bootPrefix/vmlinux.sm-$version
+	    /sbin/addRamDisk $initrdfile $bootPrefix/System.map-$version $bootPrefix/vmlinux.sm-$version $bootPrefix/vmlinitrd-$version 2>/dev/null
+	    rm $bootPrefix/vmlinux.sm-$version
+	fi
+	return
+    fi
+
+    # get the root filesystem to use
+    rootdevice=$(awk '{ if ($1 !~ /^[ \t]*#/ && $2 == "/") { print $1; }}' /etc/fstab 2>/dev/null)
+    if [ "$rootdevice" = "" ];
+    then
+	    rootdevice=`grep -o -P "(?<=root=)\S+" /proc/cmdline`
+    fi
+
+    if [ -n "$mbkernel" -a -n "$cfgLilo" -a "$liloFlag" != "elilo" ]; then
+	[ -n "$verbose" ] && echo "multiboot specified, not updating lilo.conf"
+	cfgLilo=""
+    fi
+
+    set_title
+
+    if [ -n "$cfgGrub" ]; then
+	[ -n "$verbose" ] && echo "adding $version to $grubConfig"
+
+	ARGS="--grub -c $grubConfig --add-kernel=$kernelImage $INITRD \
+		${mbkernel:+--add-multiboot=\"$mbkernel\"} \
+		${mbargs:+--mbargs=\"$mbargs\"} \
+		--title=\"$title\$debugtitle\" --copy-default \
+		--args=\"root=$rootdevice $kernargs \$debugargs\" \
+		--remove-kernel=\"TITLE=$title\$debugtitle\""
+
+	rungrubby ${ARGS} $makedefault
+	rungrubby --debug ${ARGS} --set-index=1
+    else
+	[ -n "$verbose" ] && echo "$grubConfig does not exist, not running grubby for grub 0.97"
+    fi
+    if [ -n "$cfgGrub2" ]; then
+	[ -n "$verbose" ] && echo "adding $version to $grub2Config"
+
+	ARGS="--grub2 -c $grub2Config --add-kernel=$kernelImage $INITRD \
+		--copy-default --title \"$title\$debugtitle\" \
+		${mbkernel:+--add-multiboot=\"$mbkernel\"} \
+		${mbargs:+--mbargs=\"$mbargs\"} \
+		--args=\"root=$rootdevice $kernargs \$debugargs\" \
+		--remove-kernel=\"TITLE=$title\$debugtitle\""
+	rungrubby ${ARGS} $makedefault
+	rungrubby --debug ${ARGS} --set-index=1
+    else
+	[ -n "$verbose" ] && echo "$grub2Config does not exist, not running grubby for grub 2"
+    fi
+    if [ -n "$cfgGrub2Efi" ]; then
+	[ -n "$verbose" ] && echo "adding $version to $grub2EfiConfig"
+
+	ARGS="--grub2 -c $grub2EfiConfig --efi \
+		--add-kernel=$kernelImage $DEVTREE $INITRD \
+		--copy-default --title \"$title\$debugtitle\" \
+		${mbkernel:+--add-multiboot=\"$mbkernel\"} \
+		${mbargs:+--mbargs=\"$mbargs\"} \
+		--args=\"root=$rootdevice $kernargs \$debugargs\" \
+		--remove-kernel=\"TITLE=$title\$debugtitle\""
+	rungrubby ${ARGS} $makedefault
+	rungrubby --debug ${ARGS} --set-index=1
+    else
+	[ -n "$verbose" ] && echo "$grub2EfiConfig does not exist, not running grubby for grub 2 with UEFI"
+    fi
+
+    if [ -n "$cfgLilo" ]; then
+	[ -n "$verbose" ] && echo "adding $version to $liloConfig"
+
+	ARGS="--$liloFlag --add-kernel=$kernelImage $INITRD \
+		--copy-default --title \"$title\$debugtitle\" \
+		${mbkernel:+--add-multiboot=\"$mbkernel\"} \
+		${mbargs:+--mbargs=\"$mbargs\"} \
+		--args=\"root=$rootdevice $kernargs \$debugargs\" \
+		--remove-kernel=\"TITLE=$version\""
+
+	rungrubby ${ARGS} $makedefault
+	rungrubby --debug ${ARGS} --set-index=1
+	if [ -n "$runLilo" ]; then
+	    [ -n "$verbose" ] && echo "running $lilo"
+	    if [ ! -x $lilo ] ; then
+		[ -n "$verbose" ] && echo "$lilo does not exist"
+	    else
+		$lilo > /dev/null
+	    fi
+	fi
+    else
+	[ -n "$verbose" ] && echo "$liloConfig does not exist, not running grubby"
+    fi
+
+    if [ -n "$cfgExtlinux" ]; then
+	[ -n "$verbose" ] && echo "adding $version to $extlinuxConfig"
+
+	ARGS="--extlinux -c $extlinuxConfig --add-kernel=$kernelImage \
+	    $DEVTREEDIR $DEVTREE \
+	    $INITRD --copy-default --title \"$title\$debugtitle\" \
+	    ${mbkernel:+--add-multiboot=\"$mbkernel\"} \
+	    ${mbargs:+--mbargs=\"$mbargs\"} \
+	    --args=\"root=$rootdevice $kernargs \$debugargs\" \
+	    --remove-kernel=\"TITLE=$title\$debugtitle\""
+
+	rungrubby ${ARGS} $makedefault
+	rungrubby --debug ${ARGS} --set-index=1
+    else
+	[ -n "$verbose" ] && echo "$extlinuxConfig does not exist, not running grubby for extlinux"
+    fi
+}
+
+rpmposttrans()
+{
+    local files
+    local f
+    files="/etc/kernel/postinst.d/*[^~] /etc/kernel/postinst.d/$version/*[^~]"
+    for f in $files ; do
+	[ -f $f ] && [ -x $f ] || continue
+	$f $version $kernelImage
+    done
+}
+
+remove() {
+    # FIXME: is this a good heuristic to find out if we're on iSeries?
+    if [ -d /proc/iSeries ]; then
+	[ -n "$verbose" ] && echo "On an iSeries, remove img file"
+	rm -f $kernelImage.img 2>/dev/null
+	return
+    fi
+
+    local files
+    local f
+    files="/etc/kernel/prerm.d/*[^~] /etc/kernel/prerm.d/$version/*[^~]"
+    for f in $files ; do
+	[ -f $f ] && [ -x $f ] || continue
+	$f $version $kernelImage
+    done
+
+    if [ -n "$cfgGrub" ]; then
+	[ -n "$verbose" ] && echo "removing $version from $grubConfig"
+	$grubby --grub -c $grubConfig \
+	    --remove-kernel=$kernelImage
+    else
+	[ -n "$verbose" ] && echo "$grubConfig does not exist, not running grubby for grub 0.97"
+    fi
+    if [ -n "$cfgGrub2" ]; then
+	[ -n "$verbose" ] && echo "removing $version from $grub2Config"
+	$grubby --grub2 -c $grub2Config \
+		--remove-kernel=$kernelImage
+    else
+	[ -n "$verbose" ] && echo "$grub2Config does not exist, not running grubby for grub 2"
+    fi
+    if [ -n "$cfgGrub2Efi" ]; then
+	[ -n "$verbose" ] && echo "removing $version from $grub2EfiConfig"
+	$grubby --grub2 -c $grub2EfiConfig --efi \
+		--remove-kernel=$kernelImage
+    else
+	[ -n "$verbose" ] && echo "$grub2EfiConfig does not exist, not running grubby grub 2 with UEFI"
+    fi
+
+    if [ -n "$cfgLilo" ]; then
+	[ -n "$verbose" ] && echo "removing $version from $liloConfig"
+	$grubby --remove-kernel=$kernelImage	    \
+		     --$liloFlag
+
+	if [ -n "$runLilo" ]; then
+	    [ -n "$verbose" ] && echo "running $lilo"
+	    if [ ! -x $lilo ] ; then
+		[ -n "$verbose" ] && echo "$lilo does not exist"
+	    else
+		$lilo > /dev/null
+	    fi
+	fi
+    else
+	[ -n "$verbose" ] && echo "$liloConfig does not exist, not running grubby"
+    fi
+
+    if [ -n "$cfguBoot" ]; then
+	[ -n "$verbose" ] && echo "removing $version from $ubootDir..."
+
+	if [ -f $ubootDir/$ubootKList ]; then
+	    tmpKList=`mktemp $ubootDir/$ubootKList.XXXX`
+	    curversion=`tail -n1 $ubootDir/$ubootKList`
+	    sed "/$version$/d" $ubootDir/$ubootKList > $tmpKList
+	    newversion=`tail -n1 $tmpKList`
+	    if [ -f $ubootDir/uImage-$newversion ] && [ -f $ubootDir/uInitrd-$newversion ]; then
+		if [ "$curversion" != "$newversion" ]; then
+		    cp -fp $ubootDir/uImage-$newversion $ubootDir/${ubootDefaultImage}
+		    if [ $? -ne 0 ]; then
+			[ -n "$verbose" ] && echo "copy uImage-$newversion error, default kernel not replaced!" && exit
+		    fi
+		    cp -fp $ubootDir/uInitrd-$newversion $ubootDir/${ubootDefaultInitrd}
+		    if [ $? -ne 0 ]; then
+			[ -n "$verbose" ] && echo "copy uInitrd-$newversion error, default Initrd not replaced!" && exit
+		    fi
+		fi
+
+		[ -n "$verbose" ] && echo "removing uImage-$version"
+		if [ -f $ubootDir/uImage-$version ]; then
+		    rm -f $ubootDir/uImage-$version
+		else
+		    [ -n "$verbose" ] && echo "uImage-$version did not exist!"
+		fi
+
+		[ -n "$verbose" ] && echo "removing uInitrd-$version"
+		if [ -f $ubootDir/uInitrd-$version ]; then
+		    rm -f $ubootDir/uInitrd-$version
+		else
+		    [ -n "$verbose" ] && echo "uInitrd-$version did not exist!"
+		fi
+
+		mv $tmpKList $ubootDir/$ubootKList
+		[ -x /sbin/a-b-c ] && /sbin/a-b-c
+	    else
+		[ -n "$verbose" ] && echo "uImage $newversion does not exist!"
+		[ -f $tmpKList ] && rm -f $tmpKList
+	    fi
+        else
+            [ -n "$verbose" ] && echo "No previous kernel version.  U-Boot images not removed!"
+        fi
+    else
+	[ -n "$verbose" ] && echo "$ubootScript does not exist, not modifying $ubootDir"
+    fi
+
+    if [ -n "$cfgExtlinux" ]; then
+	[ -n "$verbose" ] && echo "removing $version from $extlinuxConfig"
+	$grubby --extlinux -c $extlinuxConfig \
+	    --remove-kernel=$kernelImage
+    else
+	[ -n "$verbose" ] && echo "$extlinuxConfig does not exist, not running grubby for extlinux"
+    fi
+}
+
+update() {
+    if [ ! -f $kernelImage ] ; then
+	[ -n "$verbose" ] && echo "kernel for $version does not exist, not running grubby"
+	return
+    fi
+
+    set_title
+
+    INITRD=""
+    if [ -f $initrdfile ]; then
+	[ -n "$verbose" ] && echo "found $initrdfile and using it with grubby"
+	INITRD="--initrd $initrdfile"
+
+	if [ -n "$addplymouthinitrd" ]; then
+	    INITRD="$INITRD --extra-initrd $bootPrefix/initrd-plymouth.img"
+	fi
+    fi
+
+    DEVTREE=""
+    if [ -n "$devtreefile" -a -f "$devtreefile" ]; then
+        [ -n "$verbose" ] && echo "found $devtreefile and using it with grubby"
+        DEVTREE="--devtree $devtreefile"
+    fi
+
+    DEVTREEDIR=""
+    if [ -n "$devtreedir" -a -d "$devtreedir" ]; then
+	[ -n "$verbose" ] && echo "found $devtreedir and using it with grubby"
+	DEVTREEDIR="--devtreedir $devtreedir"
+    fi
+
+    if [ -n "$cfgGrub" ]; then
+	[ -n "$verbose" ] && echo "updating $version from $grubConfig"
+	ARGS="--grub -c $grubConfig --update-kernel=$kernelImage $INITRD \
+		${kernargs:+--args=\"$kernargs\"} \
+		${removeargs:+--remove-args=\"$removeargs\"} \
+		${mbkernel:+--add-multiboot=\"$mbkernel\"} \
+		--title=\"$title\$debugtitle\""
+
+	rungrubby ${ARGS}
+	rungrubby --debug ${ARGS}
+    else
+	[ -n "$verbose" ] && echo "$grubConfig does not exist, not running grubby"
+    fi
+
+    if [ -n "$cfgGrub2" ]; then
+	[ -n "$verbose" ] && echo "updating $version from $grub2Config"
+	ARGS="--grub2 -c $grub2Config --update-kernel=$kernelImage $INITRD \
+		${kernargs:+--args=\"$kernargs\"} \
+		${removeargs:+--remove-args=\"$removeargs\"} \
+		--title=\"$title\$debugtitle\""
+
+	rungrubby ${ARGS}
+	rungrubby --debug ${ARGS}
+    else
+	[ -n "$verbose" ] && echo "$grub2Config does not exist, not running grubby"
+    fi
+
+    if [ -n "$cfgGrub2Efi" ]; then
+	[ -n "$verbose" ] && echo "updating $version from $grub2EfiConfig"
+	ARGS="--grub2 -c $grub2EfiConfig --efi --update-kernel=$kernelImage \
+		$INITRD ${kernargs:+--args=\"$kernargs\"} \
+		${removeargs:+--remove-args=\"$removeargs\"} \
+		--title=\"$title\$debugtitle\""
+
+	rungrubby ${ARGS}
+	rungrubby --debug ${ARGS}
+    else
+	[ -n "$verbose" ] && echo "$grub2EfiConfig does not exist, not running grubby"
+    fi
+
+    if [ -n "$cfgLilo" ]; then
+	[ -n "$verbose" ] && echo "updating $version from $liloConfig"
+	ARGS="--$liloFlag --update-kernel=$kernelImage $INITRD \
+		${kernargs:+--args=\"$kernargs\"} \
+		${removeargs:+--remove-args=\"$removeargs\"} \
+		--title=\"$title\$debugtitle\""
+
+	rungrubby ${ARGS}
+	rungrubby --debug ${ARGS}
+
+	if [ -n "$runLilo" ]; then
+	    [ -n "$verbose" ] && echo "running $lilo"
+	    if [ ! -x $lilo ] ; then
+		[ -n "$verbose" ] && echo "$lilo does not exist"
+	    else
+		$lilo > /dev/null
+	    fi
+	fi
+    else
+	[ -n "$verbose" ] && echo "$liloConfig does not exist, not running grubby"
+    fi
+
+    if [ -n "$cfguBoot" ]; then
+	[ -n "$verbose" ] && echo "adding $version to $ubootDir..."
+
+	[ -n "$verbose" ] && echo "creating uImage-$version"
+	mkimage -A arm -O linux -T kernel -C none -a $ubootAddress \
+		-e $ubootAddress -n $version \
+		-d $kernelImage $ubootDir/uImage-$version
+
+	[ -n "$verbose" ] && echo "creating uInitrd-$version"
+	mkimage -A arm -O linux -T ramdisk -C none -a 0 -e 0 \
+		-n initramfs -d $initrdfile $ubootDir/uInitrd-$version
+
+	if [ -f $ubootDir/uImage-$version ] && [ -f $ubootDir/uInitrd-$version ]; then
+	    cp -fp $ubootDir/uImage-$version $ubootDir/${ubootDefaultImage}
+	    if [ $? -ne 0 ]; then
+		[ -n "$verbose" ] && echo "copy uImage-$version error, kernel not installed!" && exit
+	    fi
+	    cp -fp $ubootDir/uInitrd-$version $ubootDir/${ubootDefaultInitrd}
+	    if [ $? -ne 0 ]; then
+		[ -n "$verbose" ] && echo "copy uInitrd-$version error, kernel not installed!" && exit
+	    fi
+	    echo $version >> $ubootDir/$ubootKList
+	    [ -x /sbin/a-b-c ] && /sbin/a-b-c
+	else
+	    [ -n "$verbose" ] && echo "cannot make $version the default"
+	fi
+    else
+	[ -n "$verbose" ] && echo "$ubootScript does not exist, not setting up $ubootDir"
+    fi
+
+    if [ -n "$cfgExtlinux" ]; then
+	[ -n "$verbose" ] && echo "updating $version from $extlinuxConfig"
+	ARGS="--extlinux -c $extlinuxConfig --update-kernel=$kernelImage \
+		$DEVTREE $DEVTREEDIR $INITRD ${kernargs:+--args=\"$kernargs\"} \
+		${removeargs:+--remove-args=\"$removeargs\"} \
+		--title=\"$title\$debugtitle\""
+
+	rungrubby ${ARGS}
+	rungrubby --debug ${ARGS}
+    else
+	[ -n "$verbose" ] && echo "$extlinuxConfig does not exist, not running grubby"
+    fi
+}
+
+doMkinitrd() {
+    if [ -n "$dracut" ]; then
+        tool="dracut $dracuthostonly -f $initrdfile $version"
+    else
+	tool="mkinitrd --allow-missing -f $initrdfile $version"
+    fi
+    [ -n "$verbose" ] && echo "creating initrd: $tool"
+    $tool
+    rc=$?
+    if [ $rc != 0 ]; then
+	echo "mkinitrd failed" >&2
+	exit 1
+    fi
+}
+
+rminitrd() {
+    [ -n "$verbose" ] && echo "removing initrd $initrdfile"
+    [ -f $initrdfile ] && rm -f $initrdfile
+}
+
+doDepmod() {
+    [ -n "$verbose" ] && echo "running depmod for $version"
+    depmod -ae -F /boot/System.map-$version $version
+}
+
+doRmmoddep() {
+    [ -n "$verbose" ] && echo "removing modules.dep info for $version"
+    if [ -d /lib/modules/$version ]; then
+        rm -f /lib/modules/$version/modules.*.bin \
+            /lib/modules/$version/modules.{alias,dep,devname,symbols,softdep}
+    fi
+}
+
+# kernel image for 2.4 is vmlinux
+if [ $ARCH = 'ppc64' -o $ARCH = 'ppc' ]; then
+  if [ "$kernelmajor" == "2.4" ]; then
+      kernelName=vmlinux
+  fi
+fi
+
+while [ $# -gt 0 ]; do
+    case $1 in
+	--mkinitrd)
+	    initrd="make"
+	    ;;
+
+	--rminitrd)
+	    initrd="remove"
+	    ;;
+
+	--devtree*)
+	    if [[ $1 == --devtree\=* ]]; then
+		devtreefile=${1#--devtreefile=}
+	    else
+		devtreefile=$2
+		shift
+	    fi
+	    ;;
+
+	--devtreedir*)
+	    if [[ $1 == --devtreedir\=* ]]; then
+		devtreedir=${1#--devtreedir=}
+	    else
+		devtreedir=$2
+		shift
+	    fi
+	    ;;
+
+	--dracut)
+	    dracut=--dracut
+	    ;;
+
+	--host-only)
+	    dracuthostonly=-H
+	    ;;
+
+	--initrdfile*)
+	    if [[ $1 == --initrdfile\=* ]]; then
+		initrdfile=${1#--initrdfile=}
+	    else
+		initrdfile=$2
+		shift
+	    fi
+	    ;;
+
+	--kernel-args*)
+	    if [[ $1 == --kernel-args\=* ]]; then
+		kernargs=${1#--kernel-args=}
+	    else
+		kernargs=$2
+		shift
+	    fi
+	    ;;
+
+	--remove-args*)
+	    if [[ $1 == --remove-args\=* ]]; then
+		removeargs=${1#--remove-args=}
+	    else
+		removeargs=$2
+		shift
+	    fi
+	    ;;
+
+	--banner*)
+	    if [[ $1 == --banner\=* ]]; then
+		banner=${1#--banner=}
+	    else
+		banner=$2
+		shift
+	    fi
+	    ;;
+
+	--multiboot*)
+	    if [[ $1 == --multiboot\=* ]]; then
+		mbkernel=${1#--multiboot=}
+	    else
+		# can't really support having an optional second arg here
+		# sorry!
+		mbkernel="/boot/xen.gz"
+	    fi
+	    ;;
+
+        --mbargs*)
+            if [[ $1 == --mbargs\=* ]]; then
+                mbargs=${1#--mbargs=}
+            else
+                mbargs="$2"
+                shift
+            fi
+            ;;
+
+	--depmod)
+	    moddep="make"
+	    ;;
+
+	--rmmoddep)
+	    moddep="remove"
+	    ;;
+
+	--make-default)
+	    makedefault="--make-default"
+	    ;;
+
+        --package*)
+            if [[ $1 == --package\=* ]]; then
+                package=${1#--package=}
+            else
+                package=$2
+                shift
+            fi
+            ;;
+
+	--add-dracut-args)
+	    adddracutargs=--add-dracut-args
+	    ;;
+
+	--add-plymouth-initrd)
+	    addplymouthinitrd=--add-plymouth-initrd
+	    ;;
+
+        --kernel-image*)
+            if [[ $1 == --kernel-image\=* ]]; then
+                kernelImage=${1#--kernel-image=}
+            else
+                kernelImage="$2"
+                shift
+            fi
+            if ! [[ -f $kernelImage ]]; then
+                echo "Can't find kernel image '$kernelImage'" >&2
+                usage
+                exit 1
+            fi
+            ;;
+
+        --kernel-name*)
+            if [[ $1 == --kernel-name\=* ]]; then
+                kernelName=${1#--kernel-name=}
+            else
+                kernelName="$2"
+                shift
+            fi
+            ;;
+
+	-v)
+	    verbose=-v
+	    ;;
+
+	*)
+	    if [ -z "$mode" ]; then
+		mode=$1
+	    elif [ -z "$version" ]; then
+		version=$1
+	    else
+		usage
+	    fi
+	    ;;
+    esac
+
+    shift
+done
+
+# make sure the mode is valid
+if [ "$mode" != "--install" -a "$mode" != "--remove"  -a "$mode" != "--update" -a "$mode" != "--rpmposttrans" ] ; then
+    usage
+fi
+
+if [ -z "$version" ]; then
+    usage
+fi
+
+if [ "$mode" != "--install" -a "$makedefault" ]; then
+    usage
+fi
+
+kernelmajor=`echo $kernel | cut -d . -f 1,2`
+
+[[ $kernelImage ]] || kernelImage="$bootPrefix/$kernelName-$version"
+
+# set the initrd file based on arch; ia64 is the only currently known oddball
+if [ -z "$initrdfile" ]; then
+    INITRD_NAME_PREFIX="initrd"
+    if [ -n "$dracut" ]; then
+	INITRD_NAME_PREFIX="initramfs"
+    fi
+
+    if [ `uname -m` = "ia64" ]; then
+	initrdfile="/boot/efi/EFI/redhat/$INITRD_NAME_PREFIX-$version.img"
+    else
+	initrdfile="/boot/$INITRD_NAME_PREFIX-$version.img"
+    fi
+
+fi
+[ -n "$verbose" ] && echo "initrdfile is $initrdfile"
+
+if [[ ${ARCH} =~ armv[5|7].*l ]]; then
+    if [ -z "$SHIPSDTB" -o "$SHIPSDTB" != "yes" ]; then
+	if [ -n "$dtbfile" -a -f "$bootPrefix/dtb-$version/$dtbfile" ]; then
+	    devtreefile="$bootPrefix/dtb-$version/$dtbfile"
+	    [ -n "$verbose" ] && echo "devtreefile is $devtreefile"
+	elif [ -d "$bootPrefix/dtb-$version/" ]; then
+	    devtreedir="$bootPrefix/dtb-$version/"
+	    [ -n "$verbose" ] && echo "devtreedir is $devtreedir"
+	fi
+    fi
+fi
+[ -n "$verbose" ] && echo "devtreedir is $devtreedir"
+
+# add dracut kernel args if requested
+if [ -n "$dracut" -a -n "$adddracutargs" ]; then
+    [ -r /etc/vconsole.conf ] && . /etc/vconsole.conf
+    [ -r /etc/locale.conf ] && . /etc/locale.conf
+
+    while read opt rd_opt; do
+        [ -n "${!opt}" ] && kernargs="$kernargs $rd_opt=\"${!opt}\""
+    done <<< 'KEYMAP      rd.vconsole.keymap
+              FONT        rd.vconsole.font
+              FONT_MAP    rd.vconsole.font.map
+              FONT_UNIMAP rd.vconsole.font.unimap
+              UNICODE     rd.vconsole.font.unicode
+              EXT_KEYMAP  rd.vconsole.keymap.ext
+              LANG        rd.locale.LANG
+              LC_ALL      rd.locale.LC_ALL'
+fi
+
+# set this as the default if we have the package and it matches
+if [ "$mode" == "--install" -a "$UPDATEDEFAULT" == "yes" -a -n "$package" -a -n "$DEFAULTKERNEL" ]; then
+    if [ "$package" == "$DEFAULTKERNEL" -o "${package}-core" == "$DEFAULTKERNEL" ]; then
+        makedefault="--make-default"
+        [ -n "$verbose" ] && echo "making it the default based on config"
+    fi
+fi
+
+if [ "$moddep" == "make" ]; then
+    doDepmod
+elif [ "$moddep" == "remove" ]; then
+    doRmmoddep
+fi
+
+if [ "$initrd" == "make" ]; then
+    doMkinitrd
+elif [ "$initrd" == "remove" ]; then
+    rminitrd
+fi
+
+if [ ! -x $grubby ] ; then
+    [ -n "$verbose" ] && echo "$grubby does not exist"
+    exit 0
+fi
+
+
+[ -n "$grubConfig" ] && [ -f "$grubConfig" ] && cfgGrub=1;
+[ -n "$grub2Config" ] && [ -f "$grub2Config" ] && cfgGrub2=1;
+[ -n "$grub2EfiConfig" ] && [ -f "$grub2EfiConfig" ] && cfgGrub2Efi=1;
+[ -n "$liloConfig" ] && [ -f "$liloConfig" ] && cfgLilo=1;
+[ -n "$extlinuxConfig" ] && [ -f "$extlinuxConfig" ] && cfgExtlinux=1;
+
+# if we have a U-Boot directory, but no boot script, check if the directory
+# is mounted.  If not, mount it, and then check if a boot script exists.
+if [ -n "$ubootDir" ]; then
+    if [ -f "$ubootScript" ]; then
+        cfguBoot=1
+    else
+	mountEntry=`mount | grep $ubootDir`
+	if [ -z "$mountEntry" ]; then
+	    mount $ubootDevice $ubootDir
+	    mounted=1
+	fi
+	[ -f "$ubootScript" ] && cfguBoot=1;
+    fi
+fi
+
+# if we're using U-Boot, check if the default load address should change
+if [ -n "$cfguBoot" -a -z "$UBOOT_IMGADDR" ]; then
+    [[ $version  =~ .([^.]*)$ ]]
+    platform=${BASH_REMATCH[1]}
+    # A few platforms use an alternate kernel load address
+    if [ "$platform" = "omap" ]; then
+        ubootAddress=0x80008000
+    elif [ "$platform" = "imx" ]; then
+        ubootAddress=0x90008000
+    fi
+fi
+
+# if we have a lilo config on an x86 box, see if the default boot loader
+# is lilo to determine if it should be run
+if [ -n "$cfgLilo" -a -n "$isx86" ]; then
+    runLilo=$($grubby --bootloader-probe | grep lilo)
+fi
+
+if [ "$mode" == "--install" ]; then
+    install
+elif [ "$mode" == "--remove" ]; then
+    remove
+elif [ "$mode" == "--update" ]; then
+    update
+elif [ "$mode" == "--rpmposttrans" ]; then
+    rpmposttrans
+fi
+
+# if we mounted the U-Boot directory, unmount it.
+[ -n "$mounted" ] && umount $ubootDir
+
+# make sure changes make it to the disk.
+# if /boot is a mountpoint, force the meta data on disk
+# to by-pass writeback delay.
+# PPC64LE-only to deal with Petitboot issues
+if [ "$ARCH" = "ppc64le" ]; then
+    sync && mountpoint -q /boot && fsfreeze -f /boot && fsfreeze -u /boot
+fi
+
+exit 0

--- a/distribution/kpkginstall/runtest.sh
+++ b/distribution/kpkginstall/runtest.sh
@@ -5,6 +5,12 @@
 ARCH=$(uname -m)
 REBOOTCOUNT=${REBOOTCOUNT:-0}
 
+# Some RHEL deployments may be missing the new-kernel-pkg script
+if [ ! -x /sbin/new-kernel-pkg ]; then
+  cp -af new-kernel-pkg /sbin/new-kernel-pkg
+  chmod +x /sbin/new-kernel-pkg
+fi
+
 if [ ${REBOOTCOUNT} -eq 0 ]; then
   if [ -z ${KPKG_URL} ]; then
     echo "No KPKG_URL specified" | tee -a ${OUTPUTFILE}


### PR DESCRIPTION
Some RHEL deployments do not have `/sbin/new-kernel-pkg` present.
Ensure that the script is always present and executable.

Signed-off-by: Major Hayden <major@redhat.com>