### PR TITLE
LTP: temporarily disable migrate_pages02

### DIFF
--- a/distribution/ltp/lite/RHELKT1LITE.20180515
+++ b/distribution/ltp/lite/RHELKT1LITE.20180515
@@ -620,7 +620,8 @@ memcmp01 memcmp01
 memcpy01 memcpy01
 
 migrate_pages01 migrate_pages01
-migrate_pages02 migrate_pages02
+# See https://github.com/linux-test-project/ltp/issues/407
+#migrate_pages02 migrate_pages02
 
 mlockall01 mlockall01
 mlockall02 mlockall02


### PR DESCRIPTION
See https://github.com/linux-test-project/ltp/issues/407
The test can be re-enabled after the issue is fixed and patch ported.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>